### PR TITLE
Add missing TLS fields to Splunk

### DIFF
--- a/fastly/fixtures/splunks/cleanup.yaml
+++ b/fastly/fixtures/splunks/cleanup.yaml
@@ -1,34 +1,32 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/42/logging/splunk/test-splunk
+      - FastlyGo/1.7.2 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/logging/splunk/test-splunk
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e test-splunk, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 42 }''"}'
+      version =\u003e 3 }''"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:50:18 GMT
+      - Mon, 20 Apr 2020 18:15:39 GMT
       Fastly-Ratelimit-Remaining:
-      - "983"
+      - "995"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1587409200"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -43,38 +41,38 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3647-SJC
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17421-PAO
       X-Timer:
-      - S1557442218.325510,VS0,VE189
+      - S1587406540.657911,VS0,VE229
     status: 404 Not Found
     code: 404
+    duration: ""
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/42/logging/splunk/new-test-splunk
+      - FastlyGo/1.7.2 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/logging/splunk/new-test-splunk
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e new-test-splunk, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 42 }''"}'
+      version =\u003e 3 }''"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:50:18 GMT
+      - Mon, 20 Apr 2020 18:15:40 GMT
       Fastly-Ratelimit-Remaining:
-      - "982"
+      - "994"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1587409200"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -89,8 +87,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sjc3647-SJC
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17421-PAO
       X-Timer:
-      - S1557442219.520622,VS0,VE180
+      - S1587406540.909345,VS0,VE217
     status: 404 Not Found
     code: 404
+    duration: ""

--- a/fastly/fixtures/splunks/create.yaml
+++ b/fastly/fixtures/splunks/create.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=42&format=%25h+%25l+%25u+%25t+%22%25r%22+%25%3Es+%25b&format_version=2&name=test-splunk&placement=waf_debug&token=super-secure-token&url=https%3A%2F%2Fmysplunkendpoint.example.com%2Fservices%2Fcollector%2Fevent
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=3&format=%25h+%25l+%25u+%25t+%22%25r%22+%25%3Es+%25b&format_version=2&name=test-splunk&placement=waf_debug&tls_ca_cert=-----BEGIN+CERTIFICATE-----%0AMIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjEL%0AMAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMC%0AVU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgx%0ANDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJD%0ATjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFu%0AZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE%2FB7j%0AV14qeyslnr26xZUsSVko36ZnhiaO%2FzbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGj%0AgbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaA%0AFFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UE%0ACBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDAS%0ABgNVBAMTC0hlcm9uZyBZYW5nggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEE%0ABQADQQA%2FugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z%2F%2BHQX67aRfgZu7KWdI%2BJu%0AWm7DCfrPNGVwFWUQOmsPue9rZBgO%0A-----END+CERTIFICATE-----&tls_hostname=example.com&token=super-secure-token&url=https%3A%2F%2Fmysplunkendpoint.example.com%2Fservices%2Fcollector%2Fevent
     form:
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "42"
+      - "3"
       format:
       - '%h %l %u %t "%r" %>s %b'
       format_version:
@@ -17,6 +16,25 @@ interactions:
       - test-splunk
       placement:
       - waf_debug
+      tls_ca_cert:
+      - |-
+        -----BEGIN CERTIFICATE-----
+        MIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjEL
+        MAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMC
+        VU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgx
+        NDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJD
+        TjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFu
+        ZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE/B7j
+        V14qeyslnr26xZUsSVko36ZnhiaO/zbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGj
+        gbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaA
+        FFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UE
+        CBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDAS
+        BgNVBAMTC0hlcm9uZyBZYW5nggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEE
+        BQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+Ju
+        Wm7DCfrPNGVwFWUQOmsPue9rZBgO
+        -----END CERTIFICATE-----
+      tls_hostname:
+      - example.com
       token:
       - super-secure-token
       url:
@@ -24,27 +42,28 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/42/logging/splunk
+      - FastlyGo/1.7.2 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/logging/splunk
     method: POST
   response:
