### PR TITLE
Add fastly waf related fields

### DIFF
--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -387,9 +387,11 @@ func (c *Client) UpdateOWASP(i *UpdateOWASPInput) (*OWASP, error) {
 // Rule is the information about a WAF rule.
 type Rule struct {
 	ID       string `jsonapi:"primary,rule"`
+	Message  string `jsonapi:"attr,message,omitempty"`
 	RuleID   string `jsonapi:"attr,rule_id,omitempty"`
 	Severity int    `jsonapi:"attr,severity,omitempty"`
-	Message  string `jsonapi:"attr,message,omitempty"`
+	Source   string `jsonapi:"attr,source,omitempty"`
+	VCL      string `jsonapi:"attr,vcl,omitempty"`
 }
 
 // rulesType is used for reflection because JSONAPI wants to know what it's

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -27,6 +27,7 @@ type WAF struct {
 	PrefetchCondition string     `jsonapi:"attr,prefetch_condition"`
 	Response          string     `jsonapi:"attr,response"`
 	LastPush          *time.Time `jsonapi:"attr,last_push,iso8601"`
+	Disabled          bool       `jsonapi:"attr,disabled"`
 
 	ConfigurationSet *WAFConfigurationSet `jsonapi:"relation,configuration_set"`
 }


### PR DESCRIPTION
## What

* Add ...
    * `vcl` field in `RuleStatus` struct 
    * `disabled` in `WAF` struct
* Change ...
    * Reorder `RuleStatus` structs field to follow document order


## Why

* Since this is missing compared to [WEB API Doc](https://docs.fastly.com/api/waf)