### PR TITLE
Add missing type hash to snippets

### DIFF
--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -14,6 +14,9 @@ const (
 	// SnippetTypeRecv sets the type to recv
 	SnippetTypeRecv SnippetType = "recv"
 
+	// SnippetTypeHash sets the type to hash
+	SnippetTypeHash SnippetType = "hash"
+
 	// SnippetTypeHit sets the type to hit
 	SnippetTypeHit SnippetType = "hit"
 


### PR DESCRIPTION
This PR adds the missing `hash` type to VCL snippets. The VCL snippet API can be found [here](https://docs.fastly.com/api/config#api-section-snippet) for reference.