-    body: '{"format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","name":"test-splunk","placement":"waf_debug","token":"super-secure-token","url":"https://mysplunkendpoint.example.com/services/collector/event","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"42","created_at":"2019-05-09T22:50:15Z","tls_allow_insecure":"0","tls_ca_cert":null,"tls_hostname":null,"deleted_at":null,"response_condition":"","updated_at":"2019-05-09T22:50:15Z","content_type":null}'
+    body: '{"format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","name":"test-splunk","placement":"waf_debug","tls_ca_cert":"-----BEGIN
+      CERTIFICATE-----\nMIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjEL\nMAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMC\nVU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgx\nNDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJD\nTjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFu\nZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE/B7j\nV14qeyslnr26xZUsSVko36ZnhiaO/zbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGj\ngbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaA\nFFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UE\nCBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDAS\nBgNVBAMTC0hlcm9uZyBZYW5nggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEE\nBQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+Ju\nWm7DCfrPNGVwFWUQOmsPue9rZBgO\n-----END
+      CERTIFICATE-----","tls_hostname":"example.com","token":"super-secure-token","url":"https://mysplunkendpoint.example.com/services/collector/event","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"3","updated_at":"2020-04-20T18:15:37Z","deleted_at":null,"created_at":"2020-04-20T18:15:37Z","response_condition":""}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:50:16 GMT
+      - Mon, 20 Apr 2020 18:15:37 GMT
       Fastly-Ratelimit-Remaining:
-      - "986"
+      - "998"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1587409200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -59,8 +78,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sjc3647-SJC
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17421-PAO
       X-Timer:
-      - S1557442216.561112,VS0,VE764
+      - S1587406537.133599,VS0,VE484
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/splunks/delete.yaml
+++ b/fastly/fixtures/splunks/delete.yaml
@@ -1,32 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/42/logging/splunk/new-test-splunk
+      - FastlyGo/1.7.2 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/logging/splunk/new-test-splunk
     method: DELETE
   response:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:50:18 GMT
+      - Mon, 20 Apr 2020 18:15:39 GMT
       Fastly-Ratelimit-Remaining:
-      - "984"
+      - "996"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1587409200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3647-SJC
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17421-PAO
       X-Timer:
-      - S1557442218.014222,VS0,VE278
+      - S1587406539.371367,VS0,VE264
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/splunks/get.yaml
+++ b/fastly/fixtures/splunks/get.yaml
@@ -1,30 +1,33 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/42/logging/splunk/test-splunk
+      - FastlyGo/1.7.2 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/logging/splunk/test-splunk
     method: GET
   response:
-    body: '{"format":"%h %l %u %t \"%r\" %\u003es %b","name":"test-splunk","updated_at":"2019-05-09T22:50:15Z","created_at":"2019-05-09T22:50:15Z","response_condition":"","content_type":null,"format_version":"2","tls_hostname":null,"url":"https://mysplunkendpoint.example.com/services/collector/event","version":"42","tls_allow_insecure":"0","deleted_at":null,"token":"super-secure-token","service_id":"7i6HN3TK9wS159v2gPAZ8A","tls_ca_cert":null,"placement":"waf_debug"}'
+    body: '{"tls_hostname":"example.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","name":"test-splunk","token":"super-secure-token","deleted_at":null,"url":"https://mysplunkendpoint.example.com/services/collector/event","updated_at":"2020-04-20T18:15:37Z","response_condition":"","tls_ca_cert":"-----BEGIN
+      CERTIFICATE-----\nMIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjEL\nMAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMC\nVU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgx\nNDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJD\nTjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFu\nZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE/B7j\nV14qeyslnr26xZUsSVko36ZnhiaO/zbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGj\ngbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaA\nFFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UE\nCBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDAS\nBgNVBAMTC0hlcm9uZyBZYW5nggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEE\nBQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+Ju\nWm7DCfrPNGVwFWUQOmsPue9rZBgO\n-----END
+      CERTIFICATE-----","placement":"waf_debug","version":"3","created_at":"2020-04-20T18:15:37Z","format":"%h
+      %l %u %t \"%r\" %\u003es %b"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
+      - bytes
       Age:
+      - "0"
       - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:50:17 GMT
+      - Mon, 20 Apr 2020 18:15:38 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,8 +42,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3647-SJC
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17421-PAO
       X-Timer:
-      - S1557442217.889419,VS0,VE413
+      - S1587406538.118440,VS0,VE496
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/splunks/list.yaml
+++ b/fastly/fixtures/splunks/list.yaml
@@ -1,31 +1,33 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/42/logging/splunk
+      - FastlyGo/1.7.2 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/logging/splunk
     method: GET
   response:
