### PR TITLE
Stop double encoding Condition URLs

### DIFF
--- a/fastly/condition.go
+++ b/fastly/condition.go
@@ -121,7 +121,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, url.PathEscape(i.Name))
+	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, url.PathEscape(i.Name))
+	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, url.PathEscape(i.Name))
+	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/condition.go
+++ b/fastly/condition.go
@@ -2,7 +2,6 @@ package fastly
 
 import (
 	"fmt"
-	"net/url"
 	"sort"
 )
 

--- a/fastly/condition_test.go
+++ b/fastly/condition_test.go
@@ -72,7 +72,7 @@ func TestClient_Conditions(t *testing.T) {
 		newCondition, err = c.GetCondition(&GetConditionInput{
 			Service: testServiceID,
 			Version: tv.Number,
-			Name:    "test/condition",
+			Name:    "test condition",
 		})
 	})
 	if err != nil {
@@ -97,7 +97,7 @@ func TestClient_Conditions(t *testing.T) {
 		updatedCondition, err = c.UpdateCondition(&UpdateConditionInput{
 			Service:   testServiceID,
 			Version:   tv.Number,
-			Name:      "test/condition",
+			Name:      "test condition",
 			Statement: "req.url~+\"updated.html\"",
 		})
 	})
@@ -113,7 +113,7 @@ func TestClient_Conditions(t *testing.T) {
 		err = c.DeleteCondition(&DeleteConditionInput{
 			Service: testServiceID,
 			Version: tv.Number,
-			Name:    "test/condition",
+			Name:    "test condition",
 		})
 	})
 	if err != nil {

--- a/fastly/fixtures/conditions/delete.yaml
+++ b/fastly/fixtures/conditions/delete.yaml
@@ -10,7 +10,7 @@ interactions:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/0.3.0 (+github.com/sethvargo/go-fastly; go1.8.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/700/condition/test%252Fcondition
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/700/condition/test%20condition
     method: DELETE
   response:
     body: '{"status":"ok"}'

--- a/fastly/fixtures/conditions/get.yaml
+++ b/fastly/fixtures/conditions/get.yaml
@@ -10,7 +10,7 @@ interactions:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/0.3.0 (+github.com/sethvargo/go-fastly; go1.8.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/700/condition/test%252Fcondition
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/700/condition/test%20condition
     method: GET
   response:
     body: '{"priority":"1","version":"700","name":"test/condition","deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2017-07-20T02:25:45+00:00","comment":"","statement":"req.url~+\"index.html\"","updated_at":"2017-07-20T02:25:45+00:00","type":"REQUEST"}'

--- a/fastly/fixtures/conditions/update.yaml
+++ b/fastly/fixtures/conditions/update.yaml
@@ -20,7 +20,7 @@ interactions:
       - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/0.3.0 (+github.com/sethvargo/go-fastly; go1.8.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/700/condition/test%252Fcondition
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/700/condition/test%20condition
     method: PUT
   response:
     body: '{"priority":"1","version":"700","name":"test/condition","deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2017-07-20T02:25:45+00:00","comment":"","statement":"req.url~+\"updated.html\"","updated_at":"2017-07-20T02:25:45+00:00","type":"REQUEST"}'


### PR DESCRIPTION
This addresses https://github.com/sethvargo/go-fastly/issues/65
  
It looks like the reason URL encoding was being done was to accomodate forward slashes in Condition names. If you look at the test fixtures however, you can see that the slash was being double encoded anyway, so this would never have worked AFAICT.

This fix makes it possible to now use any non-slash special character - I think that how to deal with slashes will need to be a broader fix, as it will affect any element that can be addressed by name in the URL.