### PR TITLE
Let purges run in parallel.

### DIFF
--- a/fastly/client.go
+++ b/fastly/client.go
@@ -203,7 +203,7 @@ func (c *Client) Request(verb, p string, ro *RequestOptions) (*http.Response, er
 		return nil, err
 	}
 
-	if verb != "GET" && verb != "HEAD" {
+	if verb != "GET" && verb != "HEAD" && !strings.Contains(p, "/purge/") && !strings.HasPrefix(p, "purge/") {
 		c.updateLock.Lock()
 		defer c.updateLock.Unlock()
 

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -122,11 +122,19 @@ func (c *Client) init() (*Client, error) {
 
 // Get issues an HTTP GET request.
 func (c *Client) Get(p string, ro *RequestOptions) (*http.Response, error) {
+	if ro == nil {
+		ro = new(RequestOptions)
+	}
+	ro.Parallel = true
 	return c.Request("GET", p, ro)
 }
 
 // Head issues an HTTP HEAD request.
 func (c *Client) Head(p string, ro *RequestOptions) (*http.Response, error) {
+	if ro == nil {
+		ro = new(RequestOptions)
+	}
+	ro.Parallel = true
 	return c.Request("HEAD", p, ro)
 }
 
@@ -203,7 +211,7 @@ func (c *Client) Request(verb, p string, ro *RequestOptions) (*http.Response, er
 		return nil, err
 	}
 
-	if verb != "GET" && verb != "HEAD" && !strings.Contains(p, "/purge/") && !strings.HasPrefix(p, "purge/") {
+	if ro == nil || !ro.Parallel {
 		c.updateLock.Lock()
 		defer c.updateLock.Unlock()
 

--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -27,6 +27,7 @@ func (c *Client) Purge(i *PurgeInput) (*Purge, error) {
 	}
 
 	ro := new(RequestOptions)
+	ro.Parallel = true
 	if i.Soft {
 		ro.Headers["Fastly-Soft-Purge"] = "1"
 	}
@@ -66,7 +67,10 @@ func (c *Client) PurgeKey(i *PurgeKeyInput) (*Purge, error) {
 	}
 
 	path := fmt.Sprintf("/service/%s/purge/%s", i.Service, i.Key)
-	req, err := c.RawRequest("POST", path, nil)
+
+	ro := new(RequestOptions)
+	ro.Parallel = true
+	req, err := c.RawRequest("POST", path, ro)
 	if err != nil {
 		return nil, err
 	}

--- a/fastly/request.go
+++ b/fastly/request.go
@@ -19,6 +19,9 @@ type RequestOptions struct {
 	// Request. BodyLength is the final size of the Body.
 	Body       io.Reader
 	BodyLength int64
+
+	// Can this request run in parallel
+	Parallel bool
 }
 
 // RawRequest accepts a verb, URL, and RequestOptions struct and returns the


### PR DESCRIPTION
Allow purges to bypass the lock to on modifications.