### PR TITLE
Add Support for ServerSideEncryption including using KMS key Id

### DIFF
--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -117,9 +117,9 @@ var ErrMissingWAFList = errors.New("WAF slice is empty")
 // The Fastly API specifies an maximum limit.
 var ErrBatchUpdateMaximumOperationsExceeded = errors.New("batch modify maximum operations exceeded")
 
-// ErrMissingKmsKeyId is an error that is returned from an input struct that requires
-// a "ServerSideEncryptionKmsKeyId" key, but one was not set.
-var ErrMissingKmsKeyId = errors.New("Missing required field 'ServerSideEncryptionKmsKeyId'")
+// ErrMissingKMSKeyID is an error that is returned from an input struct that requires
+// a "ServerSideEncryptionKMSKeyID" key, but one was not set.
+var ErrMissingKMSKeyID = errors.New("Missing required field 'ServerSideEncryptionKMSKeyID'")
 
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -117,6 +117,10 @@ var ErrMissingWAFList = errors.New("WAF slice is empty")
 // The Fastly API specifies an maximum limit.
 var ErrBatchUpdateMaximumOperationsExceeded = errors.New("batch modify maximum operations exceeded")
 
+// ErrMissingKmsKeyId is an error that is returned from an input struct that requires
+// a "ServerSideEncryptionKmsKeyId" key, but one was not set.
+var ErrMissingKmsKeyId = errors.New("Missing required field 'ServerSideEncryptionKmsKeyId'")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 

--- a/fastly/fixtures/s3s/cleanup.yaml
+++ b/fastly/fixtures/s3s/cleanup.yaml
@@ -1,34 +1,32 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/41/logging/s3/test-s3
+      - FastlyGo/1.4.0 (+github.com/fastly/go-fastly; go1.12.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/s3/test-s3
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e test-s3, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 41 }''"}'
+      version =\u003e 6 }''"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:30:59 GMT
+      - Tue, 11 Feb 2020 22:23:42 GMT
       Fastly-Ratelimit-Remaining:
-      - "989"
+      - "993"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1581462000"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -43,38 +41,38 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sjc3633-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sea4454-SEA
       X-Timer:
-      - S1557441060.555473,VS0,VE172
+      - S1581459822.291131,VS0,VE209
     status: 404 Not Found
     code: 404
+    duration: ""
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/41/logging/s3/new-test-s3
+      - FastlyGo/1.4.0 (+github.com/fastly/go-fastly; go1.12.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/s3/new-test-s3
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e new-test-s3, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 41 }''"}'
+      version =\u003e 6 }''"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:30:59 GMT
+      - Tue, 11 Feb 2020 22:23:42 GMT
       Fastly-Ratelimit-Remaining:
-      - "988"
+      - "992"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1581462000"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -89,8 +87,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sjc3633-SJC
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4454-SEA
       X-Timer:
-      - S1557441060.738397,VS0,VE171
+      - S1581459823.524575,VS0,VE214
     status: 404 Not Found
     code: 404
+    duration: ""

--- a/fastly/fixtures/s3s/create.yaml
+++ b/fastly/fixtures/s3s/create.yaml
@@ -47,7 +47,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/41/logging/s3
     method: POST
   response:
-    body: '{"access_key":"AKIAIOSFODNN7EXAMPLE","bucket_name":"bucket-name","domain":"s3.us-east-1.amazonaws.com","format":"format","format_version":"2","gzip_level":9,"message_type":"classic","name":"test-s3","path":"/path","period":12,"placement":"waf_debug","redundancy":"reduced_redundancy","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","timestamp_format":"%Y","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"41","server_side_encryption":null,"server_side_encryption_kms_key_id":null,"response_condition":"","updated_at":"2019-05-09T22:30:57Z","acl":null,"deleted_at":null,"public_key":null,"created_at":"2019-05-09T22:30:57Z"}'
+    body: '{"access_key":"AKIAIOSFODNN7EXAMPLE","bucket_name":"bucket-name","domain":"s3.us-east-1.amazonaws.com","format":"format","format_version":"2","gzip_level":9,"message_type":"classic","name":"test-s3","path":"/path","period":12,"placement":"waf_debug","redundancy":"reduced_redundancy","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","timestamp_format":"%Y","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"41","server_side_encryption":"aws:kms","server_side_encryption_kms_key_id":"1234","response_condition":"","updated_at":"2019-05-09T22:30:57Z","acl":null,"deleted_at":null,"public_key":null,"created_at":"2019-05-09T22:30:57Z"}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/fixtures/s3s/create.yaml
+++ b/fastly/fixtures/s3s/create.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=41&access_key=AKIAIOSFODNN7EXAMPLE&bucket_name=bucket-name&domain=s3.us-east-1.amazonaws.com&format=format&format_version=2&gzip_level=9&message_type=classic&name=test-s3&path=%2Fpath&period=12&placement=waf_debug&redundancy=reduced_redundancy&secret_key=wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY&timestamp_format=%25Y
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=6&access_key=AKIAIOSFODNN7EXAMPLE&bucket_name=bucket-name&domain=s3.us-east-1.amazonaws.com&format=format&format_version=2&gzip_level=9&message_type=classic&name=test-s3&path=%2Fpath&period=12&placement=waf_debug&redundancy=reduced_redundancy&secret_key=wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY&server_side_encryption=aws%3Akms&server_side_encryption_kms_key_id=1234&timestamp_format=%25Y
     form:
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "41"
+      - "6"
       access_key:
       - AKIAIOSFODNN7EXAMPLE
       bucket_name:
