### PR TITLE
Add methods for Token CRUD API endpoints

### DIFF
--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -2,9 +2,11 @@ package fastly
 
 import (
 	"fmt"
-	"github.com/dnaeon/go-vcr/recorder"
 	"sync"
 	"testing"
+
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/dnaeon/go-vcr/recorder"
 )
 
 // testClient is the test client.
@@ -30,6 +32,12 @@ func record(t *testing.T, fixture string, f func(*Client)) {
 			t.Fatal(err)
 		}
 	}()
+
+	// Add a filter which removes Fastly-Key header from all recorded requests.
+	r.AddFilter(func(i *cassette.Interaction) error {
+		delete(i.Request.Headers, "Fastly-Key")
+		return nil
+	})
 
 	client := DefaultClient()
 	client.HTTPClient.Transport = r
@@ -61,7 +69,7 @@ func createTestService(t *testing.T, serviceFixture string, serviceNameSuffix st
 
 	record(t, serviceFixture, func(client *Client) {
 		service, err = client.CreateService(&CreateServiceInput{
-			Name: fmt.Sprintf("test_service_%s", serviceNameSuffix),
+			Name:    fmt.Sprintf("test_service_%s", serviceNameSuffix),
 			Comment: "go-fastly client test",
 		})
 	})
@@ -115,7 +123,7 @@ func createTestDictionary(t *testing.T, dictionaryFixture string, serviceId stri
 		dictionary, err = client.CreateDictionary(&CreateDictionaryInput{
 			Service: serviceId,
 			Version: version,
-			Name: fmt.Sprintf("test_dictionary_%s", dictionaryNameSuffix),
+			Name:    fmt.Sprintf("test_dictionary_%s", dictionaryNameSuffix),
 		})
 	})
 	if err != nil {
@@ -149,7 +157,7 @@ func createTestACL(t *testing.T, createFixture string, serviceId string, version
 		acl, err = client.CreateACL(&CreateACLInput{
 			Service: serviceId,
 			Version: version,
-			Name: fmt.Sprintf("test_acl_%s", aclNameSuffix),
+			Name:    fmt.Sprintf("test_acl_%s", aclNameSuffix),
 		})
 	})
 	if err != nil {
@@ -174,7 +182,7 @@ func deleteTestACL(t *testing.T, acl *ACL, deleteFixture string) {
 	}
 }
 