-    body: '[{"format_version":"2","content_type":null,"tls_hostname":null,"url":"https://mysplunkendpoint.example.com/services/collector/event","format":"%h
-      %l %u %t \"%r\" %\u003es %b","name":"test-splunk","updated_at":"2019-05-09T22:50:15Z","response_condition":"","created_at":"2019-05-09T22:50:15Z","deleted_at":null,"token":"super-secure-token","tls_ca_cert":null,"placement":"waf_debug","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"42","tls_allow_insecure":"0"}]'
+    body: '[{"updated_at":"2020-04-20T18:15:37Z","response_condition":"","tls_ca_cert":"-----BEGIN
+      CERTIFICATE-----\nMIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjEL\nMAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMC\nVU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgx\nNDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJD\nTjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFu\nZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE/B7j\nV14qeyslnr26xZUsSVko36ZnhiaO/zbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGj\ngbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaA\nFFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UE\nCBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDAS\nBgNVBAMTC0hlcm9uZyBZYW5nggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEE\nBQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+Ju\nWm7DCfrPNGVwFWUQOmsPue9rZBgO\n-----END
+      CERTIFICATE-----","placement":"waf_debug","version":"3","created_at":"2020-04-20T18:15:37Z","format":"%h
+      %l %u %t \"%r\" %\u003es %b","tls_hostname":"example.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","name":"test-splunk","token":"super-secure-token","deleted_at":null,"url":"https://mysplunkendpoint.example.com/services/collector/event"}]'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
+      - bytes
       Age:
+      - "0"
       - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:50:16 GMT
+      - Mon, 20 Apr 2020 18:15:38 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -40,8 +42,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3647-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17421-PAO
       X-Timer:
-      - S1557442216.376741,VS0,VE407
+      - S1587406538.645437,VS0,VE456
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/splunks/update.yaml
+++ b/fastly/fixtures/splunks/update.yaml
@@ -1,43 +1,42 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Name=test-splunk&Service=7i6HN3TK9wS159v2gPAZ8A&Version=42&name=new-test-splunk
+    body: Name=test-splunk&Service=7i6HN3TK9wS159v2gPAZ8A&Version=3&name=new-test-splunk
     form:
       Name:
       - test-splunk
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "42"
+      - "3"
       name:
       - new-test-splunk
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/42/logging/splunk/test-splunk
+      - FastlyGo/1.7.2 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/logging/splunk/test-splunk
     method: PUT
   response:
-    body: '{"url":"https://mysplunkendpoint.example.com/services/collector/event","tls_hostname":null,"tls_allow_insecure":"0","created_at":"2019-05-09T22:50:15Z","name":"new-test-splunk","response_condition":"","version":"42","deleted_at":null,"placement":"waf_debug","updated_at":"2019-05-09T22:50:15Z","token":"super-secure-token","format_version":"2","service_id":"7i6HN3TK9wS159v2gPAZ8A","tls_ca_cert":null,"content_type":null,"format":"%h
-      %l %u %t \"%r\" %\u003es %b"}'
+    body: '{"token":"super-secure-token","format":"%h %l %u %t \"%r\" %\u003es %b","response_condition":"","version":"3","placement":"waf_debug","name":"new-test-splunk","tls_ca_cert":"-----BEGIN
+      CERTIFICATE-----\nMIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjEL\nMAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMC\nVU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgx\nNDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJD\nTjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFu\nZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE/B7j\nV14qeyslnr26xZUsSVko36ZnhiaO/zbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGj\ngbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaA\nFFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UE\nCBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDAS\nBgNVBAMTC0hlcm9uZyBZYW5nggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEE\nBQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+Ju\nWm7DCfrPNGVwFWUQOmsPue9rZBgO\n-----END
+      CERTIFICATE-----","updated_at":"2020-04-20T18:15:37Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","tls_hostname":"example.com","url":"https://mysplunkendpoint.example.com/services/collector/event","created_at":"2020-04-20T18:15:37Z","format_version":"2","deleted_at":null}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:50:17 GMT
+      - Mon, 20 Apr 2020 18:15:39 GMT
       Fastly-Ratelimit-Remaining:
-      - "985"
+      - "997"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1587409200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -52,8 +51,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sjc3647-SJC
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17421-PAO
       X-Timer:
