### PR TITLE
Adds maximum size constants for dictionaries and acls.

### DIFF
--- a/fastly/fastly.go
+++ b/fastly/fastly.go
@@ -16,6 +16,12 @@ const (
 	// Represents the maximum number of operations that can be sent within a single batch request.
 	// This is currently not documented in the API.
 	BatchModifyMaximumOperations = 1000
+
+	// Represents the maximum number of items that can be placed within an Edge Dictionary.
+	MaximumDictionarySize = 10000
+
+	// Represents the maximum number of entries that can be placed within an ACL.
+	MaximumACLSize = 10000
 )
 
 type statusResp struct {


### PR DESCRIPTION
Introduces two constants that represent the maximum number of items that can be placed within an Edge Dictionary and entries within an ACL.

These constants can be used by the terraform provider to validate the max number of items and entries in a configuration.