### PR TITLE
Improve testing experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,3 +96,11 @@ test-race:
 	@echo "==> Testing ${NAME} (race)"
 	@go test -timeout=60s -race -tags="${GOTAGS}" ${GOFILES} ${TESTARGS}
 .PHONY: test-race
+
+# test without VCR
+test-full:
+	@echo "==> Testing ${NAME} with VCR disabled"
+	@env \
+		VCR_DISABLE=1 \
+		go test -parallel=20 ${GOFILES} ${TESTARGS}
+.PHONY: test-full

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ GOCACHE ?= $(shell go env GOCACHE)
 # List of tests to run
 FILES ?= ./...
 
+# Test Service ID
+FASTLY_TEST_SERVICE_ID ?=
+
 # bootstrap installs the necessary go tools for development or build.
 bootstrap:
 	@echo "==> Bootstrapping ${PROJECT}"
@@ -102,5 +105,11 @@ test-full:
 	@echo "==> Testing ${NAME} with VCR disabled"
 	@env \
 		VCR_DISABLE=1 \
-		go test -parallel=20 ${GOFILES} ${TESTARGS}
+		go test -timeout=60s -parallel=20 ${GOFILES} ${TESTARGS}
 .PHONY: test-full
+
+# update fixtures default service ID
+fix-fixtures:
+	@echo "==> Updating fixtures"
+	@$(CURRENT_DIR)/scripts/fixFixtures.sh ${FASTLY_TEST_SERVICE_ID}
+.PHONY: fix-fixtures

