### PR TITLE
Implement batch operations for ACL entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- acl: Surpport for Create, Delete and Update BatchOperations ([#126](https://github.com/fastly/go-fastly/pull/126)).
 
 ## [1.1.0] - 2019-07-22
 ### Added

--- a/fastly/acl_entries_batch_test.go
+++ b/fastly/acl_entries_batch_test.go
@@ -1,0 +1,350 @@
+package fastly
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestClient_BatchModifyAclEntries_Create(t *testing.T) {
+
+	fixtureBase := "acl_entries_batch/create/"
+	nameSuffix := "BatchModifyAclEntries_Create"
+
+	// Given: a test service with an ACL and a batch of create operations,
+	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
+	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+
+	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+
+	testACL := createTestACL(t, fixtureBase+"create_acl", testService.ID, testVersion.Number, nameSuffix)
+	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
+
+	batchCreateOperations := &BatchModifyACLEntriesInput{
+		Service: testService.ID,
+		ACL:     testACL.ID,
+		Entries: []*BatchACLEntry{
+			{
+				Operation: CreateBatchOperation,
+				IP:        "127.0.0.1",
+				Subnet:    "24",
+				Negated:   false,
+				Comment:   "ACL Entry 1",
+			},
+			{
+				Operation: CreateBatchOperation,
+				IP:        "192.168.0.1",
+				Subnet:    "24",
+				Negated:   false,
+				Comment:   "ACL Entry 2",
+			},
+		},
+	}
+
+	// When: I execute the batch create operations against the Fastly API,
+	var err error
+	record(t, fixtureBase+"create_acl_entries", func(c *Client) {
+
+		err = c.BatchModifyACLEntries(batchCreateOperations)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Then: I expect to be able to list all of the created ACL entries.
+	var actualACLEntries []*ACLEntry
+	record(t, fixtureBase+"list_after_create", func(c *Client) {
+		actualACLEntries, err = c.ListACLEntries(&ListACLEntriesInput{
+			Service: testService.ID,
+			ACL:     testACL.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Slice(actualACLEntries, func(i, j int) bool {
+		return actualACLEntries[i].IP < actualACLEntries[j].IP
+	})
+
+	actualNumberOfACLEntries := len(actualACLEntries)
+	expectedNumberOfACLEntries := len(batchCreateOperations.Entries)
+	if actualNumberOfACLEntries != expectedNumberOfACLEntries {
+		t.Errorf("Incorrect number of ACL entries returned, expected: %d, got %d", expectedNumberOfACLEntries, actualNumberOfACLEntries)
+	}
+
+	for i, entry := range actualACLEntries {
+
+		actualIp := entry.IP
+		expectedIp := batchCreateOperations.Entries[i].IP
+
+		if actualIp != expectedIp {
+			t.Errorf("IP did not match, expected %s, got %s", expectedIp, actualIp)
+		}
+
+		actualSubnet := entry.Subnet
+		expectedSubnet := batchCreateOperations.Entries[i].Subnet
+
+		if actualSubnet != expectedSubnet {
+			t.Errorf("Subnet did not match, expected %s, got %s", expectedSubnet, actualSubnet)
+		}
+
+		actualNegated := entry.Negated
+		expectedNegated := batchCreateOperations.Entries[i].Negated
+
+		if actualNegated != expectedNegated {
+			t.Errorf("Negated did not match, expected %t, got %t", expectedNegated, actualNegated)
+		}
+
+		actualComment := entry.Comment
+		expectedComment := batchCreateOperations.Entries[i].Comment
+
+		if actualComment != expectedComment {
+			t.Errorf("Comment did not match, expected %s, got %s", expectedComment, actualComment)
+		}
+	}
+
+}
+
+func TestClient_BatchModifyAclEntries_Delete(t *testing.T) {
+
+	fixtureBase := "acl_entries_batch/delete/"
+	nameSuffix := "BatchModifyAclEntries_Delete"
+
+	// Given: a test service with an ACL and a batch of create operations,
+	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
+	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+
+	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+
+	testACL := createTestACL(t, fixtureBase+"create_acl", testService.ID, testVersion.Number, nameSuffix)
+	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
+
+	batchCreateOperations := &BatchModifyACLEntriesInput{
+		Service: testService.ID,
+		ACL:     testACL.ID,
+		Entries: []*BatchACLEntry{
+			{
+				Operation: CreateBatchOperation,
+				IP:        "127.0.0.1",
+				Subnet:    "24",
+				Negated:   false,
+				Comment:   "ACL Entry 1",
+			},
+			{
+				Operation: CreateBatchOperation,
+				IP:        "192.168.0.1",
+				Subnet:    "24",
+				Negated:   false,
+				Comment:   "ACL Entry 2",
+			},
+		},
+	}
+
+	var err error
+	record(t, fixtureBase+"create_acl_entries", func(c *Client) {
+
+		err = c.BatchModifyACLEntries(batchCreateOperations)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var createdACLEntries []*ACLEntry
+	record(t, fixtureBase+"list_before_delete", func(client *Client) {
+		createdACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
+			Service: testService.ID,
+			ACL:     testACL.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Slice(createdACLEntries, func(i, j int) bool {
+		return createdACLEntries[i].IP < createdACLEntries[j].IP
+	})
+
+	// When: I execute the batch delete operations against the Fastly API,
+	batchDeleteOperations := &BatchModifyACLEntriesInput{
+		Service: testService.ID,
+		ACL:     testACL.ID,
+		Entries: []*BatchACLEntry{
+			{
+				Operation: DeleteBatchOperation,
+				ID: createdACLEntries[0].ID,
+			},
+		},
+	}
+
+	record(t, fixtureBase+"delete_acl_entries", func(c *Client) {
+
+		err = c.BatchModifyACLEntries(batchDeleteOperations)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Then: I expect to be able to list a single ACL entry.
+	var actualACLEntries []*ACLEntry
+	record(t, fixtureBase+"list_after_delete", func(client *Client) {
+		actualACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
+			Service:    testService.ID,
+			ACL: testACL.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Slice(actualACLEntries, func(i, j int) bool {
+		return actualACLEntries[i].IP < actualACLEntries[j].IP
+	})
+
+	actualNumberOfACLEntries := len(actualACLEntries)
+	expectedNumberOfACLEntries := len(batchDeleteOperations.Entries)
+	if actualNumberOfACLEntries != expectedNumberOfACLEntries {
+		t.Errorf("Incorrect number of ACL entries returned, expected: %d, got %d", expectedNumberOfACLEntries, actualNumberOfACLEntries)
+	}
+}
+
+func TestClient_BatchModifyAclEntries_Update(t *testing.T) {
+
+	fixtureBase := "acl_entries_batch/update/"
+	nameSuffix := "BatchModifyAclEntries_Update"
+
+	// Given: a test service with an ACL and ACL entries,
+	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
+	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+
+	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+
+	testACL := createTestACL(t, fixtureBase+"create_acl", testService.ID, testVersion.Number, nameSuffix)
+	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
+
+	batchCreateOperations := &BatchModifyACLEntriesInput{
+		Service: testService.ID,
+		ACL:     testACL.ID,
+		Entries: []*BatchACLEntry{
+			{
+				Operation: CreateBatchOperation,
+				IP:        "127.0.0.1",
+				Subnet:    "24",
+				Negated:   false,
+				Comment:   "ACL Entry 1",
+			},
+			{
+				Operation: CreateBatchOperation,
+				IP:        "192.168.0.1",
+				Subnet:    "24",
+				Negated:   false,
+				Comment:   "ACL Entry 2",
+			},
+		},
+	}
+
+	var err error
+	record(t, fixtureBase+"create_acl_entries", func(c *Client) {
+
+		err = c.BatchModifyACLEntries(batchCreateOperations)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var createdACLEntries []*ACLEntry
+	record(t, fixtureBase+"list_before_update", func(client *Client) {
+		createdACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
+			Service: testService.ID,
+			ACL:     testACL.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Slice(createdACLEntries, func(i, j int) bool {
+		return createdACLEntries[i].IP < createdACLEntries[j].IP
+	})
+
+	// When: I execute the batch update operations against the Fastly API,
+	batchUpdateOperations := &BatchModifyACLEntriesInput{
+		Service: testService.ID,
+		ACL:     testACL.ID,
+		Entries: []*BatchACLEntry{
+			{
+				Operation: UpdateBatchOperation,
+				ID: createdACLEntries[0].ID,
+				IP: "127.0.0.2",
+				Subnet: "16",
+				Negated: true,
+				Comment: "Updated ACL Entry 1",
+			},
+		},
+	}
+
+	record(t, fixtureBase+"update_acl_entries", func(c *Client) {
+
+		err = c.BatchModifyACLEntries(batchUpdateOperations)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Then: I expect to be able to list all of the ACL entries with modifications applied to a single item.
+	var actualACLEntries []*ACLEntry
+	record(t, fixtureBase+"list_after_update", func(client *Client) {
+		actualACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
+			Service: testService.ID,
+			ACL:     testACL.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Slice(actualACLEntries, func(i, j int) bool {
+		return actualACLEntries[i].IP < actualACLEntries[j].IP
+	})
+
+	actualNumberOfAclEntries := len(actualACLEntries)
+	expectedNumberOfAclEntries := len(batchCreateOperations.Entries)
+	if actualNumberOfAclEntries != expectedNumberOfAclEntries {
+		t.Errorf("Incorrect number of ACL entries returned, expected: %d, got %d", expectedNumberOfAclEntries, actualNumberOfAclEntries)
+	}
+
+	actualID := actualACLEntries[0].ID
+	expectedID := batchUpdateOperations.Entries[0].ID
+
+	if actualID != expectedID {
+		t.Errorf("First ID did not match, expected %s, got %s", expectedID, actualID)
+	}
+
+	actualIP := actualACLEntries[0].IP
+	expectedIP := batchUpdateOperations.Entries[0].IP
+
+	if actualIP != expectedIP {
+		t.Errorf("First IP did not match, expected %s, got %s", expectedIP, actualIP)
+	}
+
+	actualSubnet := actualACLEntries[0].Subnet
+	expectedSubnet := batchUpdateOperations.Entries[0].Subnet
+
+	if actualSubnet != expectedSubnet {
+		t.Errorf("First Subnet did not match, expected %s, got %s", expectedSubnet, actualSubnet)
+	}
+
+	actualNegated := actualACLEntries[0].Negated
+	expectedNegated := batchUpdateOperations.Entries[0].Negated
+
+	if actualNegated != expectedNegated {
+		t.Errorf("First Subnet did not match, expected %t, got %t", expectedNegated, actualNegated)
+	}
+
+	actualComment := actualACLEntries[0].Comment
+	expectedComment := batchUpdateOperations.Entries[0].Comment
+
+	if actualComment != expectedComment {
+		t.Errorf("First Comment did not match, expected %s, got %s", expectedComment, actualComment)
+	}
+
+}

--- a/fastly/acl_test.go
+++ b/fastly/acl_test.go
@@ -5,35 +5,17 @@ import "testing"
 func TestClient_ACLs(t *testing.T) {
 	t.Parallel()
 
-	var err error
-	var tv *Version
-	record(t, "acls/version", func(c *Client) {
-		tv = testVersion(t, c)
-	})
+	fixtureBase := "acls/"
 
-	// Clean up
-	defer func() {
-		record(t, "acls/cleanup", func(c *Client) {
-			c.DeleteACL(&DeleteACLInput{
-				Service: testServiceID,
-				Version: tv.Number,
-				Name:    "test_acl",
-			})
-
-			c.DeleteACL(&DeleteACLInput{
-				Service: testServiceID,
-				Version: tv.Number,
-				Name:    "new_test_acl",
-			})
-		})
-	}()
-
+	testVersion := createTestVersion(t, fixtureBase+"version", testServiceID)
+	
 	// Create
+	var err error
 	var a *ACL
-	record(t, "acls/create", func(c *Client) {
+	record(t, fixtureBase+"create", func(c *Client) {
 		a, err = c.CreateACL(&CreateACLInput{
 			Service: testServiceID,
-			Version: tv.Number,
+			Version: testVersion.Number,
 			Name:    "test_acl",
 		})
 	})
@@ -41,16 +23,33 @@ func TestClient_ACLs(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Ensure deleted
+	defer func() {
+		record(t, fixtureBase+"cleanup", func(c *Client) {
+			c.DeleteACL(&DeleteACLInput{
+				Service: testServiceID,
+				Version: testVersion.Number,
+				Name:    "test_acl",
+			})
+
+			c.DeleteACL(&DeleteACLInput{
+				Service: testServiceID,
+				Version: testVersion.Number,
+				Name:    "new_test_acl",
+			})
+		})
+	}()
+	
 	if a.Name != "test_acl" {
 		t.Errorf("bad name: %q", a.Name)
 	}
 
 	// List
 	var as []*ACL
-	record(t, "acls/list", func(c *Client) {
+	record(t, fixtureBase+"list", func(c *Client) {
 		as, err = c.ListACLs(&ListACLsInput{
 			Service: testServiceID,
-			Version: tv.Number,
+			Version: testVersion.Number,
 		})
 	})
 	if err != nil {
@@ -62,10 +61,10 @@ func TestClient_ACLs(t *testing.T) {
 
 	// Get
 	var na *ACL
-	record(t, "acls/get", func(c *Client) {
+	record(t, fixtureBase+"get", func(c *Client) {
 		na, err = c.GetACL(&GetACLInput{
 			Service: testServiceID,
-			Version: tv.Number,
+			Version: testVersion.Number,
 			Name:    "test_acl",
 		})
 	})
@@ -78,10 +77,10 @@ func TestClient_ACLs(t *testing.T) {
 
 	// Update
 	var ua *ACL
-	record(t, "acls/update", func(c *Client) {
+	record(t, fixtureBase+"update", func(c *Client) {
 		ua, err = c.UpdateACL(&UpdateACLInput{
 			Service: testServiceID,
-			Version: tv.Number,
+			Version: testVersion.Number,
 			Name:    "test_acl",
 			NewName: "new_test_acl",
 		})
@@ -98,10 +97,10 @@ func TestClient_ACLs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "acls/delete", func(c *Client) {
+	record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteACL(&DeleteACLInput{
 			Service: testServiceID,
-			Version: tv.Number,
+			Version: testVersion.Number,
 			Name:    "new_test_acl",
 		})
 	})

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -215,7 +215,7 @@ func (c *Client) BatchModifyDictionaryItems(i *BatchModifyDictionaryItemsInput) 
 	}
 
 	if len(i.Items) > BatchModifyMaximumOperations {
-		return ErrBatchUpdateMaximumItemsExceeded
+		return ErrBatchUpdateMaximumOperationsExceeded
 	}
 
 	path := fmt.Sprintf("/service/%s/dictionary/%s/items", i.Service, i.Dictionary)

--- a/fastly/dictionary_item_test.go
+++ b/fastly/dictionary_item_test.go
@@ -251,7 +251,7 @@ func TestClient_BatchModifyDictionaryItem_validation(t *testing.T) {
 		Dictionary: "bar",
 		Items:      oversizedDictionaryItems,
 	})
-	if err != ErrBatchUpdateMaximumItemsExceeded {
+	if err != ErrBatchUpdateMaximumOperationsExceeded {
 		t.Errorf("bad error: %s", err)
 	}
 

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -115,7 +115,7 @@ var ErrMissingWAFList = errors.New("WAF slice is empty")
 
 // ErrBatchUpdateMaximumItemsExceeded is an error that indicates that too many batch operations are being executed.
 // The Fastly API specifies an maximum limit.
-var ErrBatchUpdateMaximumItemsExceeded = errors.New("batch modify maximum items exceeded")
+var ErrBatchUpdateMaximumOperationsExceeded = errors.New("batch modify maximum operations exceeded")
 
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -140,6 +140,40 @@ func deleteTestDictionary(t *testing.T, dictionary *Dictionary, deleteFixture st
 	}
 }
 
+func createTestACL(t *testing.T, createFixture string, serviceId string, version int, aclNameSuffix string) *ACL {
+
+	var err error
+	var acl *ACL
+
+	record(t, createFixture, func(client *Client) {
+		acl, err = client.CreateACL(&CreateACLInput{
+			Service: serviceId,
+			Version: version,
+			Name: fmt.Sprintf("test_acl_%s", aclNameSuffix),
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return acl
+}
+
+func deleteTestACL(t *testing.T, acl *ACL, deleteFixture string) {
+
+	var err error
+
+	record(t, deleteFixture, func(client *Client) {
+		err = client.DeleteACL(&DeleteACLInput{
+			Service: acl.ServiceID,
+			Version: acl.Version,
+			Name:    acl.Name,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func deleteTestService(t *testing.T, cleanupFixture string, serviceId string){
 
 	var err error

--- a/fastly/fixtures/acl_entries/acl.yaml
+++ b/fastly/fixtures/acl_entries/acl.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/version/2/acl
@@ -24,7 +24,6 @@ interactions:
     body: '{"service_id":"2voeSM5z6889qin6D9waPl","version":"2","name":"test_acl_ACLEntries","deleted_at":null,"id":"1d7GeY6Ky6eeqSsO5c1r29","created_at":"2019-07-23T10:47:06Z","updated_at":"2019-07-23T10:47:06Z"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -43,7 +42,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries/acl.yaml
+++ b/fastly/fixtures/acl_entries/acl.yaml
@@ -3,18 +3,14 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ACL=1d7GeY6Ky6eeqSsO5c1r29&ID=5z5nqKm0IGS8ovR512rSaT&Service=2voeSM5z6889qin6D9waPl&ip=10.0.0.4&negated=true
+    body: Service=2voeSM5z6889qin6D9waPl&Version=2&name=test_acl_ACLEntries
     form:
-      ACL:
-      - 1d7GeY6Ky6eeqSsO5c1r29
-      ID:
-      - 5z5nqKm0IGS8ovR512rSaT
       Service:
       - 2voeSM5z6889qin6D9waPl
-      ip:
-      - 10.0.0.4
-      negated:
-      - "true"
+      Version:
+      - "2"
+      name:
+      - test_acl_ACLEntries
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -22,10 +18,10 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry/5z5nqKm0IGS8ovR512rSaT
-    method: PATCH
+    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/version/2/acl
+    method: POST
   response:
-    body: '{"ip":"10.0.0.4","updated_at":"2019-07-23T10:47:07Z","comment":"test entry","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","created_at":"2019-07-23T10:47:07Z","negated":"true","service_id":"2voeSM5z6889qin6D9waPl","id":"5z5nqKm0IGS8ovR512rSaT","subnet":8,"deleted_at":null}'
+    body: '{"service_id":"2voeSM5z6889qin6D9waPl","version":"2","name":"test_acl_ACLEntries","deleted_at":null,"id":"1d7GeY6Ky6eeqSsO5c1r29","created_at":"2019-07-23T10:47:06Z","updated_at":"2019-07-23T10:47:06Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,9 +31,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:08 GMT
+      - Tue, 23 Jul 2019 10:47:06 GMT
       Fastly-Ratelimit-Remaining:
-      - "980"
+      - "982"
       Fastly-Ratelimit-Reset:
       - "1563879600"
       Status:
@@ -54,8 +50,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878828.855404,VS0,VE260
+      - S1563878826.351704,VS0,VE310
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries/create.yaml
+++ b/fastly/fixtures/acl_entries/create.yaml
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry
@@ -29,7 +29,6 @@ interactions:
       entry","updated_at":"2019-07-23T10:47:07Z","deleted_at":null,"id":"5z5nqKm0IGS8ovR512rSaT","negated":0,"created_at":"2019-07-23T10:47:07Z"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -48,7 +47,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries/create_service.yaml
+++ b/fastly/fixtures/acl_entries/create_service.yaml
@@ -3,18 +3,12 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ACL=1d7GeY6Ky6eeqSsO5c1r29&ID=5z5nqKm0IGS8ovR512rSaT&Service=2voeSM5z6889qin6D9waPl&ip=10.0.0.4&negated=true
+    body: comment=go-fastly+client+test&name=test_service_ACLEntries
     form:
-      ACL:
-      - 1d7GeY6Ky6eeqSsO5c1r29
-      ID:
-      - 5z5nqKm0IGS8ovR512rSaT
-      Service:
-      - 2voeSM5z6889qin6D9waPl
-      ip:
-      - 10.0.0.4
-      negated:
-      - "true"
+      comment:
+      - go-fastly client test
+      name:
+      - test_service_ACLEntries
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -22,10 +16,10 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry/5z5nqKm0IGS8ovR512rSaT
-    method: PATCH
+    url: https://api.fastly.com/service
+    method: POST
   response:
-    body: '{"ip":"10.0.0.4","updated_at":"2019-07-23T10:47:07Z","comment":"test entry","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","created_at":"2019-07-23T10:47:07Z","negated":"true","service_id":"2voeSM5z6889qin6D9waPl","id":"5z5nqKm0IGS8ovR512rSaT","subnet":8,"deleted_at":null}'
+    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_ACLEntries","created_at":"2019-07-23T10:47:05Z","versions":[{"active":false,"number":1,"staging":false,"testing":false,"created_at":"2019-07-23T10:47:05Z","service_id":"2voeSM5z6889qin6D9waPl","deployed":false,"comment":"","deleted_at":null,"updated_at":"2019-07-23T10:47:05Z","locked":false}],"id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"publish_key":"7325baa561b97bdb5ee97af05b50630c4e9a3cf2","updated_at":"2019-07-23T10:47:05Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,9 +29,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:08 GMT
+      - Tue, 23 Jul 2019 10:47:05 GMT
       Fastly-Ratelimit-Remaining:
-      - "980"
+      - "984"
       Fastly-Ratelimit-Reset:
       - "1563879600"
       Status:
@@ -56,6 +50,6 @@ interactions:
       X-Served-By:
       - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878828.855404,VS0,VE260
+      - S1563878825.257544,VS0,VE529
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries/create_service.yaml
+++ b/fastly/fixtures/acl_entries/create_service.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service
@@ -22,7 +22,6 @@ interactions:
     body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_ACLEntries","created_at":"2019-07-23T10:47:05Z","versions":[{"active":false,"number":1,"staging":false,"testing":false,"created_at":"2019-07-23T10:47:05Z","service_id":"2voeSM5z6889qin6D9waPl","deployed":false,"comment":"","deleted_at":null,"updated_at":"2019-07-23T10:47:05Z","locked":false}],"id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"publish_key":"7325baa561b97bdb5ee97af05b50630c4e9a3cf2","updated_at":"2019-07-23T10:47:05Z"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -41,7 +40,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries/delete.yaml
+++ b/fastly/fixtures/acl_entries/delete.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry/5z5nqKm0IGS8ovR512rSaT
@@ -16,7 +16,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -35,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries/delete.yaml
+++ b/fastly/fixtures/acl_entries/delete.yaml
@@ -7,26 +7,27 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/acl/3xMPlUKElxNy5JAd2HQkhZ/entry/1P5vZXb4sHxFXE2IF473SI
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry/5z5nqKm0IGS8ovR512rSaT
     method: DELETE
   response:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 18:07:27 GMT
+      - Tue, 23 Jul 2019 10:47:08 GMT
       Fastly-Ratelimit-Remaining:
-      - "995"
+      - "979"
       Fastly-Ratelimit-Reset:
-      - "1557428400"
+      - "1563879600"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +42,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17433-PAO
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1557425247.635413,VS0,VE1012
+      - S1563878828.117953,VS0,VE319
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries/delete_acl.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/version/2/acl/test_acl_ACLEntries
@@ -16,7 +16,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -35,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries/delete_acl.yaml
@@ -3,29 +3,17 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ACL=1d7GeY6Ky6eeqSsO5c1r29&ID=5z5nqKm0IGS8ovR512rSaT&Service=2voeSM5z6889qin6D9waPl&ip=10.0.0.4&negated=true
-    form:
-      ACL:
-      - 1d7GeY6Ky6eeqSsO5c1r29
-      ID:
-      - 5z5nqKm0IGS8ovR512rSaT
-      Service:
-      - 2voeSM5z6889qin6D9waPl
-      ip:
-      - 10.0.0.4
-      negated:
-      - "true"
+    body: ""
+    form: {}
     headers:
-      Content-Type:
-      - application/x-www-form-urlencoded
       Fastly-Key:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry/5z5nqKm0IGS8ovR512rSaT
-    method: PATCH
+    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/version/2/acl/test_acl_ACLEntries
+    method: DELETE
   response:
-    body: '{"ip":"10.0.0.4","updated_at":"2019-07-23T10:47:07Z","comment":"test entry","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","created_at":"2019-07-23T10:47:07Z","negated":"true","service_id":"2voeSM5z6889qin6D9waPl","id":"5z5nqKm0IGS8ovR512rSaT","subnet":8,"deleted_at":null}'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -37,7 +25,7 @@ interactions:
       Date:
       - Tue, 23 Jul 2019 10:47:08 GMT
       Fastly-Ratelimit-Remaining:
-      - "980"
+      - "978"
       Fastly-Ratelimit-Reset:
       - "1563879600"
       Status:
@@ -56,6 +44,6 @@ interactions:
       X-Served-By:
       - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878828.855404,VS0,VE260
+      - S1563878828.439209,VS0,VE398
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries/delete_service.yaml
+++ b/fastly/fixtures/acl_entries/delete_service.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl
@@ -16,7 +16,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -35,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries/delete_service.yaml
+++ b/fastly/fixtures/acl_entries/delete_service.yaml
@@ -10,25 +10,24 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl
+    method: DELETE
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 10:47:09 GMT
+      Fastly-Ratelimit-Remaining:
+      - "977"
+      Fastly-Ratelimit-Reset:
+      - "1563879600"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +42,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563878829.839717,VS0,VE233
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries/get.yaml
+++ b/fastly/fixtures/acl_entries/get.yaml
@@ -7,25 +7,28 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/acl/3xMPlUKElxNy5JAd2HQkhZ/entry/1P5vZXb4sHxFXE2IF473SI
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry/5z5nqKm0IGS8ovR512rSaT
     method: GET
   response:
-    body: '{"acl_id":"3xMPlUKElxNy5JAd2HQkhZ","ip":"10.0.0.3","service_id":"7i6HN3TK9wS159v2gPAZ8A","deleted_at":null,"id":"1P5vZXb4sHxFXE2IF473SI","comment":"test
-      entry","updated_at":"2019-05-09T18:07:24Z","created_at":"2019-05-09T18:07:24Z","subnet":8,"negated":"0"}'
+    body: '{"service_id":"2voeSM5z6889qin6D9waPl","id":"5z5nqKm0IGS8ovR512rSaT","created_at":"2019-07-23T10:47:07Z","negated":"0","updated_at":"2019-07-23T10:47:07Z","comment":"test
+      entry","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","ip":"10.0.0.3","subnet":8,"deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
+      - bytes
       Age:
+      - "0"
       - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 18:07:25 GMT
+      - Tue, 23 Jul 2019 10:47:07 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -40,8 +43,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17433-PAO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1557425245.283749,VS0,VE404
+      - S1563878827.370844,VS0,VE482
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries/get.yaml
+++ b/fastly/fixtures/acl_entries/get.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry/5z5nqKm0IGS8ovR512rSaT
@@ -18,10 +18,7 @@ interactions:
     headers:
       Accept-Ranges:
       - bytes
-      - bytes
-      - bytes
       Age:
-      - "0"
       - "0"
       Cache-Control:
       - no-cache
@@ -36,7 +33,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries/list.yaml
+++ b/fastly/fixtures/acl_entries/list.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
@@ -18,10 +18,7 @@ interactions:
     headers:
       Accept-Ranges:
       - bytes
-      - bytes
-      - bytes
       Age:
-      - "0"
       - "0"
       Cache-Control:
       - no-cache
@@ -36,7 +33,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries/update.yaml
+++ b/fastly/fixtures/acl_entries/update.yaml
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry/5z5nqKm0IGS8ovR512rSaT
@@ -28,7 +28,6 @@ interactions:
     body: '{"ip":"10.0.0.4","updated_at":"2019-07-23T10:47:07Z","comment":"test entry","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","created_at":"2019-07-23T10:47:07Z","negated":"true","service_id":"2voeSM5z6889qin6D9waPl","id":"5z5nqKm0IGS8ovR512rSaT","subnet":8,"deleted_at":null}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -47,7 +46,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries/version.yaml
+++ b/fastly/fixtures/acl_entries/version.yaml
@@ -3,34 +3,35 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A
+    body: Service=2voeSM5z6889qin6D9waPl
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
+      - 2voeSM5z6889qin6D9waPl
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":25}'
+    body: '{"service_id":"2voeSM5z6889qin6D9waPl","number":2}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 18:07:23 GMT
+      - Tue, 23 Jul 2019 10:47:06 GMT
       Fastly-Ratelimit-Remaining:
-      - "999"
+      - "983"
       Fastly-Ratelimit-Reset:
-      - "1557428400"
+      - "1563879600"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,8 +46,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17433-PAO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1557425243.451642,VS0,VE477
+      - S1563878826.790312,VS0,VE559
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries/version.yaml
+++ b/fastly/fixtures/acl_entries/version.yaml
@@ -11,7 +11,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/version
@@ -20,7 +20,6 @@ interactions:
     body: '{"service_id":"2voeSM5z6889qin6D9waPl","number":2}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -39,7 +38,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/create/create_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_acl.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/version/2/acl
@@ -24,7 +24,6 @@ interactions:
     body: '{"service_id":"3MYXdSsO9U0dulSgjNLvMq","version":"2","name":"test_acl_BatchModifyAclEntries_Create","created_at":"2019-07-23T09:37:36Z","updated_at":"2019-07-23T09:37:36Z","deleted_at":null,"id":"2Klss85C29mdombaiuERZv"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -43,7 +42,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/create/create_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_acl.yaml
@@ -3,18 +3,14 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ACL=1d7GeY6Ky6eeqSsO5c1r29&Service=2voeSM5z6889qin6D9waPl&comment=test+entry&ip=10.0.0.3&subnet=8
+    body: Service=3MYXdSsO9U0dulSgjNLvMq&Version=2&name=test_acl_BatchModifyAclEntries_Create
     form:
-      ACL:
-      - 1d7GeY6Ky6eeqSsO5c1r29
       Service:
-      - 2voeSM5z6889qin6D9waPl
-      comment:
-      - test entry
-      ip:
-      - 10.0.0.3
-      subnet:
-      - "8"
+      - 3MYXdSsO9U0dulSgjNLvMq
+      Version:
+      - "2"
+      name:
+      - test_acl_BatchModifyAclEntries_Create
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -22,11 +18,10 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry
+    url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/version/2/acl
     method: POST
   response:
-    body: '{"service_id":"2voeSM5z6889qin6D9waPl","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","ip":"10.0.0.3","subnet":8,"comment":"test
-      entry","updated_at":"2019-07-23T10:47:07Z","deleted_at":null,"id":"5z5nqKm0IGS8ovR512rSaT","negated":0,"created_at":"2019-07-23T10:47:07Z"}'
+    body: '{"service_id":"3MYXdSsO9U0dulSgjNLvMq","version":"2","name":"test_acl_BatchModifyAclEntries_Create","created_at":"2019-07-23T09:37:36Z","updated_at":"2019-07-23T09:37:36Z","deleted_at":null,"id":"2Klss85C29mdombaiuERZv"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -36,11 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:36 GMT
       Fastly-Ratelimit-Remaining:
       - "981"
       Fastly-Ratelimit-Reset:
-      - "1563879600"
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -55,8 +50,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1563878827.664010,VS0,VE481
+      - S1563874656.904176,VS0,VE307
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/create/create_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_acl_entries.yaml
@@ -3,32 +3,37 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ""
+    body: '{"entries":[{"op":"create","ip":"127.0.0.1","subnet":"24","comment":"ACL
+      Entry 1"},{"op":"create","ip":"192.168.0.1","subnet":"24","comment":"ACL Entry
+      2"}]}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       Fastly-Key:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/acl/2Klss85C29mdombaiuERZv/entries
+    method: PATCH
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:36 GMT
+      Fastly-Ratelimit-Remaining:
+      - "980"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +48,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874656.214418,VS0,VE269
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/create/create_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_acl_entries.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/acl/2Klss85C29mdombaiuERZv/entries
@@ -22,7 +22,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -41,7 +40,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/create/create_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_service.yaml
@@ -1,0 +1,55 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: comment=go-fastly+client+test&name=test_service_BatchModifyAclEntries_Create
+    form:
+      comment:
+      - go-fastly client test
+      name:
+      - test_service_BatchModifyAclEntries_Create
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Fastly-Key:
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      User-Agent:
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service
+    method: POST
+  response:
+    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Create","created_at":"2019-07-23T09:37:35Z","deleted_at":null,"publish_key":"f20b3f94c392835f34fe594cc3ed23d4437863d1","id":"3MYXdSsO9U0dulSgjNLvMq","versions":[{"staging":false,"created_at":"2019-07-23T09:37:35Z","deployed":false,"deleted_at":null,"comment":"","service_id":"3MYXdSsO9U0dulSgjNLvMq","testing":false,"active":false,"updated_at":"2019-07-23T09:37:35Z","number":1,"locked":false}],"updated_at":"2019-07-23T09:37:35Z"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jul 2019 09:37:35 GMT
+      Fastly-Ratelimit-Remaining:
+      - "983"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19226-LCY
+      X-Timer:
+      - S1563874655.999568,VS0,VE255
+    status: 200 OK
+    code: 200

--- a/fastly/fixtures/acl_entries_batch/create/create_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_service.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service
@@ -22,7 +22,6 @@ interactions:
     body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Create","created_at":"2019-07-23T09:37:35Z","deleted_at":null,"publish_key":"f20b3f94c392835f34fe594cc3ed23d4437863d1","id":"3MYXdSsO9U0dulSgjNLvMq","versions":[{"staging":false,"created_at":"2019-07-23T09:37:35Z","deployed":false,"deleted_at":null,"comment":"","service_id":"3MYXdSsO9U0dulSgjNLvMq","testing":false,"active":false,"updated_at":"2019-07-23T09:37:35Z","number":1,"locked":false}],"updated_at":"2019-07-23T09:37:35Z"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -41,7 +40,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/create/create_version.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_version.yaml
@@ -11,7 +11,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/version
@@ -20,7 +20,6 @@ interactions:
     body: '{"service_id":"3MYXdSsO9U0dulSgjNLvMq","number":2}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -39,7 +38,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/create/create_version.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_version.yaml
@@ -3,30 +3,35 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ""
-    form: {}
+    body: Service=3MYXdSsO9U0dulSgjNLvMq
+    form:
+      Service:
+      - 3MYXdSsO9U0dulSgjNLvMq
     headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
       Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/25/acl/entry_acl
-    method: DELETE
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/version
+    method: POST
   response:
-    body: '{"status":"ok"}'
+    body: '{"service_id":"3MYXdSsO9U0dulSgjNLvMq","number":2}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 18:07:27 GMT
+      - Tue, 23 Jul 2019 09:37:35 GMT
       Fastly-Ratelimit-Remaining:
-      - "994"
+      - "982"
       Fastly-Ratelimit-Reset:
-      - "1557428400"
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +46,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17433-PAO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1557425248.667395,VS0,VE266
+      - S1563874655.258344,VS0,VE643
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/create/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/delete_acl.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/version/2/acl/test_acl_BatchModifyAclEntries_Create
@@ -16,7 +16,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -35,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/create/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/delete_acl.yaml
@@ -10,25 +10,24 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/version/2/acl/test_acl_BatchModifyAclEntries_Create
+    method: DELETE
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:37 GMT
+      Fastly-Ratelimit-Remaining:
+      - "979"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +42,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874657.976616,VS0,VE638
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/create/delete_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/delete_service.yaml
@@ -10,25 +10,24 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq
+    method: DELETE
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:37 GMT
+      Fastly-Ratelimit-Remaining:
+      - "978"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +42,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874658.617475,VS0,VE265
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/create/delete_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/delete_service.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq
@@ -16,7 +16,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -35,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/create/list_after_create.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/list_after_create.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/acl/2Klss85C29mdombaiuERZv/entries
@@ -19,10 +19,7 @@ interactions:
     headers:
       Accept-Ranges:
       - bytes
-      - bytes
-      - bytes
       Age:
-      - "0"
       - "0"
       Cache-Control:
       - no-cache
@@ -37,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/create/list_after_create.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/list_after_create.yaml
@@ -1,0 +1,51 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Fastly-Key:
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      User-Agent:
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service/3MYXdSsO9U0dulSgjNLvMq/acl/2Klss85C29mdombaiuERZv/entries
+    method: GET
+  response:
+    body: '[{"acl_id":"2Klss85C29mdombaiuERZv","updated_at":"2019-07-23T09:37:36Z","created_at":"2019-07-23T09:37:36Z","ip":"127.0.0.1","id":"3s9TpkN6E9WiSdY5qLsIbf","service_id":"3MYXdSsO9U0dulSgjNLvMq","negated":"0","comment":"ACL
+      Entry 1","subnet":24,"deleted_at":null},{"service_id":"3MYXdSsO9U0dulSgjNLvMq","deleted_at":null,"negated":"0","subnet":24,"comment":"ACL
+      Entry 2","created_at":"2019-07-23T09:37:36Z","ip":"192.168.0.1","acl_id":"2Klss85C29mdombaiuERZv","updated_at":"2019-07-23T09:37:36Z","id":"7NGMjQBaW2rMBo8iPfkVuy"}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jul 2019 09:37:36 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19226-LCY
+      X-Timer:
+      - S1563874656.486632,VS0,VE487
+    status: 200 OK
+    code: 200

--- a/fastly/fixtures/acl_entries_batch/delete/create_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_acl.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/version/2/acl
@@ -24,7 +24,6 @@ interactions:
     body: '{"service_id":"1fn1uiuo7LwssNl2EH2gBI","version":"2","name":"test_acl_BatchModifyAclEntries_Delete","deleted_at":null,"id":"2WOimUJEh3AE0iFaE3E5JL","updated_at":"2019-07-23T09:37:49Z","created_at":"2019-07-23T09:37:49Z"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -43,7 +42,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/delete/create_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_acl.yaml
@@ -3,18 +3,14 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ACL=1d7GeY6Ky6eeqSsO5c1r29&Service=2voeSM5z6889qin6D9waPl&comment=test+entry&ip=10.0.0.3&subnet=8
+    body: Service=1fn1uiuo7LwssNl2EH2gBI&Version=2&name=test_acl_BatchModifyAclEntries_Delete
     form:
-      ACL:
-      - 1d7GeY6Ky6eeqSsO5c1r29
       Service:
-      - 2voeSM5z6889qin6D9waPl
-      comment:
-      - test entry
-      ip:
-      - 10.0.0.3
-      subnet:
-      - "8"
+      - 1fn1uiuo7LwssNl2EH2gBI
+      Version:
+      - "2"
+      name:
+      - test_acl_BatchModifyAclEntries_Delete
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -22,11 +18,10 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry
+    url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/version/2/acl
     method: POST
   response:
-    body: '{"service_id":"2voeSM5z6889qin6D9waPl","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","ip":"10.0.0.3","subnet":8,"comment":"test
-      entry","updated_at":"2019-07-23T10:47:07Z","deleted_at":null,"id":"5z5nqKm0IGS8ovR512rSaT","negated":0,"created_at":"2019-07-23T10:47:07Z"}'
+    body: '{"service_id":"1fn1uiuo7LwssNl2EH2gBI","version":"2","name":"test_acl_BatchModifyAclEntries_Delete","deleted_at":null,"id":"2WOimUJEh3AE0iFaE3E5JL","updated_at":"2019-07-23T09:37:49Z","created_at":"2019-07-23T09:37:49Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -36,11 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:49 GMT
       Fastly-Ratelimit-Remaining:
-      - "981"
+      - "975"
       Fastly-Ratelimit-Reset:
-      - "1563879600"
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,6 +52,6 @@ interactions:
       X-Served-By:
       - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878827.664010,VS0,VE481
+      - S1563874669.460370,VS0,VE317
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/delete/create_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_acl_entries.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/acl/2WOimUJEh3AE0iFaE3E5JL/entries
@@ -22,7 +22,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -41,7 +40,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/delete/create_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_acl_entries.yaml
@@ -3,32 +3,37 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ""
+    body: '{"entries":[{"op":"create","ip":"127.0.0.1","subnet":"24","comment":"ACL
+      Entry 1"},{"op":"create","ip":"192.168.0.1","subnet":"24","comment":"ACL Entry
+      2"}]}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       Fastly-Key:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/acl/2WOimUJEh3AE0iFaE3E5JL/entries
+    method: PATCH
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:50 GMT
+      Fastly-Ratelimit-Remaining:
+      - "974"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +48,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874670.786264,VS0,VE275
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/delete/create_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_service.yaml
@@ -1,0 +1,55 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: comment=go-fastly+client+test&name=test_service_BatchModifyAclEntries_Delete
+    form:
+      comment:
+      - go-fastly client test
+      name:
+      - test_service_BatchModifyAclEntries_Delete
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Fastly-Key:
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      User-Agent:
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service
+    method: POST
+  response:
+    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Delete","versions":[{"active":false,"number":1,"staging":false,"testing":false,"created_at":"2019-07-23T09:37:48Z","service_id":"1fn1uiuo7LwssNl2EH2gBI","deployed":false,"comment":"","deleted_at":null,"updated_at":"2019-07-23T09:37:48Z","locked":false}],"id":"1fn1uiuo7LwssNl2EH2gBI","created_at":"2019-07-23T09:37:48Z","publish_key":"2e5f823858cfa77117dc4a88dacd04ace95d407c","deleted_at":null,"updated_at":"2019-07-23T09:37:48Z"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jul 2019 09:37:48 GMT
+      Fastly-Ratelimit-Remaining:
+      - "977"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19277-LCY
+      X-Timer:
+      - S1563874668.249724,VS0,VE530
+    status: 200 OK
+    code: 200

--- a/fastly/fixtures/acl_entries_batch/delete/create_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_service.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service
@@ -22,7 +22,6 @@ interactions:
     body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Delete","versions":[{"active":false,"number":1,"staging":false,"testing":false,"created_at":"2019-07-23T09:37:48Z","service_id":"1fn1uiuo7LwssNl2EH2gBI","deployed":false,"comment":"","deleted_at":null,"updated_at":"2019-07-23T09:37:48Z","locked":false}],"id":"1fn1uiuo7LwssNl2EH2gBI","created_at":"2019-07-23T09:37:48Z","publish_key":"2e5f823858cfa77117dc4a88dacd04ace95d407c","deleted_at":null,"updated_at":"2019-07-23T09:37:48Z"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -41,7 +40,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/delete/create_version.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_version.yaml
@@ -3,18 +3,10 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ACL=1d7GeY6Ky6eeqSsO5c1r29&Service=2voeSM5z6889qin6D9waPl&comment=test+entry&ip=10.0.0.3&subnet=8
+    body: Service=1fn1uiuo7LwssNl2EH2gBI
     form:
-      ACL:
-      - 1d7GeY6Ky6eeqSsO5c1r29
       Service:
-      - 2voeSM5z6889qin6D9waPl
-      comment:
-      - test entry
-      ip:
-      - 10.0.0.3
-      subnet:
-      - "8"
+      - 1fn1uiuo7LwssNl2EH2gBI
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -22,11 +14,10 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry
+    url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/version
     method: POST
   response:
-    body: '{"service_id":"2voeSM5z6889qin6D9waPl","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","ip":"10.0.0.3","subnet":8,"comment":"test
-      entry","updated_at":"2019-07-23T10:47:07Z","deleted_at":null,"id":"5z5nqKm0IGS8ovR512rSaT","negated":0,"created_at":"2019-07-23T10:47:07Z"}'
+    body: '{"service_id":"1fn1uiuo7LwssNl2EH2gBI","number":2}'
     headers:
       Accept-Ranges:
       - bytes
@@ -36,11 +27,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:49 GMT
       Fastly-Ratelimit-Remaining:
-      - "981"
+      - "976"
       Fastly-Ratelimit-Reset:
-      - "1563879600"
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,6 +48,6 @@ interactions:
       X-Served-By:
       - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878827.664010,VS0,VE481
+      - S1563874669.786338,VS0,VE668
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/delete/create_version.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_version.yaml
@@ -11,7 +11,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/version
@@ -20,7 +20,6 @@ interactions:
     body: '{"service_id":"1fn1uiuo7LwssNl2EH2gBI","number":2}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -39,7 +38,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/delete/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/delete_acl.yaml
@@ -10,25 +10,24 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/version/2/acl/test_acl_BatchModifyAclEntries_Delete
+    method: DELETE
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:51 GMT
+      Fastly-Ratelimit-Remaining:
+      - "972"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,6 +44,6 @@ interactions:
       X-Served-By:
       - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874671.806868,VS0,VE310
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/delete/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/delete_acl.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/version/2/acl/test_acl_BatchModifyAclEntries_Delete
@@ -16,7 +16,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -35,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/delete/delete_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/delete_acl_entries.yaml
@@ -11,7 +11,7 @@ interactions:
       Content-Type:
       - application/json
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/acl/2WOimUJEh3AE0iFaE3E5JL/entries
@@ -20,7 +20,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -39,7 +38,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/delete/delete_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/delete_acl_entries.yaml
@@ -3,32 +3,35 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ""
+    body: '{"entries":[{"op":"delete","id":"3r5lszX6PDmmRP6kXsC8Mi"}]}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       Fastly-Key:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/acl/2WOimUJEh3AE0iFaE3E5JL/entries
+    method: PATCH
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:50 GMT
+      Fastly-Ratelimit-Remaining:
+      - "973"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +46,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874670.311630,VS0,VE257
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/delete/delete_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/delete_service.yaml
@@ -10,25 +10,24 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI
+    method: DELETE
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:51 GMT
+      Fastly-Ratelimit-Remaining:
+      - "971"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +42,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874671.121539,VS0,VE248
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/delete/delete_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/delete_service.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI
@@ -16,7 +16,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -35,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/delete/list_after_delete.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/list_after_delete.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/acl/2WOimUJEh3AE0iFaE3E5JL/entries
@@ -17,7 +17,6 @@ interactions:
       Entry 2","negated":"0","deleted_at":null,"service_id":"1fn1uiuo7LwssNl2EH2gBI"}]'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -32,7 +31,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/delete/list_after_delete.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/list_after_delete.yaml
@@ -10,25 +10,21 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
+    url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/acl/2WOimUJEh3AE0iFaE3E5JL/entries
     method: GET
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '[{"id":"3lP4jGb6tpV7OfBS2jZr8h","acl_id":"2WOimUJEh3AE0iFaE3E5JL","updated_at":"2019-07-23T09:37:49Z","ip":"192.168.0.1","created_at":"2019-07-23T09:37:49Z","subnet":24,"comment":"ACL
+      Entry 2","negated":"0","deleted_at":null,"service_id":"1fn1uiuo7LwssNl2EH2gBI"}]'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:50 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,6 +41,6 @@ interactions:
       X-Served-By:
       - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874671.573483,VS0,VE223
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/delete/list_before_delete.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/list_before_delete.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/acl/2WOimUJEh3AE0iFaE3E5JL/entries
@@ -18,10 +18,7 @@ interactions:
     headers:
       Accept-Ranges:
       - bytes
-      - bytes
-      - bytes
       Age:
-      - "0"
       - "0"
       Cache-Control:
       - no-cache
@@ -36,7 +33,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/delete/list_before_delete.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/list_before_delete.yaml
@@ -1,0 +1,50 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Fastly-Key:
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      User-Agent:
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service/1fn1uiuo7LwssNl2EH2gBI/acl/2WOimUJEh3AE0iFaE3E5JL/entries
+    method: GET
+  response:
+    body: '[{"comment":"ACL Entry 1","negated":"0","subnet":24,"id":"3r5lszX6PDmmRP6kXsC8Mi","acl_id":"2WOimUJEh3AE0iFaE3E5JL","created_at":"2019-07-23T09:37:49Z","updated_at":"2019-07-23T09:37:49Z","service_id":"1fn1uiuo7LwssNl2EH2gBI","ip":"127.0.0.1","deleted_at":null},{"id":"3lP4jGb6tpV7OfBS2jZr8h","subnet":24,"negated":"0","comment":"ACL
+      Entry 2","deleted_at":null,"service_id":"1fn1uiuo7LwssNl2EH2gBI","ip":"192.168.0.1","updated_at":"2019-07-23T09:37:49Z","acl_id":"2WOimUJEh3AE0iFaE3E5JL","created_at":"2019-07-23T09:37:49Z"}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jul 2019 09:37:50 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19277-LCY
+      X-Timer:
+      - S1563874670.064055,VS0,VE245
+    status: 200 OK
+    code: 200

--- a/fastly/fixtures/acl_entries_batch/update/create_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_acl.yaml
@@ -3,18 +3,14 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ACL=1d7GeY6Ky6eeqSsO5c1r29&Service=2voeSM5z6889qin6D9waPl&comment=test+entry&ip=10.0.0.3&subnet=8
+    body: Service=5RZUouxF6dQkKd6RQSla8P&Version=2&name=test_acl_BatchModifyAclEntries_Update
     form:
-      ACL:
-      - 1d7GeY6Ky6eeqSsO5c1r29
       Service:
-      - 2voeSM5z6889qin6D9waPl
-      comment:
-      - test entry
-      ip:
-      - 10.0.0.3
-      subnet:
-      - "8"
+      - 5RZUouxF6dQkKd6RQSla8P
+      Version:
+      - "2"
+      name:
+      - test_acl_BatchModifyAclEntries_Update
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -22,11 +18,10 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entry
+    url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/version/2/acl
     method: POST
   response:
-    body: '{"service_id":"2voeSM5z6889qin6D9waPl","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","ip":"10.0.0.3","subnet":8,"comment":"test
-      entry","updated_at":"2019-07-23T10:47:07Z","deleted_at":null,"id":"5z5nqKm0IGS8ovR512rSaT","negated":0,"created_at":"2019-07-23T10:47:07Z"}'
+    body: '{"service_id":"5RZUouxF6dQkKd6RQSla8P","version":"2","name":"test_acl_BatchModifyAclEntries_Update","deleted_at":null,"updated_at":"2019-07-23T09:37:59Z","created_at":"2019-07-23T09:37:59Z","id":"3Q5Oel6HFcUP0gxxSEkxlJ"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -36,11 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:37:59 GMT
       Fastly-Ratelimit-Remaining:
-      - "981"
+      - "968"
       Fastly-Ratelimit-Reset:
-      - "1563879600"
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -55,8 +50,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1563878827.664010,VS0,VE481
+      - S1563874679.246652,VS0,VE319
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/update/create_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_acl.yaml
@@ -15,7 +15,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/version/2/acl
@@ -24,7 +24,6 @@ interactions:
     body: '{"service_id":"5RZUouxF6dQkKd6RQSla8P","version":"2","name":"test_acl_BatchModifyAclEntries_Update","deleted_at":null,"updated_at":"2019-07-23T09:37:59Z","created_at":"2019-07-23T09:37:59Z","id":"3Q5Oel6HFcUP0gxxSEkxlJ"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -43,7 +42,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/update/create_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_acl_entries.yaml
@@ -3,32 +3,37 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ""
+    body: '{"entries":[{"op":"create","ip":"127.0.0.1","subnet":"24","comment":"ACL
+      Entry 1"},{"op":"create","ip":"192.168.0.1","subnet":"24","comment":"ACL Entry
+      2"}]}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       Fastly-Key:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/acl/3Q5Oel6HFcUP0gxxSEkxlJ/entries
+    method: PATCH
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:38:00 GMT
+      Fastly-Ratelimit-Remaining:
+      - "967"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +48,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874680.569203,VS0,VE498
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/update/create_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_acl_entries.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/acl/3Q5Oel6HFcUP0gxxSEkxlJ/entries
@@ -22,7 +22,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -41,7 +40,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/update/create_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_service.yaml
@@ -1,0 +1,55 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: comment=go-fastly+client+test&name=test_service_BatchModifyAclEntries_Update
+    form:
+      comment:
+      - go-fastly client test
+      name:
+      - test_service_BatchModifyAclEntries_Update
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Fastly-Key:
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      User-Agent:
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service
+    method: POST
+  response:
+    body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Update","id":"5RZUouxF6dQkKd6RQSla8P","versions":[{"deployed":false,"comment":"","service_id":"5RZUouxF6dQkKd6RQSla8P","deleted_at":null,"updated_at":"2019-07-23T09:37:58Z","locked":false,"active":false,"staging":false,"number":1,"testing":false,"created_at":"2019-07-23T09:37:58Z"}],"created_at":"2019-07-23T09:37:58Z","updated_at":"2019-07-23T09:37:58Z","deleted_at":null,"publish_key":"1727de065b592b00de52380007e78994ffe88d73"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jul 2019 09:37:58 GMT
+      Fastly-Ratelimit-Remaining:
+      - "970"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19226-LCY
+      X-Timer:
+      - S1563874678.038518,VS0,VE529
+    status: 200 OK
+    code: 200

--- a/fastly/fixtures/acl_entries_batch/update/create_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_service.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service
@@ -22,7 +22,6 @@ interactions:
     body: '{"customer_id":"WpqWFjTA4lk2N1g0GY2HH","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Update","id":"5RZUouxF6dQkKd6RQSla8P","versions":[{"deployed":false,"comment":"","service_id":"5RZUouxF6dQkKd6RQSla8P","deleted_at":null,"updated_at":"2019-07-23T09:37:58Z","locked":false,"active":false,"staging":false,"number":1,"testing":false,"created_at":"2019-07-23T09:37:58Z"}],"created_at":"2019-07-23T09:37:58Z","updated_at":"2019-07-23T09:37:58Z","deleted_at":null,"publish_key":"1727de065b592b00de52380007e78994ffe88d73"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -41,7 +40,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/update/create_version.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_version.yaml
@@ -11,7 +11,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/version
@@ -20,7 +20,6 @@ interactions:
     body: '{"service_id":"5RZUouxF6dQkKd6RQSla8P","number":2}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -39,7 +38,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/update/create_version.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_version.yaml
@@ -3,38 +3,35 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=25&name=entry_acl
+    body: Service=5RZUouxF6dQkKd6RQSla8P
     form:
       Service:
-      - 7i6HN3TK9wS159v2gPAZ8A
-      Version:
-      - "25"
-      name:
-      - entry_acl
+      - 5RZUouxF6dQkKd6RQSla8P
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/25/acl
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"25","name":"entry_acl","id":"3xMPlUKElxNy5JAd2HQkhZ","deleted_at":null,"created_at":"2019-05-09T18:07:24Z","updated_at":"2019-05-09T18:07:24Z"}'
+    body: '{"service_id":"5RZUouxF6dQkKd6RQSla8P","number":2}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 18:07:24 GMT
+      - Tue, 23 Jul 2019 09:37:59 GMT
       Fastly-Ratelimit-Remaining:
-      - "998"
+      - "969"
       Fastly-Ratelimit-Reset:
-      - "1557428400"
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,8 +46,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17433-PAO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1557425244.935705,VS0,VE240
+      - S1563874679.571980,VS0,VE669
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/update/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/delete_acl.yaml
@@ -10,25 +10,24 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/version/2/acl/test_acl_BatchModifyAclEntries_Update
+    method: DELETE
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:38:01 GMT
+      Fastly-Ratelimit-Remaining:
+      - "965"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +42,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874681.843056,VS0,VE433
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/update/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/delete_acl.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/version/2/acl/test_acl_BatchModifyAclEntries_Update
@@ -16,7 +16,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -35,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/update/delete_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/delete_service.yaml
@@ -10,25 +10,24 @@ interactions:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P
+    method: DELETE
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:38:01 GMT
+      Fastly-Ratelimit-Remaining:
+      - "964"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +42,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874681.281891,VS0,VE241
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/update/delete_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/delete_service.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P
@@ -16,7 +16,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -35,7 +34,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/update/list_after_update.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/list_after_update.yaml
@@ -1,0 +1,47 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Fastly-Key:
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      User-Agent:
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/acl/3Q5Oel6HFcUP0gxxSEkxlJ/entries
+    method: GET
+  response:
+    body: '[{"id":"4Ex37PIt2oESevIFfYKdur","created_at":"2019-07-23T09:37:59Z","ip":"127.0.0.2","updated_at":"2019-07-23T09:38:00Z","acl_id":"3Q5Oel6HFcUP0gxxSEkxlJ","deleted_at":null,"negated":"1","comment":"Updated
+      ACL Entry 1","subnet":16,"service_id":"5RZUouxF6dQkKd6RQSla8P"},{"deleted_at":null,"negated":"0","subnet":24,"comment":"ACL
+      Entry 2","service_id":"5RZUouxF6dQkKd6RQSla8P","id":"4BuyRhMCxnU23tnyw63zCa","created_at":"2019-07-23T09:37:59Z","ip":"192.168.0.1","updated_at":"2019-07-23T09:37:59Z","acl_id":"3Q5Oel6HFcUP0gxxSEkxlJ"}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jul 2019 09:38:00 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lcy19226-LCY
+      X-Timer:
+      - S1563874681.588596,VS0,VE249
+    status: 200 OK
+    code: 200

--- a/fastly/fixtures/acl_entries_batch/update/list_after_update.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/list_after_update.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/acl/3Q5Oel6HFcUP0gxxSEkxlJ/entries
@@ -18,7 +18,6 @@ interactions:
       Entry 2","service_id":"5RZUouxF6dQkKd6RQSla8P","id":"4BuyRhMCxnU23tnyw63zCa","created_at":"2019-07-23T09:37:59Z","ip":"192.168.0.1","updated_at":"2019-07-23T09:37:59Z","acl_id":"3Q5Oel6HFcUP0gxxSEkxlJ"}]'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -33,7 +32,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/update/list_before_update.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/list_before_update.yaml
@@ -7,7 +7,7 @@ interactions:
     form: {}
     headers:
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/acl/3Q5Oel6HFcUP0gxxSEkxlJ/entries
@@ -18,10 +18,7 @@ interactions:
     headers:
       Accept-Ranges:
       - bytes
-      - bytes
-      - bytes
       Age:
-      - "0"
       - "0"
       Cache-Control:
       - no-cache
@@ -36,7 +33,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acl_entries_batch/update/list_before_update.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/list_before_update.yaml
@@ -1,0 +1,50 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Fastly-Key:
+      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      User-Agent:
+      - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
+    url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/acl/3Q5Oel6HFcUP0gxxSEkxlJ/entries
+    method: GET
+  response:
+    body: '[{"acl_id":"3Q5Oel6HFcUP0gxxSEkxlJ","comment":"ACL Entry 1","updated_at":"2019-07-23T09:37:59Z","negated":"0","deleted_at":null,"subnet":24,"ip":"127.0.0.1","created_at":"2019-07-23T09:37:59Z","id":"4Ex37PIt2oESevIFfYKdur","service_id":"5RZUouxF6dQkKd6RQSla8P"},{"updated_at":"2019-07-23T09:37:59Z","acl_id":"3Q5Oel6HFcUP0gxxSEkxlJ","comment":"ACL
+      Entry 2","negated":"0","subnet":24,"deleted_at":null,"ip":"192.168.0.1","created_at":"2019-07-23T09:37:59Z","service_id":"5RZUouxF6dQkKd6RQSla8P","id":"4BuyRhMCxnU23tnyw63zCa"}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Jul 2019 09:38:00 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19226-LCY
+      X-Timer:
+      - S1563874680.073614,VS0,VE289
+    status: 200 OK
+    code: 200

--- a/fastly/fixtures/acl_entries_batch/update/update_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/update_acl_entries.yaml
@@ -3,32 +3,36 @@ version: 1
 rwmutex: {}
 interactions:
 - request:
-    body: ""
+    body: '{"entries":[{"op":"update","id":"4Ex37PIt2oESevIFfYKdur","ip":"127.0.0.2","subnet":"16","negated":true,"comment":"Updated
+      ACL Entry 1"}]}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       Fastly-Key:
       - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
-    url: https://api.fastly.com/service/2voeSM5z6889qin6D9waPl/acl/1d7GeY6Ky6eeqSsO5c1r29/entries
-    method: GET
+    url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/acl/3Q5Oel6HFcUP0gxxSEkxlJ/entries
+    method: PATCH
   response:
-    body: '[{"service_id":"2voeSM5z6889qin6D9waPl","deleted_at":null,"negated":"0","comment":"test
-      entry","subnet":8,"created_at":"2019-07-23T10:47:07Z","ip":"10.0.0.3","updated_at":"2019-07-23T10:47:07Z","acl_id":"1d7GeY6Ky6eeqSsO5c1r29","id":"5z5nqKm0IGS8ovR512rSaT"}]'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
       - bytes
-      - bytes
-      Age:
-      - "0"
-      - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Jul 2019 10:47:07 GMT
+      - Tue, 23 Jul 2019 09:38:00 GMT
+      Fastly-Ratelimit-Remaining:
+      - "966"
+      Fastly-Ratelimit-Reset:
+      - "1563876000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,8 +47,8 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lcy19277-LCY
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lcy19226-LCY
       X-Timer:
-      - S1563878827.147987,VS0,VE220
+      - S1563874680.368134,VS0,VE218
     status: 200 OK
     code: 200

--- a/fastly/fixtures/acl_entries_batch/update/update_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/update_acl_entries.yaml
@@ -12,7 +12,7 @@ interactions:
       Content-Type:
       - application/json
       Fastly-Key:
-      - Q96iQhxXh4S08JmV1kIGddpLPtgd_Wp6
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
       - FastlyGo/1.1.0 (+github.com/fastly/go-fastly; go1.12.1)
     url: https://api.fastly.com/service/5RZUouxF6dQkKd6RQSla8P/acl/3Q5Oel6HFcUP0gxxSEkxlJ/entries
@@ -21,7 +21,6 @@ interactions:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
-      - bytes
       - bytes
       Cache-Control:
       - no-cache
@@ -40,7 +39,6 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
       - 1.1 varnish
       X-Cache:
       - MISS, MISS

--- a/fastly/fixtures/acls/cleanup.yaml
+++ b/fastly/fixtures/acls/cleanup.yaml
@@ -37,7 +37,6 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
@@ -46,52 +45,5 @@ interactions:
       - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17422-PAO
       X-Timer:
       - S1557265864.454172,VS0,VE161
-    status: 404 Not Found
-    code: 404
-- request:
-    body: ""
-    form: {}
-    headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-      User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/acl/new_test_acl
-    method: DELETE
-  response:
-    body: '{"msg":"Record not found","detail":"Couldn''t find ACL ''{ deleted =\u003e
-      0000-00-00 00:00:00, name =\u003e new_test_acl, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 6 }''"}'
-    headers:
-      Accept-Ranges:
-      - bytes
-      - bytes
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 07 May 2019 21:51:05 GMT
-      Fastly-Ratelimit-Remaining:
-      - "991"
-      Fastly-Ratelimit-Reset:
-      - "1557266400"
-      Status:
-      - 404 Not Found
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Accept-Encoding
-      Via:
-      - 1.1 varnish
-      - 1.1 varnish
-      X-Cache:
-      - MISS, MISS
-      X-Cache-Hits:
-      - 0, 0
-      X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17422-PAO
-      X-Timer:
-      - S1557265865.626073,VS0,VE423
     status: 404 Not Found
     code: 404

--- a/fastly/fixtures/acls/create.yaml
+++ b/fastly/fixtures/acls/create.yaml
@@ -43,7 +43,6 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:

--- a/fastly/fixtures/acls/delete.yaml
+++ b/fastly/fixtures/acls/delete.yaml
@@ -35,7 +35,6 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:

--- a/fastly/fixtures/acls/get.yaml
+++ b/fastly/fixtures/acls/get.yaml
@@ -33,7 +33,6 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:

--- a/fastly/fixtures/acls/list.yaml
+++ b/fastly/fixtures/acls/list.yaml
@@ -33,7 +33,6 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:

--- a/fastly/fixtures/acls/update.yaml
+++ b/fastly/fixtures/acls/update.yaml
@@ -45,7 +45,6 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:

--- a/fastly/fixtures/acls/version.yaml
+++ b/fastly/fixtures/acls/version.yaml
@@ -39,7 +39,6 @@ interactions:
       - Accept-Encoding
       Via:
       - 1.1 varnish
-      - 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:


### PR DESCRIPTION
The primary focus of this PR is to introduce batch operations, (Create, Update and delete) covering acl entries.
The acl entry function BatchModifyACLEntries executes a list of BatchACLEntry against the FASTLY API endpoint PATCH/service/service_id/acl/acl_id/entries

This implementations follows the updates to provide batch operations for dictionary items.  Functions and structs use the same convention.

The tests around the acl, acl entries and acl entries batch have been refactored to aid reading. The tests covering acl entries and the batches set up their own services for the test and the tear them down. The fixtures have been updated to reflect the current request/response accepted by the Fastly API above.