-      - S1557442217.399163,VS0,VE515
+      - S1587406539.629776,VS0,VE711
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/splunks/version.yaml
+++ b/fastly/fixtures/splunks/version.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: Service=7i6HN3TK9wS159v2gPAZ8A
@@ -10,27 +9,26 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
+      - FastlyGo/1.7.2 (+github.com/fastly/go-fastly; go1.14.2)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":42}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":3}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 May 2019 22:50:15 GMT
+      - Mon, 20 Apr 2020 18:15:37 GMT
       Fastly-Ratelimit-Remaining:
-      - "987"
+      - "999"
       Fastly-Ratelimit-Reset:
-      - "1557442800"
+      - "1587409200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,8 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3647-SJC
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17421-PAO
       X-Timer:
-      - S1557442215.030683,VS0,VE490
+      - S1587406537.729610,VS0,VE372
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/splunk.go
+++ b/fastly/splunk.go
@@ -19,6 +19,8 @@ type Splunk struct {
 	ResponseCondition string     `mapstructure:"response_condition"`
 	Placement         string     `mapstructure:"placement"`
 	Token             string     `mapstructure:"token"`
+	TLSCACert         string     `mapstructure:"tls_ca_cert"`
+	TLSHostname       string     `mapstructure:"tls_hostname"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
@@ -81,6 +83,8 @@ type CreateSplunkInput struct {
 	ResponseCondition string `form:"response_condition,omitempty"`
 	Placement         string `form:"placement,omitempty"`
 	Token             string `form:"token,omitempty"`
+	TLSCACert         string `form:"tls_ca_cert,omitempty"`
+	TLSHostname       string `form:"tls_hostname,omitempty"`
 }
 
 // CreateSplunk creates a new Fastly splunk.
@@ -161,6 +165,8 @@ type UpdateSplunkInput struct {
 	ResponseCondition string `form:"response_condition,omitempty"`
 	Placement         string `form:"placement,omitempty"`
 	Token             string `form:"token,omitempty"`
+	TLSCACert         string `form:"tls_ca_cert,omitempty"`
+	TLSHostname       string `form:"tls_hostname,omitempty"`
 }
 
 // UpdateSplunk updates a specific splunk.

--- a/fastly/splunk_test.go
+++ b/fastly/splunk_test.go
@@ -1,6 +1,9 @@
 package fastly
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestClient_Splunks(t *testing.T) {
 	t.Parallel()
@@ -10,6 +13,24 @@ func TestClient_Splunks(t *testing.T) {
 	record(t, "splunks/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
+
+	caCert := strings.TrimSpace(`
+-----BEGIN CERTIFICATE-----
+MIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjEL
+MAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMC
+VU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgx
+NDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJD
+TjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFu
+ZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE/B7j
+V14qeyslnr26xZUsSVko36ZnhiaO/zbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGj
+gbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaA
+FFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UE
+CBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDAS
+BgNVBAMTC0hlcm9uZyBZYW5nggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEE
+BQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+Ju
+Wm7DCfrPNGVwFWUQOmsPue9rZBgO
+-----END CERTIFICATE-----
+`)
 
 	// Create
 	var s *Splunk
@@ -23,6 +44,8 @@ func TestClient_Splunks(t *testing.T) {
 			FormatVersion: 2,
 			Placement:     "waf_debug",
 			Token:         "super-secure-token",
+			TLSCACert:     caCert,
+			TLSHostname:   "example.com",
 		})
 	})
 	if err != nil {
@@ -63,6 +86,12 @@ func TestClient_Splunks(t *testing.T) {
 	}
 	if s.Token != "super-secure-token" {
 		t.Errorf("bad token: %q", s.Token)
+	}
+	if s.TLSCACert != caCert {
+		t.Errorf("bad tls_ca_cert: %q", s.TLSCACert)
+	}
+	if s.TLSHostname != "example.com" {
+		t.Errorf("bad tls_hostname: %q", s.TLSHostname)
 	}
 
 	// List
@@ -109,6 +138,12 @@ func TestClient_Splunks(t *testing.T) {
 	}
 	if s.Token != ns.Token {
 		t.Errorf("bad token: %q", s.Token)
+	}
+	if s.TLSCACert != ns.TLSCACert {
+		t.Errorf("bad tls_ca_cert: %q", s.TLSCACert)
+	}
+	if s.TLSHostname != ns.TLSHostname {
+		t.Errorf("bad tls_hostname: %q", s.TLSHostname)
 	}
 
 	// Update


### PR DESCRIPTION
Add missing fields `tls_hostname` and `tls_ca_cert` to Splunk logging configuration.