### PR TITLE
WAF-1740 use content-type header for bulk requests

### DIFF
--- a/fastly/client.go
+++ b/fastly/client.go
@@ -298,7 +298,7 @@ func (c *Client) RequestJSONAPIBulk(verb, p string, i interface{}, ro *RequestOp
 	if ro.Headers == nil {
 		ro.Headers = make(map[string]string)
 	}
-	ro.Headers["Content-Type"] = jsonapi.MediaType
+	ro.Headers["Content-Type"] = jsonapi.MediaType + "; ext=bulk"
 	ro.Headers["Accept"] = jsonapi.MediaType + "; ext=bulk"
 
 	var buf bytes.Buffer

--- a/fastly/fixtures/waf_active_rules/create.yaml
+++ b/fastly/fixtures/waf_active_rules/create.yaml
@@ -9,7 +9,7 @@ interactions:
       Accept:
       - application/vnd.api+json; ext=bulk
       Content-Type:
-      - application/vnd.api+json
+      - application/vnd.api+json; ext=bulk
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
     url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules

--- a/fastly/fixtures/waf_active_rules/delete_one.yaml
+++ b/fastly/fixtures/waf_active_rules/delete_one.yaml
@@ -9,7 +9,7 @@ interactions:
       Accept:
       - application/vnd.api+json; ext=bulk
       Content-Type:
-      - application/vnd.api+json
+      - application/vnd.api+json; ext=bulk
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
     url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules

--- a/fastly/fixtures/waf_active_rules/update.yaml
+++ b/fastly/fixtures/waf_active_rules/update.yaml
@@ -9,7 +9,7 @@ interactions:
       Accept:
       - application/vnd.api+json; ext=bulk
       Content-Type:
-      - application/vnd.api+json
+      - application/vnd.api+json; ext=bulk
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
     url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules


### PR DESCRIPTION
This change addresses the change made to use the `content-type` header to process bulk requests on the WAF API:

https://github.com/fastly/moonbeam/pull/825
https://jira.corp.fastly.com/browse/WAF-1740

It appears that this API call was added by Oscar when he was creating the WAF provider for Fastly:

https://github.com/fastly/go-fastly/blame/service-waf-implementation/fastly/client.go#L293-L313

It shouldn't impact any other service using go-fastly