-func deleteTestService(t *testing.T, cleanupFixture string, serviceId string){
+func deleteTestService(t *testing.T, cleanupFixture string, serviceId string) {
 
 	var err error
 

--- a/fastly/fixtures/tokens/create.yaml
+++ b/fastly/fixtures/tokens/create.yaml
@@ -1,0 +1,111 @@
+---
+version: 1
+interactions:
+- request:
+    body: name=my-test-token&password=xxxxxxxxxxxxxxxxxxxx&scope=global&username=xxxxxxxxxxxxxxxxxxxx
+    form:
+      name:
+      - my-test-token
+      password:
+      - xxxxxxxxxxxxxxxxxxxxx
+      scope:
+      - global
+      username:
+      - xxxxxxxxxxxxxxxxxxxxx
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/1.2.1 (+github.com/fastly/go-fastly; go1.13)
+    url: https://api.fastly.com/sudo
+    method: POST
+  response:
+    body: '{"expiry_time":"2019-09-25T12:37:45+00:00"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 25 Sep 2019 12:32:45 GMT
+      Fastly-Ratelimit-Remaining:
+      - "998"
+      Fastly-Ratelimit-Reset:
+      - "1569416400"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-cdg20755-CDG
+      X-Timer:
+      - S1569414765.217878,VS0,VE714
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: name=my-test-token&password=xxxxxxxxxxxxxxxxxxxx&scope=global&username=xxxxxxxxxxxxxxxxxxxx
+    form:
+      name:
+      - my-test-token
+      password:
+      - xxxxxxxxxxxxxxxxxxxx
+      scope:
+      - global
+      username:
+      - xxxxxxxxxxxxxxxxxxxx
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/1.2.1 (+github.com/fastly/go-fastly; go1.13)
+    url: https://api.fastly.com/tokens
+    method: POST
+  response:
+    body: '{"id":"xxxxxxxxxxxxxxxxxxxx","name":"my-test-token","user_id":"xxxxxxxxxxxxxxxxxxxx","service_id":null,"expires_at":null,"created_at":"2019-09-25T12:32:46Z","updated_at":"2019-09-25T12:32:46Z","scope":"global","services":[],"access_token":"xxxxxxxxxxxxxxxxxxxx"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 25 Sep 2019 12:32:46 GMT
+      Fastly-Ratelimit-Remaining:
+      - "997"
+      Fastly-Ratelimit-Reset:
+      - "1569416400"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-cdg20755-CDG
+      X-Timer:
+      - S1569414766.001643,VS0,VE572
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/tokens/delete.yaml
+++ b/fastly/fixtures/tokens/delete.yaml
@@ -1,0 +1,43 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.2.1 (+github.com/fastly/go-fastly; go1.13)
+    url: https://api.fastly.com/tokens/xxxxxxxxxxxxxxxxxxxxx
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Date:
+      - Wed, 25 Sep 2019 12:51:58 GMT
+      Fastly-Ratelimit-Remaining:
+      - "995"
+      Fastly-Ratelimit-Reset:
+      - "1569416400"
+      Status:
+      - 204 No Content
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-cdg20759-CDG
+      X-Timer:
+      - S1569415918.693164,VS0,VE570
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/fastly/fixtures/tokens/delete_self.yaml
+++ b/fastly/fixtures/tokens/delete_self.yaml
@@ -1,0 +1,43 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.2.1 (+github.com/fastly/go-fastly; go1.13)
+    url: https://api.fastly.com/tokens/self
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Date:
+      - Wed, 25 Sep 2019 13:08:17 GMT
+      Fastly-Ratelimit-Remaining:
+      - "999"
+      Fastly-Ratelimit-Reset:
+      - "1569420000"
+      Status:
+      - 204 No Content
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-cdg20733-CDG
+      X-Timer:
+      - S1569416896.434183,VS0,VE567
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/fastly/fixtures/tokens/get_self.yaml
+++ b/fastly/fixtures/tokens/get_self.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.2.1 (+github.com/fastly/go-fastly; go1.13)
+    url: https://api.fastly.com/tokens/self
+    method: GET
+  response:
+    body: '{"id":"xxxxxxxxxxxxxxxxxxxx","user_id":"xxxxxxxxxxxxxxxxxxxx","customer_id":"xxxxxxxxxxxxxxxxxxxx","name":"go-fastly-tests","last_used_at":"2019-09-25T10:42:50Z","created_at":"2019-09-25T10:15:12Z","expires_at":null,"ip":"127.0.0.1","user_agent":"FastlyGo/1.2.1
+      (+github.com/fastly/go-fastly; go1.13)","sudo_expires_at":null,"scopes":["global"],"scope":"global","services":[],"service_id":null}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 25 Sep 2019 10:42:50 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-cdg20741-CDG
+      X-Timer:
+      - S1569408170.039160,VS0,VE468
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/tokens/list.yaml
+++ b/fastly/fixtures/tokens/list.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.2.1 (+github.com/fastly/go-fastly; go1.13)
+    url: https://api.fastly.com/tokens
+    method: GET
+  response:
+    body: '[{"id":"xxxxxxxxxxxxxxxxxxxx","user_id":"xxxxxxxxxxxxxxxxxxxx","customer_id":"xxxxxxxxxxxxxxxxxxxx","name":"go-fastly-tests","last_used_at":"2019-09-25T10:26:59Z","created_at":"2019-09-25T10:15:12Z","expires_at":null,"ip":"127.0.0.1","user_agent":"FastlyGo/1.2.1
+      (+github.com/fastly/go-fastly; go1.13)","sudo_expires_at":null,"scopes":["global"],"scope":"global","services":[],"service_id":null}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 25 Sep 2019 10:26:59 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-cdg20780-CDG
+      X-Timer:
+      - S1569407219.321177,VS0,VE481
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/tokens/list_customer.yaml
+++ b/fastly/fixtures/tokens/list_customer.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.2.1 (+github.com/fastly/go-fastly; go1.13)
+    url: https://api.fastly.com/customer/xxxxxxxxxxxxxxxxxxxx/tokens
+    method: GET
+  response:
+    body: '[{"id":"xxxxxxxxxxxxxxxxxxxx","user_id":"xxxxxxxxxxxxxxxxxxxx","customer_id":"xxxxxxxxxxxxxxxxxxxx","name":"go-fastly-tests","last_used_at":"2019-09-25T10:26:59Z","created_at":"2019-09-25T10:15:12Z","expires_at":null,"ip":"127.0.0.1","user_agent":"FastlyGo/1.2.1
+      (+github.com/fastly/go-fastly; go1.13)","sudo_expires_at":null,"scopes":["global"],"scope":"global","services":[],"service_id":null}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 25 Sep 2019 10:35:47 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-cdg20766-CDG
+      X-Timer:
+      - S1569407747.596795,VS0,VE478
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/token.go
+++ b/fastly/token.go
@@ -1,0 +1,171 @@
+package fastly
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+)
+
+// TokenScope is used to match possible authorization scopes
+type TokenScope string
+
+const (
+	// GlobalScope is the default scope covering all supported capabilities.
+	GlobalScope TokenScope = "global"
+	// PurgeSelectScope allows purging with surrogate key and URL, disallows purging with purge all.
+	PurgeSelectScope TokenScope = "purge_select"
+	// PurgeAllScope allows purging an entire service via purge_all.
+	PurgeAllScope TokenScope = "purge_all"
+	// GlobalReadScope allows read-only access to account information, configuration, and stats.
+	GlobalReadScope TokenScope = "global:read"
+)
+
+// Token represents an API token which are used to authenticate requests to the
+// Fastly API.
+type Token struct {
+	ID          string     `mapstructure:"id"`
+	Name        string     `mapstructure:"name"`
+	UserID      string     `mapstructure:"user_id"`
+	Services    []string   `mapstructure:"services"`
+	AccessToken string     `mapstructure:"access_token"`
+	Scope       TokenScope `mapstructure:"scope"`
+	IP          string     `mapstructure:"ip"`
+	CreatedAt   *time.Time `mapstructure:"created_at"`
+	LastUsedAt  *time.Time `mapstructure:"last_used_at"`
+	ExpiresAt   *time.Time `mapstructure:"expires_at"`
+}
+
+// tokensByName is a sortable list of tokens.
+type tokensByName []*Token
+
+// Len, Swap, and Less implement the sortable interface.
+func (s tokensByName) Len() int      { return len(s) }
+func (s tokensByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s tokensByName) Less(i, j int) bool {
+	return s[i].Name < s[j].Name
+}
+
+// ListTokens returns the full list of tokens belonging to the currently
+// authenticated user.
+func (c *Client) ListTokens() ([]*Token, error) {
+	resp, err := c.Get("/tokens", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var t []*Token
+	if err := decodeJSON(&t, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(tokensByName(t))
+	return t, nil
+}
+
+// ListCustomerTokensInput is used as input to the ListCustomerTokens function.
+type ListCustomerTokensInput struct {
+	ID string
+}
+
+// ListCustomerTokens returns the full list of tokens belonging to a specfic
+// customer.
+func (c *Client) ListCustomerTokens(i *ListCustomerTokensInput) ([]*Token, error) {
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
+
+	path := fmt.Sprintf("/customer/%s/tokens", i.ID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var t []*Token
+	if err := decodeJSON(&t, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(tokensByName(t))
+	return t, nil
+}
+
+// GetTokenSelf retrieves the token information for the the access_token used
+// used to authenticate the request. Returns a 401 if the token has expired
+// and a 403 for invalid access token.
+func (c *Client) GetTokenSelf() (*Token, error) {
+	resp, err := c.Get("/tokens/self", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var t *Token
+	if err := decodeJSON(&t, resp.Body); err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+// CreateTokenInput is used as input to the Token function.
+type CreateTokenInput struct {
+	Name      string     `form:"name,omitempty"`
+	Scope     TokenScope `form:"scope,omitempty"`
+	Username  string     `form:"username,omitempty"`
+	Password  string     `form:"password,omitempty"`
+	Services  []string   `form:"services,omitempty"`
+	ExpiresAt *time.Time `form:"expires_at,omitempty"`
+}
+
+// CreateToken creates a new API token with the given information.
+func (c *Client) CreateToken(i *CreateTokenInput) (*Token, error) {
+	_, err := c.PostForm("/sudo", i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.PostForm("/tokens", i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var t *Token
+	if err := decodeJSON(&t, resp.Body); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// DeleteTokenInput is used as input to the DeleteToken function.
+type DeleteTokenInput struct {
+	ID string
+}
+
+// DeleteToken revokes a specific token by its ID.
+func (c *Client) DeleteToken(i *DeleteTokenInput) error {
+	if i.ID == "" {
+		return ErrMissingID
+	}
+
+	path := fmt.Sprintf("/tokens/%s", i.ID)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
+}
+
+// DeleteTokenSelf revokes the token used to authorise the request.
+func (c *Client) DeleteTokenSelf() error {
+	resp, err := c.Delete("/tokens/self", nil)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("Not Ok")
+	}
+	return nil
+}

--- a/fastly/token_test.go
+++ b/fastly/token_test.go
@@ -1,0 +1,107 @@
+package fastly
+
+import "testing"
+
+func TestClient_ListTokens(t *testing.T) {
+	t.Parallel()
+
+	var tokens []*Token
+	var err error
+	record(t, "tokens/list", func(c *Client) {
+		tokens, err = c.ListTokens()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tokens) < 1 {
+		t.Errorf("bad tokens: %v", tokens)
+	}
+}
+
+func TestClient_ListCustomerTokens(t *testing.T) {
+	t.Parallel()
+
+	var tokens []*Token
+	var err error
+	record(t, "tokens/list_customer", func(c *Client) {
+		tokens, err = c.ListCustomerTokens(&ListCustomerTokensInput{
+			ID: "xxxxxxxxxxxxxxxxxxxx",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tokens) < 1 {
+		t.Errorf("bad tokens: %v", tokens)
+	}
+}
+
+func TestClient_GetTokenSelf(t *testing.T) {
+	t.Parallel()
+
+	var token *Token
+	var err error
+	record(t, "tokens/get_self", func(c *Client) {
+		token, err = c.GetTokenSelf()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%+v", token)
+}
+
+func TestClient_CreateToken(t *testing.T) {
+	t.Parallel()
+
+	input := &CreateTokenInput{
+		Name:     "my-test-token",
+		Scope:    "global",
+		Username: "xxxxxxxxxxxxxxxxxxxx",
+		Password: "xxxxxxxxxxxxxxxxxxxx",
+	}
+
+	var token *Token
+	var err error
+	record(t, "tokens/create", func(c *Client) {
+		token, err = c.CreateToken(input)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if token.Name != input.Name {
+		t.Errorf("returned invalid name, got %s, want %s", token.Name, input.Name)
+	}
+
+	if token.Scope != input.Scope {
+		t.Errorf("returned invalid scope, got %s, want %s", token.Scope, input.Scope)
+	}
+}
+
+func TestClient_DeleteToken(t *testing.T) {
+	t.Parallel()
+
+	input := &DeleteTokenInput{
+		ID: "xxxxxxxxxxxxxxxxxxxxx",
+	}
+
+	var err error
+	record(t, "tokens/delete", func(c *Client) {
+		err = c.DeleteToken(input)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClient_DeleteTokenSelf(t *testing.T) {
+	t.Parallel()
+
+	var err error
+	record(t, "tokens/delete_self", func(c *Client) {
+		err = c.DeleteTokenSelf()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/fastly/go-fastly
 
 require (
 	github.com/ajg/form v0.0.0-20160802194845-cc2954064ec9
-	github.com/dnaeon/go-vcr v0.0.0-20170218072653-87d4990451a8
+	github.com/dnaeon/go-vcr v1.0.1
 	github.com/google/jsonapi v0.0.0-20170708005851-46d3ced04344
 	github.com/hashicorp/go-cleanhttp v0.0.0-20170211013415-3573b8b52aa7
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ajg/form v0.0.0-20160802194845-cc2954064ec9 h1:fJ4XPqxuZfm11zauw9XX7c30P8xwDyucdWu8H6Htrxs=
 github.com/ajg/form v0.0.0-20160802194845-cc2954064ec9/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
-github.com/dnaeon/go-vcr v0.0.0-20170218072653-87d4990451a8 h1:9W38WyoOkLTitPbj0ltn6yE4PrZ2WJrxUh06pwdKjCQ=
-github.com/dnaeon/go-vcr v0.0.0-20170218072653-87d4990451a8/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
+github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/google/jsonapi v0.0.0-20170708005851-46d3ced04344 h1:G5TmuUtIYeR0scfa8ZQ06cfHeAAfVeFlIG8TVOCfuAA=
 github.com/google/jsonapi v0.0.0-20170708005851-46d3ced04344/go.mod h1:XSx4m2SziAqk9DXY9nz659easTq4q6TyrpYd9tHSm0g=
 github.com/hashicorp/go-cleanhttp v0.0.0-20170211013415-3573b8b52aa7 h1:67fHcS+inUoiIqWCKIqeDuq2AlPHNHPiTqp97LdQ+bc=

--- a/vendor/github.com/dnaeon/go-vcr/recorder/go17_nobody.go
+++ b/vendor/github.com/dnaeon/go-vcr/recorder/go17_nobody.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2015-2016 Marin Atanasov Nikolov <dnaeon@gmail.com>
+// Copyright (c) 2016 David Jack <davars@gmail.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer
+//    in this position and unchanged.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// +build !go1.8
+
+package recorder
+
+import (
+	"io"
+)
+
+// isNoBody returns true iff r is an http.NoBody.
+// http.NoBody didn't exist before Go 1.7, so the version in this file
+// always returns false.
+func isNoBody(r io.ReadCloser) bool { return false }

--- a/vendor/github.com/dnaeon/go-vcr/recorder/go18_nobody.go
+++ b/vendor/github.com/dnaeon/go-vcr/recorder/go18_nobody.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2015-2016 Marin Atanasov Nikolov <dnaeon@gmail.com>
+// Copyright (c) 2016 David Jack <davars@gmail.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer
+//    in this position and unchanged.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// +build go1.8
+
+package recorder
+
+import (
+	"io"
+	"net/http"
+)
+
+// isNoBody returns true iff r is an http.NoBody.
+func isNoBody(r io.ReadCloser) bool { return r == http.NoBody  }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,8 @@
 # github.com/ajg/form v0.0.0-20160802194845-cc2954064ec9
 github.com/ajg/form
-# github.com/dnaeon/go-vcr v0.0.0-20170218072653-87d4990451a8
-github.com/dnaeon/go-vcr/recorder
+# github.com/dnaeon/go-vcr v1.0.1
 github.com/dnaeon/go-vcr/cassette
+github.com/dnaeon/go-vcr/recorder
 # github.com/google/jsonapi v0.0.0-20170708005851-46d3ced04344
 github.com/google/jsonapi
 # github.com/hashicorp/go-cleanhttp v0.0.0-20170211013415-3573b8b52aa7


### PR DESCRIPTION
### TL;DR
Adds methods to expose API Token management (list, get, create, delete) endpoints: https://docs.fastly.com/api/auth#tokens.

### Notes:
- Upgrades the [go-vcr](https://github.com/dnaeon/go-vcr) dependency to take advantage of the [`AddFilter`](https://github.com/dnaeon/go-vcr#protecting-sensitive-data) method on the recorder instance to automatically strip API keys from requests. 
- Cleaned token credentials form all test recordings
- Didn't implement the batch endpoint