### PR TITLE
implement the batch dictionary item patch endpoint

### DIFF
--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -1,6 +1,7 @@
 package fastly
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -223,5 +224,75 @@ func (c *Client) DeleteDictionaryItem(i *DeleteDictionaryItemInput) error {
 
 	// Unlike other endpoints, the dictionary endpoint does not return a status
 	// response - it just returns a 200 OK.
+	return nil
+}
+
+// BatchUpdateDictionaryItemsInput is used as an input to the  BatchUpdateDictionaryItems function
+type BatchUpdateDictionaryItemsInput struct {
+	// Service is the ID of the service. Dictionary is the ID of the dictionary.
+	// Both fields are required.
+	Service    string
+	Dictionary string
+
+	Items []BatchUpdateDictionaryItem `json:"items"`
+}
+
+// BatchOperation is the operation for the update
+type BatchOperation string
+
+var (
+	// CreateBatchOperation creates the dictionary item
+	CreateBatchOperation = BatchOperation("create")
+
+	// UpdateBatchOperation updates the existing dictionary item
+	UpdateBatchOperation = BatchOperation("update")
+
+	// UpsertBatchOperation upserts the existing dictionary item
+	UpsertBatchOperation = BatchOperation("upsert")
+
+	// DeleteBatchOperation deletes the existing dictionary item
+	DeleteBatchOperation = BatchOperation("delete")
+
+	// ErrBatchUpdateMaximumItemsExceeded signals the user has supplied more than the maximum
+	// number of items as specified by Fastly
+	ErrBatchUpdateMaximumItemsExceeded = errors.New("batch update maximum items exceeded")
+)
+
+const (
+	// BatchUpdateMaximumItems is the hard limit on amount of updates allowed in one batch.
+	BatchUpdateMaximumItems = 1000
+)
+
+// BatchUpdateDictionaryItem holds the information for the update
+type BatchUpdateDictionaryItem struct {
+	Operation BatchOperation `json:"op"`
+	Key       string         `json:"item_key"`
+	Value     string         `json:"item_value"`
+}
+
+// BatchUpdateDictionaryItems performs the update or returns an error
+func (c *Client) BatchUpdateDictionaryItems(i *BatchUpdateDictionaryItemsInput) error {
+	if i.Service == "" {
+		return ErrMissingService
+	}
+
+	if i.Dictionary == "" {
+		return ErrMissingDictionary
+	}
+
+	if len(i.Items) > BatchUpdateMaximumItems {
+		return ErrBatchUpdateMaximumItemsExceeded
+	}
+
+	path := fmt.Sprintf("/service/%s/dictionary/%s/items", i.Service, i.Dictionary)
+	resp, err := c.PatchJSON(path, i, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// This endpoint returns an object with a status of 'ok' according to the documentation
+	// Other responses are undocumented.
+	// It is reasonable to rely on the HTTP status.
 	return nil
 }

--- a/fastly/dictionary_item_test.go
+++ b/fastly/dictionary_item_test.go
@@ -256,3 +256,31 @@ func TestClient_DeleteDictionaryItem_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 }
+
+func TestClient_BatchUpdatDictionaryItem_validation(t *testing.T) {
+	var err error
+	err = testClient.BatchUpdateDictionaryItems(&BatchUpdateDictionaryItemsInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+	err = testClient.BatchUpdateDictionaryItems(&BatchUpdateDictionaryItemsInput{
+		Service:    "foo",
+		Dictionary: "",
+	})
+	if err != ErrMissingDictionary {
+		t.Errorf("bad error: %s", err)
+	}
+
+	tooMany := make([]BatchUpdateDictionaryItem, BatchUpdateMaximumItems+1)
+	err = testClient.BatchUpdateDictionaryItems(&BatchUpdateDictionaryItemsInput{
+		Service:    "foo",
+		Dictionary: "bar",
+		Items:      tooMany,
+	})
+	if err != ErrBatchUpdateMaximumItemsExceeded {
+		t.Errorf("bad error: %s", err)
+	}
+
+}


### PR DESCRIPTION
This PR implements the PATCH /service/service_id/dictionary/dictionary_id/items endpoint.
See https://docs.fastly.com/api/config#dictionary_item_dc826ce1255a7c42bc48eb204eed8f7f

I'm not too sure about adding the fixture based tests - will do if needed.

Cheers,

Mark