### PR TITLE
Release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2020-04-24
+### Added
+- tls: Add support for Platform TLS API endpoints ([#154](https://github.com/fastly/go-fastly/pull/154))
+
 ## [1.9.0] - 2020-04-23
 ### Changed
 - splunk: Add missing TLS fields to the Splunk logging endpoint ([#156](https://github.com/fastly/go-fastly/pull/156))
@@ -159,7 +163,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial tagged release
 
-[Unreleased]: https://github.com/fastly/go-fastly/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/fastly/go-fastly/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/fastly/go-fastly/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/fastly/go-fastly/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/fastly/go-fastly/compare/v1.7.2...v1.8.0
 [1.7.2]: https://github.com/fastly/go-fastly/compare/v1.7.1...v1.7.2

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -36,7 +36,7 @@ const RealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "1.9.0"
+var ProjectVersion = "1.10.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",


### PR DESCRIPTION
Prepare for v1.10.0 release:
- Update  changelog
- Update client version

Release includes:
- #154 Adding support Platform TLS api endpoints