@@ -35,32 +34,35 @@ interactions:
       - reduced_redundancy
       secret_key:
       - wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+      server_side_encryption:
+      - aws:kms
+      server_side_encryption_kms_key_id:
+      - "1234"
       timestamp_format:
       - '%Y'
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/41/logging/s3
+      - FastlyGo/1.4.0 (+github.com/fastly/go-fastly; go1.12.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/s3
     method: POST
   response:
-    body: '{"access_key":"AKIAIOSFODNN7EXAMPLE","bucket_name":"bucket-name","domain":"s3.us-east-1.amazonaws.com","format":"format","format_version":"2","gzip_level":9,"message_type":"classic","name":"test-s3","path":"/path","period":12,"placement":"waf_debug","redundancy":"reduced_redundancy","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","timestamp_format":"%Y","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"41","server_side_encryption":"aws:kms","server_side_encryption_kms_key_id":"1234","response_condition":"","updated_at":"2019-05-09T22:30:57Z","acl":null,"deleted_at":null,"public_key":null,"created_at":"2019-05-09T22:30:57Z"}'
+    body: '{"access_key":"AKIAIOSFODNN7EXAMPLE","bucket_name":"bucket-name","domain":"s3.us-east-1.amazonaws.com","format":"format","format_version":"2","gzip_level":"9","message_type":"classic","name":"test-s3","path":"/path","period":"12","placement":"waf_debug","redundancy":"reduced_redundancy","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","server_side_encryption":"aws:kms","server_side_encryption_kms_key_id":"1234","timestamp_format":"%Y","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"6","acl":null,"response_condition":"","deleted_at":null,"public_key":null,"created_at":"2020-02-11T22:23:40Z","updated_at":"2020-02-11T22:23:40Z"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:30:57 GMT
+      - Tue, 11 Feb 2020 22:23:40 GMT
       Fastly-Ratelimit-Remaining:
-      - "992"
+      - "996"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1581462000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -75,8 +77,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sjc3633-SJC
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sea4454-SEA
       X-Timer:
-      - S1557441057.790510,VS0,VE782
+      - S1581459820.129654,VS0,VE522
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/s3s/delete.yaml
+++ b/fastly/fixtures/s3s/delete.yaml
@@ -1,32 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/41/logging/s3/new-test-s3
+      - FastlyGo/1.4.0 (+github.com/fastly/go-fastly; go1.12.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/s3/new-test-s3
     method: DELETE
   response:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:30:59 GMT
+      - Tue, 11 Feb 2020 22:23:42 GMT
       Fastly-Ratelimit-Remaining:
-      - "990"
+      - "994"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1581462000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sjc3633-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sea4454-SEA
       X-Timer:
-      - S1557441059.176597,VS0,VE358
+      - S1581459822.911958,VS0,VE354
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/s3s/get.yaml
+++ b/fastly/fixtures/s3s/get.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/41/logging/s3/test-s3
     method: GET
   response:
-    body: '{"acl":null,"format":"format","path":"/path","access_key":"AKIAIOSFODNN7EXAMPLE","redundancy":"reduced_redundancy","message_type":"classic","placement":"waf_debug","updated_at":"2019-05-09T22:30:57Z","response_condition":"","version":"41","period":"12","domain":"s3.us-east-1.amazonaws.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","timestamp_format":"%Y","server_side_encryption":null,"deleted_at":null,"bucket_name":"bucket-name","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","server_side_encryption_kms_key_id":null,"name":"test-s3","created_at":"2019-05-09T22:30:57Z","public_key":null,"gzip_level":"9","format_version":"2"}'
+    body: '{"acl":null,"format":"format","path":"/path","access_key":"AKIAIOSFODNN7EXAMPLE","redundancy":"reduced_redundancy","message_type":"classic","placement":"waf_debug","updated_at":"2019-05-09T22:30:57Z","response_condition":"","version":"41","period":"12","domain":"s3.us-east-1.amazonaws.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","timestamp_format":"%Y","server_side_encryption":"aws:kms","deleted_at":null,"bucket_name":"bucket-name","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","server_side_encryption_kms_key_id":"1234","name":"test-s3","created_at":"2019-05-09T22:30:57Z","public_key":null,"gzip_level":"9","format_version":"2"}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/fixtures/s3s/get.yaml
+++ b/fastly/fixtures/s3s/get.yaml
@@ -1,30 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/41/logging/s3/test-s3
+      - FastlyGo/1.4.0 (+github.com/fastly/go-fastly; go1.12.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/s3/test-s3
     method: GET
   response:
-    body: '{"acl":null,"format":"format","path":"/path","access_key":"AKIAIOSFODNN7EXAMPLE","redundancy":"reduced_redundancy","message_type":"classic","placement":"waf_debug","updated_at":"2019-05-09T22:30:57Z","response_condition":"","version":"41","period":"12","domain":"s3.us-east-1.amazonaws.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","timestamp_format":"%Y","server_side_encryption":"aws:kms","deleted_at":null,"bucket_name":"bucket-name","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","server_side_encryption_kms_key_id":"1234","name":"test-s3","created_at":"2019-05-09T22:30:57Z","public_key":null,"gzip_level":"9","format_version":"2"}'
+    body: '{"period":"12","path":"/path","placement":"waf_debug","gzip_level":"9","acl":null,"response_condition":"","format_version":"2","server_side_encryption_kms_key_id":"1234","redundancy":"reduced_redundancy","deleted_at":null,"bucket_name":"bucket-name","domain":"s3.us-east-1.amazonaws.com","format":"format","timestamp_format":"%Y","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","public_key":null,"access_key":"AKIAIOSFODNN7EXAMPLE","created_at":"2020-02-11T22:23:40Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2020-02-11T22:23:40Z","version":"6","message_type":"classic","name":"test-s3","server_side_encryption":"aws:kms"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
+      - bytes
       Age:
+      - "0"
       - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:30:58 GMT
+      - Tue, 11 Feb 2020 22:23:41 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,8 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3633-SJC
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4454-SEA
       X-Timer:
-      - S1557441058.120930,VS0,VE184
+      - S1581459821.929978,VS0,VE197
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/s3s/list.yaml
+++ b/fastly/fixtures/s3s/list.yaml
@@ -1,30 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/41/logging/s3
+      - FastlyGo/1.4.0 (+github.com/fastly/go-fastly; go1.12.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/s3
     method: GET
   response:
-    body: '[{"version":"41","message_type":"classic","updated_at":"2019-05-09T22:30:57Z","deleted_at":null,"placement":"waf_debug","domain":"s3.us-east-1.amazonaws.com","response_condition":"","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","name":"test-s3","created_at":"2019-05-09T22:30:57Z","redundancy":"reduced_redundancy","path":"/path","bucket_name":"bucket-name","server_side_encryption":null,"access_key":"AKIAIOSFODNN7EXAMPLE","period":"12","format":"format","server_side_encryption_kms_key_id":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","gzip_level":"9","public_key":null,"acl":null,"timestamp_format":"%Y"}]'
+    body: '[{"deleted_at":null,"redundancy":"reduced_redundancy","server_side_encryption_kms_key_id":"1234","domain":"s3.us-east-1.amazonaws.com","bucket_name":"bucket-name","gzip_level":"9","acl":null,"period":"12","path":"/path","placement":"waf_debug","response_condition":"","format_version":"2","created_at":"2020-02-11T22:23:40Z","access_key":"AKIAIOSFODNN7EXAMPLE","message_type":"classic","server_side_encryption":"aws:kms","name":"test-s3","service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2020-02-11T22:23:40Z","version":"6","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","format":"format","timestamp_format":"%Y","public_key":null}]'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
+      - bytes
       Age:
+      - "0"
       - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:30:58 GMT
+      - Tue, 11 Feb 2020 22:23:40 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,8 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sjc3633-SJC
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sea4454-SEA
       X-Timer:
-      - S1557441058.608713,VS0,VE410
+      - S1581459821.695167,VS0,VE193
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/s3s/update.yaml
+++ b/fastly/fixtures/s3s/update.yaml
@@ -1,42 +1,40 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Name=test-s3&Service=7i6HN3TK9wS159v2gPAZ8A&Version=41&name=new-test-s3
+    body: Name=test-s3&Service=7i6HN3TK9wS159v2gPAZ8A&Version=6&name=new-test-s3
     form:
       Name:
       - test-s3
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "41"
+      - "6"
       name:
       - new-test-s3
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/41/logging/s3/test-s3
+      - FastlyGo/1.4.0 (+github.com/fastly/go-fastly; go1.12.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/s3/test-s3
     method: PUT
   response:
-    body: '{"placement":"waf_debug","response_condition":"","server_side_encryption_kms_key_id":null,"format_version":"2","server_side_encryption":null,"path":"/path","redundancy":"reduced_redundancy","updated_at":"2019-05-09T22:30:57Z","message_type":"classic","gzip_level":"9","bucket_name":"bucket-name","domain":"s3.us-east-1.amazonaws.com","deleted_at":null,"period":"12","acl":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","name":"new-test-s3","version":"41","access_key":"AKIAIOSFODNN7EXAMPLE","timestamp_format":"%Y","format":"format","public_key":null,"created_at":"2019-05-09T22:30:57Z"}'
+    body: '{"format":"format","access_key":"AKIAIOSFODNN7EXAMPLE","redundancy":"reduced_redundancy","deleted_at":null,"updated_at":"2020-02-11T22:23:40Z","name":"new-test-s3","service_id":"7i6HN3TK9wS159v2gPAZ8A","period":"12","acl":null,"path":"/path","server_side_encryption_kms_key_id":"1234","format_version":"2","secret_key":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","placement":"waf_debug","gzip_level":"9","message_type":"classic","public_key":null,"response_condition":"","version":"6","domain":"s3.us-east-1.amazonaws.com","timestamp_format":"%Y","created_at":"2020-02-11T22:23:40Z","server_side_encryption":"aws:kms","bucket_name":"bucket-name"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:30:59 GMT
+      - Tue, 11 Feb 2020 22:23:41 GMT
       Fastly-Ratelimit-Remaining:
-      - "991"
+      - "995"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1581462000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -51,8 +49,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sjc3633-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sea4454-SEA
       X-Timer:
-      - S1557441058.310724,VS0,VE859
+      - S1581459821.236102,VS0,VE650
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/s3s/version.yaml
+++ b/fastly/fixtures/s3s/version.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: Service=7i6HN3TK9wS159v2gPAZ8A
@@ -10,27 +9,26 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
+      - FastlyGo/1.4.0 (+github.com/fastly/go-fastly; go1.12.5)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":41}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":6}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:30:56 GMT
+      - Tue, 11 Feb 2020 22:23:40 GMT
       Fastly-Ratelimit-Remaining:
-      - "993"
+      - "997"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1581462000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,8 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3633-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sea4454-SEA
       X-Timer:
-      - S1557441056.265073,VS0,VE449
+      - S1581459820.815294,VS0,VE287
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/s3.go
+++ b/fastly/s3.go
@@ -8,10 +8,13 @@ import (
 )
 
 type S3Redundancy string
+type S3ServerSideEncryption string
 
 const (
-	S3RedundancyStandard S3Redundancy = "standard"
-	S3RedundancyReduced  S3Redundancy = "reduced_redundancy"
+	S3RedundancyStandard      S3Redundancy           = "standard"
+	S3RedundancyReduced       S3Redundancy           = "reduced_redundancy"
+	S3ServerSideEncryptionAES S3ServerSideEncryption = "AES256"
+	S3ServerSideEncryptionKMS S3ServerSideEncryption = "aws:kms"
 )
 
 // S3 represents a S3 response from the Fastly API.
@@ -19,24 +22,26 @@ type S3 struct {
 	ServiceID string `mapstructure:"service_id"`
 	Version   int    `mapstructure:"version"`
 
-	Name              string       `mapstructure:"name"`
-	BucketName        string       `mapstructure:"bucket_name"`
-	Domain            string       `mapstructure:"domain"`
-	AccessKey         string       `mapstructure:"access_key"`
-	SecretKey         string       `mapstructure:"secret_key"`
-	Path              string       `mapstructure:"path"`
-	Period            uint         `mapstructure:"period"`
-	GzipLevel         uint         `mapstructure:"gzip_level"`
-	Format            string       `mapstructure:"format"`
-	FormatVersion     uint         `mapstructure:"format_version"`
-	ResponseCondition string       `mapstructure:"response_condition"`
-	MessageType       string       `mapstructure:"message_type"`
-	TimestampFormat   string       `mapstructure:"timestamp_format"`
-	Placement         string       `mapstructure:"placement"`
-	Redundancy        S3Redundancy `mapstructure:"redundancy"`
-	CreatedAt         *time.Time   `mapstructure:"created_at"`
-	UpdatedAt         *time.Time   `mapstructure:"updated_at"`
-	DeletedAt         *time.Time   `mapstructure:"deleted_at"`
+	Name                         string                 `mapstructure:"name"`
+	BucketName                   string                 `mapstructure:"bucket_name"`
+	Domain                       string                 `mapstructure:"domain"`
+	AccessKey                    string                 `mapstructure:"access_key"`
+	SecretKey                    string                 `mapstructure:"secret_key"`
+	Path                         string                 `mapstructure:"path"`
+	Period                       uint                   `mapstructure:"period"`
+	GzipLevel                    uint                   `mapstructure:"gzip_level"`
+	Format                       string                 `mapstructure:"format"`
+	FormatVersion                uint                   `mapstructure:"format_version"`
+	ResponseCondition            string                 `mapstructure:"response_condition"`
+	MessageType                  string                 `mapstructure:"message_type"`
+	TimestampFormat              string                 `mapstructure:"timestamp_format"`
+	Placement                    string                 `mapstructure:"placement"`
+	Redundancy                   S3Redundancy           `mapstructure:"redundancy"`
+	CreatedAt                    *time.Time             `mapstructure:"created_at"`
+	UpdatedAt                    *time.Time             `mapstructure:"updated_at"`
+	DeletedAt                    *time.Time             `mapstructure:"deleted_at"`
+	ServerSideEncryptionKmsKeyId string                 `mapstructure:"server_side_encryption_kms_key_id"`
+	ServerSideEncryption         S3ServerSideEncryption `mapstructure:"server_side_encryption"`
 }
 
 // s3sByName is a sortable list of S3s.
@@ -89,21 +94,23 @@ type CreateS3Input struct {
 	Service string
 	Version int
 
-	Name              string       `form:"name,omitempty"`
-	BucketName        string       `form:"bucket_name,omitempty"`
-	Domain            string       `form:"domain,omitempty"`
-	AccessKey         string       `form:"access_key,omitempty"`
-	SecretKey         string       `form:"secret_key,omitempty"`
-	Path              string       `form:"path,omitempty"`
-	Period            uint         `form:"period,omitempty"`
-	GzipLevel         uint         `form:"gzip_level,omitempty"`
-	Format            string       `form:"format,omitempty"`
-	MessageType       string       `form:"message_type,omitempty"`
-	FormatVersion     uint         `form:"format_version,omitempty"`
-	ResponseCondition string       `form:"response_condition,omitempty"`
-	TimestampFormat   string       `form:"timestamp_format,omitempty"`
-	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
-	Placement         string       `form:"placement,omitempty"`
+	Name                         string                 `form:"name,omitempty"`
+	BucketName                   string                 `form:"bucket_name,omitempty"`
+	Domain                       string                 `form:"domain,omitempty"`
+	AccessKey                    string                 `form:"access_key,omitempty"`
+	SecretKey                    string                 `form:"secret_key,omitempty"`
+	Path                         string                 `form:"path,omitempty"`
+	Period                       uint                   `form:"period,omitempty"`
+	GzipLevel                    uint                   `form:"gzip_level,omitempty"`
+	Format                       string                 `form:"format,omitempty"`
+	MessageType                  string                 `form:"message_type,omitempty"`
+	FormatVersion                uint                   `form:"format_version,omitempty"`
+	ResponseCondition            string                 `form:"response_condition,omitempty"`
+	TimestampFormat              string                 `form:"timestamp_format,omitempty"`
+	Redundancy                   S3Redundancy           `form:"redundancy,omitempty"`
+	Placement                    string                 `form:"placement,omitempty"`
+	ServerSideEncryptionKmsKeyId string                 `form:"server_side_encryption_kms_key_id,omitempty"`
+	ServerSideEncryption         S3ServerSideEncryption `form:"server_side_encryption,omitempty"`
 }
 
 // CreateS3 creates a new Fastly S3.
@@ -114,6 +121,10 @@ func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
 
 	if i.Version == 0 {
 		return nil, ErrMissingVersion
+	}
+
+	if i.ServerSideEncryption == S3ServerSideEncryptionKMS && i.ServerSideEncryptionKmsKeyId == "" {
+		return nil, ErrMissingKmsKeyId
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/s3", i.Service, i.Version)
@@ -177,21 +188,23 @@ type UpdateS3Input struct {
 	// Name is the name of the S3 to update.
 	Name string
 
-	NewName           string       `form:"name,omitempty"`
-	BucketName        string       `form:"bucket_name,omitempty"`
-	Domain            string       `form:"domain,omitempty"`
-	AccessKey         string       `form:"access_key,omitempty"`
-	SecretKey         string       `form:"secret_key,omitempty"`
-	Path              string       `form:"path,omitempty"`
-	Period            uint         `form:"period,omitempty"`
-	GzipLevel         uint         `form:"gzip_level,omitempty"`
-	Format            string       `form:"format,omitempty"`
-	FormatVersion     uint         `form:"format_version,omitempty"`
-	ResponseCondition string       `form:"response_condition,omitempty"`
-	MessageType       string       `form:"message_type,omitempty"`
-	TimestampFormat   string       `form:"timestamp_format,omitempty"`
-	Redundancy        S3Redundancy `form:"redundancy,omitempty"`
-	Placement         string       `form:"placement,omitempty"`
+	NewName                      string                 `form:"name,omitempty"`
+	BucketName                   string                 `form:"bucket_name,omitempty"`
+	Domain                       string                 `form:"domain,omitempty"`
+	AccessKey                    string                 `form:"access_key,omitempty"`
+	SecretKey                    string                 `form:"secret_key,omitempty"`
+	Path                         string                 `form:"path,omitempty"`
+	Period                       uint                   `form:"period,omitempty"`
+	GzipLevel                    uint                   `form:"gzip_level,omitempty"`
+	Format                       string                 `form:"format,omitempty"`
+	FormatVersion                uint                   `form:"format_version,omitempty"`
+	ResponseCondition            string                 `form:"response_condition,omitempty"`
+	MessageType                  string                 `form:"message_type,omitempty"`
+	TimestampFormat              string                 `form:"timestamp_format,omitempty"`
+	Redundancy                   S3Redundancy           `form:"redundancy,omitempty"`
+	Placement                    string                 `form:"placement,omitempty"`
+	ServerSideEncryptionKmsKeyId string                 `form:"server_side_encryption_kms_key_id,omitempty"`
+	ServerSideEncryption         S3ServerSideEncryption `form:"server_side_encryption,omitempty"`
 }
 
 // UpdateS3 updates a specific S3.
@@ -206,6 +219,10 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 
 	if i.Name == "" {
 		return nil, ErrMissingName
+	}
+
+	if i.ServerSideEncryption == S3ServerSideEncryptionKMS && i.ServerSideEncryptionKmsKeyId == "" {
+		return nil, ErrMissingKmsKeyId
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.Service, i.Version, url.PathEscape(i.Name))

--- a/fastly/s3.go
+++ b/fastly/s3.go
@@ -37,11 +37,11 @@ type S3 struct {
 	TimestampFormat              string                 `mapstructure:"timestamp_format"`
 	Placement                    string                 `mapstructure:"placement"`
 	Redundancy                   S3Redundancy           `mapstructure:"redundancy"`
+	ServerSideEncryptionKMSKeyID string                 `mapstructure:"server_side_encryption_kms_key_id"`
+	ServerSideEncryption         S3ServerSideEncryption `mapstructure:"server_side_encryption"`
 	CreatedAt                    *time.Time             `mapstructure:"created_at"`
 	UpdatedAt                    *time.Time             `mapstructure:"updated_at"`
 	DeletedAt                    *time.Time             `mapstructure:"deleted_at"`
-	ServerSideEncryptionKMSKeyID string                 `mapstructure:"server_side_encryption_kms_key_id"`
-	ServerSideEncryption         S3ServerSideEncryption `mapstructure:"server_side_encryption"`
 }
 
 // s3sByName is a sortable list of S3s.

--- a/fastly/s3.go
+++ b/fastly/s3.go
@@ -40,7 +40,7 @@ type S3 struct {
 	CreatedAt                    *time.Time             `mapstructure:"created_at"`
 	UpdatedAt                    *time.Time             `mapstructure:"updated_at"`
 	DeletedAt                    *time.Time             `mapstructure:"deleted_at"`
-	ServerSideEncryptionKmsKeyId string                 `mapstructure:"server_side_encryption_kms_key_id"`
+	ServerSideEncryptionKMSKeyID string                 `mapstructure:"server_side_encryption_kms_key_id"`
 	ServerSideEncryption         S3ServerSideEncryption `mapstructure:"server_side_encryption"`
 }
 
@@ -109,7 +109,7 @@ type CreateS3Input struct {
 	TimestampFormat              string                 `form:"timestamp_format,omitempty"`
 	Redundancy                   S3Redundancy           `form:"redundancy,omitempty"`
 	Placement                    string                 `form:"placement,omitempty"`
-	ServerSideEncryptionKmsKeyId string                 `form:"server_side_encryption_kms_key_id,omitempty"`
+	ServerSideEncryptionKMSKeyID string                 `form:"server_side_encryption_kms_key_id,omitempty"`
 	ServerSideEncryption         S3ServerSideEncryption `form:"server_side_encryption,omitempty"`
 }
 
@@ -123,8 +123,8 @@ func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
 		return nil, ErrMissingVersion
 	}
 
-	if i.ServerSideEncryption == S3ServerSideEncryptionKMS && i.ServerSideEncryptionKmsKeyId == "" {
-		return nil, ErrMissingKmsKeyId
+	if i.ServerSideEncryption == S3ServerSideEncryptionKMS && i.ServerSideEncryptionKMSKeyID == "" {
+		return nil, ErrMissingKMSKeyID
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/s3", i.Service, i.Version)
@@ -203,7 +203,7 @@ type UpdateS3Input struct {
 	TimestampFormat              string                 `form:"timestamp_format,omitempty"`
 	Redundancy                   S3Redundancy           `form:"redundancy,omitempty"`
 	Placement                    string                 `form:"placement,omitempty"`
-	ServerSideEncryptionKmsKeyId string                 `form:"server_side_encryption_kms_key_id,omitempty"`
+	ServerSideEncryptionKMSKeyID string                 `form:"server_side_encryption_kms_key_id,omitempty"`
 	ServerSideEncryption         S3ServerSideEncryption `form:"server_side_encryption,omitempty"`
 }
 
@@ -221,8 +221,8 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 		return nil, ErrMissingName
 	}
 
-	if i.ServerSideEncryption == S3ServerSideEncryptionKMS && i.ServerSideEncryptionKmsKeyId == "" {
-		return nil, ErrMissingKmsKeyId
+	if i.ServerSideEncryption == S3ServerSideEncryptionKMS && i.ServerSideEncryptionKMSKeyID == "" {
+		return nil, ErrMissingKMSKeyID
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.Service, i.Version, url.PathEscape(i.Name))

--- a/fastly/s3_test.go
+++ b/fastly/s3_test.go
@@ -31,7 +31,7 @@ func TestClient_S3s(t *testing.T) {
 			MessageType:                  "classic",
 			Redundancy:                   S3RedundancyReduced,
 			Placement:                    "waf_debug",
-			ServerSideEncryptionKmsKeyId: "1234",
+			ServerSideEncryptionKMSKeyID: "1234",
 			ServerSideEncryption:         S3ServerSideEncryptionKMS,
 		})
 	})
@@ -102,8 +102,8 @@ func TestClient_S3s(t *testing.T) {
 	if s3.ServerSideEncryption != S3ServerSideEncryptionKMS {
 		t.Errorf("bad server_side_encryption: %q", s3.ServerSideEncryption)
 	}
-	if s3.ServerSideEncryptionKmsKeyId != "1234" {
-		t.Errorf("bad server_side_encryption_kms_key_id: %q", s3.ServerSideEncryptionKmsKeyId)
+	if s3.ServerSideEncryptionKMSKeyID != "1234" {
+		t.Errorf("bad server_side_encryption_kms_key_id: %q", s3.ServerSideEncryptionKMSKeyID)
 	}
 
 	// List
@@ -175,8 +175,8 @@ func TestClient_S3s(t *testing.T) {
 	if s3.ServerSideEncryption != ns3.ServerSideEncryption {
 		t.Errorf("bad server_side_encryption: %q", s3.ServerSideEncryption)
 	}
-	if s3.ServerSideEncryptionKmsKeyId != ns3.ServerSideEncryptionKmsKeyId {
-		t.Errorf("bad server_side_encryption_kms_key_id: %q", s3.ServerSideEncryptionKmsKeyId)
+	if s3.ServerSideEncryptionKMSKeyID != ns3.ServerSideEncryptionKMSKeyID {
+		t.Errorf("bad server_side_encryption_kms_key_id: %q", s3.ServerSideEncryptionKMSKeyID)
 	}
 
 	// Update
@@ -249,9 +249,9 @@ func TestClient_CreateS3_validation(t *testing.T) {
 		Version:                      1,
 		Name:                         "test-service",
 		ServerSideEncryption:         S3ServerSideEncryptionKMS,
-		ServerSideEncryptionKmsKeyId: "",
+		ServerSideEncryptionKMSKeyID: "",
 	})
-	if err != ErrMissingKmsKeyId {
+	if err != ErrMissingKMSKeyID {
 		t.Errorf("bad error: %s", err)
 	}
 }
@@ -314,9 +314,9 @@ func TestClient_UpdateS3_validation(t *testing.T) {
 		Version:                      1,
 		Name:                         "test-service",
 		ServerSideEncryption:         S3ServerSideEncryptionKMS,
-		ServerSideEncryptionKmsKeyId: "",
+		ServerSideEncryptionKMSKeyID: "",
 	})
-	if err != ErrMissingKmsKeyId {
+	if err != ErrMissingKMSKeyID {
 		t.Errorf("bad error: %s", err)
 	}
 }

--- a/fastly/s3_test.go
+++ b/fastly/s3_test.go
@@ -15,22 +15,24 @@ func TestClient_S3s(t *testing.T) {
 	var s3 *S3
 	record(t, "s3s/create", func(c *Client) {
 		s3, err = c.CreateS3(&CreateS3Input{
-			Service:         testServiceID,
-			Version:         tv.Number,
-			Name:            "test-s3",
-			BucketName:      "bucket-name",
-			Domain:          "s3.us-east-1.amazonaws.com",
-			AccessKey:       "AKIAIOSFODNN7EXAMPLE",
-			SecretKey:       "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-			Path:            "/path",
-			Period:          12,
-			GzipLevel:       9,
-			Format:          "format",
-			FormatVersion:   2,
-			TimestampFormat: "%Y",
-			MessageType:     "classic",
-			Redundancy:      S3RedundancyReduced,
-			Placement:       "waf_debug",
+			Service:                      testServiceID,
+			Version:                      tv.Number,
+			Name:                         "test-s3",
+			BucketName:                   "bucket-name",
+			Domain:                       "s3.us-east-1.amazonaws.com",
+			AccessKey:                    "AKIAIOSFODNN7EXAMPLE",
+			SecretKey:                    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			Path:                         "/path",
+			Period:                       12,
+			GzipLevel:                    9,
+			Format:                       "format",
+			FormatVersion:                2,
+			TimestampFormat:              "%Y",
+			MessageType:                  "classic",
+			Redundancy:                   S3RedundancyReduced,
+			Placement:                    "waf_debug",
+			ServerSideEncryptionKmsKeyId: "1234",
+			ServerSideEncryption:         S3ServerSideEncryptionKMS,
 		})
 	})
 	if err != nil {
@@ -95,6 +97,13 @@ func TestClient_S3s(t *testing.T) {
 	}
 	if s3.Placement != "waf_debug" {
 		t.Errorf("bad placement: %q", s3.Placement)
+	}
+	t.Logf("%+v", s3)
+	if s3.ServerSideEncryption != S3ServerSideEncryptionKMS {
+		t.Errorf("bad server_side_encryption: %q", s3.ServerSideEncryption)
+	}
+	if s3.ServerSideEncryptionKmsKeyId != "1234" {
+		t.Errorf("bad server_side_encryption_kms_key_id: %q", s3.ServerSideEncryptionKmsKeyId)
 	}
 
 	// List
@@ -163,6 +172,12 @@ func TestClient_S3s(t *testing.T) {
 	if s3.Placement != ns3.Placement {
 		t.Errorf("bad placement: %q", s3.Placement)
 	}
+	if s3.ServerSideEncryption != ns3.ServerSideEncryption {
+		t.Errorf("bad server_side_encryption: %q", s3.ServerSideEncryption)
+	}
+	if s3.ServerSideEncryptionKmsKeyId != ns3.ServerSideEncryptionKmsKeyId {
+		t.Errorf("bad server_side_encryption_kms_key_id: %q", s3.ServerSideEncryptionKmsKeyId)
+	}
 
 	// Update
 	var us3 *S3
@@ -228,6 +243,17 @@ func TestClient_CreateS3_validation(t *testing.T) {
 	if err != ErrMissingVersion {
 		t.Errorf("bad error: %s", err)
 	}
+
+	_, err = testClient.CreateS3(&CreateS3Input{
+		Service:                      "foo",
+		Version:                      1,
+		Name:                         "test-service",
+		ServerSideEncryption:         S3ServerSideEncryptionKMS,
+		ServerSideEncryptionKmsKeyId: "",
+	})
+	if err != ErrMissingKmsKeyId {
+		t.Errorf("bad error: %s", err)
+	}
 }
 
 func TestClient_GetS3_validation(t *testing.T) {
@@ -280,6 +306,17 @@ func TestClient_UpdateS3_validation(t *testing.T) {
 		Name:    "",
 	})
 	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateS3(&UpdateS3Input{
+		Service:                      "foo",
+		Version:                      1,
+		Name:                         "test-service",
+		ServerSideEncryption:         S3ServerSideEncryptionKMS,
+		ServerSideEncryptionKmsKeyId: "",
+	})
+	if err != ErrMissingKmsKeyId {
 		t.Errorf("bad error: %s", err)
 	}
 }


### PR DESCRIPTION
Add AWS S3 server side encryption attributes to `CreateS3` and `UpdateS3` functions and update any associated tests.

Closes https://github.com/fastly/go-fastly/issues/141