--- a/README.md
+++ b/README.md
@@ -125,6 +125,54 @@ fmt.Printf("%t\n", activeVersion.Locked)
 More information can be found in the
 [Fastly Godoc](https://godoc.org/github.com/fastly/go-fastly).
 
+Testing
+-------
+Go Fastly uses [go-vcr](https://github.com/dnaeon/go-vcr) to "record" and
+"replay" API request fixtures to improve the speed and portability of
+integration tests. The test suite uses a single test service ID for all test
+fixtures.
+
+Contributors _without_ access to the test service can disable go-vcr, set a
+different test service ID, and use their own API credentials by setting the
+following environment variables:
+* `VCR_DISABLE`: disables go-vcr fixture recording and replay
+* `FASTLY_TEST_SERVICE_ID`: set default service ID used by the test suite
+* `FASTLY_API_KEY`: set a Fastly API key to be used by the test suite
+
+Example (`go test`):
+```sh
+go test -v ./... -run=Logentries \
+	VCR_DISABLE=1 \
+	FASTLY_TEST_SERVICE_ID="SERVICEID" \
+	FASTLY_API_KEY="TESTAPIKEY"
+```
+
+Example (`make test-full`):
+```sh
+make test-full FASTLY_TEST_SERVICE_ID="SERVICEID" \
+	       FASTLY_API_KEY="TESTAPIKEY" \
+	       TESTARGS="-run=Logentries"
+```
+
+When adding or updating client code and integration tests, contributors may
+record a new set of fixtures by running the tests without `VCR_DISABLE`. Before
+submitting a pull request with new or updated fixtures, we ask that contributors
+update them to use the default service ID by running `make fix-fixtures` with
+`FASTLY_TEST_SERVICE_ID` set to the same value used to run your tests.
+
+Example (`make test`, `make fix-fixtures`):
+```sh
+export FASTLY_TEST_SERVICE_ID="SERVICEID"
+export FASTLY_API_KEY="TESTAPIKEY"
+
+make test TESTARGS="-run=NewClient"
+make fix-fixtures
+
+# Re-run test suite with newly recorded fixtures
+unset FASTLY_TEST_SERVICE_ID FASTLY_API_KEY
+make test
+```
+
 License
 -------
 ```

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -33,8 +33,12 @@ const EndpointEnvVar = "FASTLY_API_URL"
 // support an on-premise solution, this is likely to always be the default.
 const DefaultEndpoint = "https://api.fastly.com"
 
-// RealtimeStatsEndpoint is the realtime stats endpoint for Fastly.
-const RealtimeStatsEndpoint = "https://rt.fastly.com"
+// RealtimeStatsEndpointEnvVar is the name of an environment variable that can be used
+// to change the URL of realtime stats requests.
+const RealtimeStatsEndpointEnvVar = "FASTLY_RTS_URL"
+
+// DefaultRealtimeStatsEndpoint is the realtime stats endpoint for Fastly.
+const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 
 // ProjectURL is the url for this library.
 var ProjectURL = "github.com/fastly/go-fastly"
@@ -109,7 +113,13 @@ func NewClientForEndpoint(key string, endpoint string) (*Client, error) {
 // This function requires the environment variable `FASTLY_API_KEY` is set and contains
 // a valid API key to authenticate with Fastly.
 func NewRealtimeStatsClient() *RTSClient {
-	c, err := NewClientForEndpoint(os.Getenv(APIKeyEnvVar), RealtimeStatsEndpoint)
+	endpoint, ok := os.LookupEnv(RealtimeStatsEndpointEnvVar)
+
+	if !ok {
+		endpoint = DefaultRealtimeStatsEndpoint
+	}
+
+	c, err := NewClientForEndpoint(os.Getenv(APIKeyEnvVar), endpoint)
 	if err != nil {
 		panic(err)
 	}

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -25,6 +25,10 @@ const APIKeyEnvVar = "FASTLY_API_KEY"
 // APIKeyHeader is the name of the header that contains the Fastly API key.
 const APIKeyHeader = "Fastly-Key"
 
+// EndpointEnvVar is the name of an environment variable that can be used
+// to change the URL of API requests.
+const EndpointEnvVar = "FASTLY_API_URL"
+
 // DefaultEndpoint is the default endpoint for Fastly. Since Fastly does not
 // support an on-premise solution, this is likely to always be the default.
 const DefaultEndpoint = "https://api.fastly.com"
@@ -83,7 +87,13 @@ func DefaultClient() *Client {
 // function will not error if the API token is not supplied. Attempts to make a
 // request that requires an API key will return a 403 response.
 func NewClient(key string) (*Client, error) {
-	return NewClientForEndpoint(key, DefaultEndpoint)
+	endpoint, ok := os.LookupEnv(EndpointEnvVar)
+
+	if !ok {
+		endpoint = DefaultEndpoint
+	}
+
+	return NewClientForEndpoint(key, endpoint)
 }
 
 // NewClientForEndpoint creates a new API client with the given key and API

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -31,9 +31,9 @@ func serviceIDForTest() string {
 
 	if tsid != "" {
 		return tsid
-	} else {
-		return defaultTestServiceID
 	}
+
+	return defaultTestServiceID
 }
 
 func vcrDisabled() bool {

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 
@@ -16,33 +17,57 @@ var testClient = DefaultClient()
 var testStatsClient = NewRealtimeStatsClient()
 
 // testServiceID is the ID of the testing service.
-var testServiceID = "7i6HN3TK9wS159v2gPAZ8A"
+var testServiceID = serviceIDForTest()
+
+// Default ID of the testing service.
+var defaultTestServiceID = "7i6HN3TK9wS159v2gPAZ8A"
 
 // testVersionLock is a lock around version creation because the Fastly API
 // kinda dies on concurrent requests to create a version.
 var testVersionLock sync.Mutex
 
-func record(t *testing.T, fixture string, f func(*Client)) {
-	r, err := recorder.New("fixtures/" + fixture)
-	if err != nil {
-		t.Fatal(err)
+func serviceIDForTest() string {
+	tsid := os.Getenv("FASTLY_TEST_SERVICE_ID")
+
+	if tsid != "" {
+		return tsid
+	} else {
+		return defaultTestServiceID
 	}
-	defer func() {
-		if err := r.Stop(); err != nil {
+}
+
+func vcrDisabled() bool {
+	vcrDisable := os.Getenv("VCR_DISABLE")
+
+	return vcrDisable != ""
+}
+
+func record(t *testing.T, fixture string, f func(*Client)) {
+	client := DefaultClient()
+
+	if vcrDisabled() {
+		f(client)
+	} else {
+		r, err := recorder.New("fixtures/" + fixture)
+		if err != nil {
 			t.Fatal(err)
 		}
-	}()
+		defer func() {
+			if err := r.Stop(); err != nil {
+				t.Fatal(err)
+			}
+		}()
 
-	// Add a filter which removes Fastly-Key header from all recorded requests.
-	r.AddFilter(func(i *cassette.Interaction) error {
-		delete(i.Request.Headers, "Fastly-Key")
-		return nil
-	})
+		// Add a filter which removes Fastly-Key header from all recorded requests.
+		r.AddFilter(func(i *cassette.Interaction) error {
+			delete(i.Request.Headers, "Fastly-Key")
+			return nil
+		})
 
-	client := DefaultClient()
-	client.HTTPClient.Transport = r
+		client.HTTPClient.Transport = r
 
-	f(client)
+		f(client)
+	}
 }
 
 func recordRealtimeStats(t *testing.T, fixture string, f func(*RTSClient)) {

--- a/scripts/fixFixtures.sh
+++ b/scripts/fixFixtures.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+FIXTURESDIR="$(pwd)/fastly/fixtures/"
+DEFAULT_SERVICE_ID="7i6HN3TK9wS159v2gPAZ8A"
+
+if [[ -z $FASTLY_TEST_SERVICE_ID && -z $1 ]]; then
+  echo "You must supply a service ID as either an argument or by setting \$FASTLY_TEST_SERVICE_ID"
+  exit
+fi
+
+if [[ -z ${FASTLY_TEST_SERVICE_ID} ]]; then
+  FASTLY_TEST_SERVICE_ID=$1
+fi
+
+echo "Searching fixtures for ${FASTLY_TEST_SERVICE_ID}"
+grep --recursive --files-with-matches "${FASTLY_TEST_SERVICE_ID}" "${FIXTURESDIR}" | xargs sed -i "s/${FASTLY_TEST_SERVICE_ID}/${DEFAULT_SERVICE_ID}/g"

--- a/scripts/fixFixtures.sh
+++ b/scripts/fixFixtures.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 set -e
 
+FASTLY_TEST_SERVICE_ID=$1
+DEFAULT_TEST_SERVICE_ID="7i6HN3TK9wS159v2gPAZ8A"
 FIXTURESDIR="$(pwd)/fastly/fixtures/"
-DEFAULT_SERVICE_ID="7i6HN3TK9wS159v2gPAZ8A"
 
-if [[ -z $FASTLY_TEST_SERVICE_ID && -z $1 ]]; then
-  echo "You must supply a service ID as either an argument or by setting \$FASTLY_TEST_SERVICE_ID"
+if [[ -z ${FASTLY_TEST_SERVICE_ID} && -z $1 ]]; then
+  echo "You must supply a service ID as the first argument"
   exit
 fi
 
-if [[ -z ${FASTLY_TEST_SERVICE_ID} ]]; then
-  FASTLY_TEST_SERVICE_ID=$1
-fi
-
-echo "Searching fixtures for ${FASTLY_TEST_SERVICE_ID}"
-grep --recursive --files-with-matches "${FASTLY_TEST_SERVICE_ID}" "${FIXTURESDIR}" | xargs sed -i "s/${FASTLY_TEST_SERVICE_ID}/${DEFAULT_SERVICE_ID}/g"
+for file in $(grep --recursive --files-with-matches "${FASTLY_TEST_SERVICE_ID}" "${FIXTURESDIR}")
+do
+  sed -i "s/${FASTLY_TEST_SERVICE_ID}/${DEFAULT_TEST_SERVICE_ID}/g" "$file"
+done


### PR DESCRIPTION
Adds four new environment variables:
* `VCR_DISABLE`: If set, tests are run with VCR disabled
* `FASTLY_TEST_SERVICE_ID`: Set a different test service ID
* `FASTLY_API_URL`: Set a different URL for Fastly API requests
* `FASTLY_RTS_URL`: Set a different URL for real-time stats requests

Adds two new make targets:
* `test-full`: run tests w/ VCR disabled
* `fix-fixtures`: runs a `scripts/fixFixtures.sh` script, which replaces `FASTLY_TEST_SERVICE_ID` with the default test service ID in the fixtures

Adds "Testing" section to README