### PR TITLE
Add NewRealtimeStatsClientForEndpoint API

### DIFF
--- a/fastly/client.go
+++ b/fastly/client.go
@@ -106,6 +106,17 @@ func NewRealtimeStatsClient() *RTSClient {
 	return &RTSClient{client: c}
 }
 
+// NewRealtimeStatsClientForEndpoint creates an RTSClient from a token and endpoint url.
+// `token` is a Fastly API token and `endpoint` is RealtimeStatsEndpoint for the production
+// realtime stats API.
+func NewRealtimeStatsClientForEndpoint(token, endpoint string) (*RTSClient, error) {
+	c, err := NewClientForEndpoint(token, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return &RTSClient{client: c}, nil
+}
+
 func (c *Client) init() (*Client, error) {
 	u, err := url.Parse(c.Address)
 	if err != nil {


### PR DESCRIPTION
This is an RTSClient counterpart to NewClientForEndpoint.

The existing API (NewRealtimeStatsClient) requires FASTLY_API_KEY
to be set in the environment, and panics if the endpoint url
cannot be parsed.

This new API doesn't make any environment requirements and returns
an error if its endpoint cannot be parsed, making it more flexible
for embedding in applications.

Fixes #118