### PR TITLE
Add Honeycomb endpoint support

### DIFF
--- a/fastly/fixtures/honeycombs/cleanup.yaml
+++ b/fastly/fixtures/honeycombs/cleanup.yaml
@@ -1,0 +1,95 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/118/logging/honeycomb/test-honeycomb
+    method: DELETE
+  response:
+    body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
+      0000-00-00 00:00:00, name =\u003e test-honeycomb, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
+      version =\u003e 118 }''"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:24:23 GMT
+      Fastly-Ratelimit-Remaining:
+      - "944"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17446-PAO
+      X-Timer:
+      - S1588937064.796330,VS0,VE193
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/118/logging/honeycomb/new-test-honeycomb
+    method: DELETE
+  response:
+    body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
+      0000-00-00 00:00:00, name =\u003e new-test-honeycomb, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
+      version =\u003e 118 }''"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:24:24 GMT
+      Fastly-Ratelimit-Remaining:
+      - "943"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17446-PAO
+      X-Timer:
+      - S1588937064.004905,VS0,VE217
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/fastly/fixtures/honeycombs/create.yaml
+++ b/fastly/fixtures/honeycombs/create.yaml
@@ -1,0 +1,65 @@
+---
+version: 1
+interactions:
+- request:
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=118&dataset=testDataset&format=%25h+%25l+%25u+%25t+%22%25r%22+%25%3Es+%25b&format_version=2&name=test-honeycomb&placement=waf_debug&token=super-secure-token
+    form:
+      Service:
+      - 7i6HN3TK9wS159v2gPAZ8A
+      Version:
+      - "118"
+      dataset:
+      - testDataset
+      format:
+      - '%h %l %u %t "%r" %>s %b'
+      format_version:
+      - "2"
+      name:
+      - test-honeycomb
+      placement:
+      - waf_debug
+      token:
+      - super-secure-token
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/118/logging/honeycomb
+    method: POST
+  response:
+    body: '{"dataset":"testDataset","format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","name":"test-honeycomb","placement":"waf_debug","token":"super-secure-token","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"118","deleted_at":null,"created_at":"2020-05-08T11:24:21Z","updated_at":"2020-05-08T11:24:21Z","response_condition":""}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:24:22 GMT
+      Fastly-Ratelimit-Remaining:
+      - "947"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17446-PAO
+      X-Timer:
+      - S1588937061.446759,VS0,VE676
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/honeycombs/delete.yaml
+++ b/fastly/fixtures/honeycombs/delete.yaml
@@ -1,0 +1,47 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/118/logging/honeycomb/new-test-honeycomb
+    method: DELETE
+  response:
+    body: '{"status":"ok"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:24:23 GMT
+      Fastly-Ratelimit-Remaining:
+      - "945"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17446-PAO
+      X-Timer:
+      - S1588937063.441251,VS0,VE340
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/honeycombs/get.yaml
+++ b/fastly/fixtures/honeycombs/get.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/118/logging/honeycomb/test-honeycomb
+    method: GET
+  response:
+    body: '{"name":"test-honeycomb","placement":"waf_debug","deleted_at":null,"dataset":"testDataset","format":"%h
+      %l %u %t \"%r\" %\u003es %b","token":"super-secure-token","updated_at":"2020-05-08T11:24:21Z","response_condition":"","version":"118","service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","created_at":"2020-05-08T11:24:21Z"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:24:22 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17446-PAO
+      X-Timer:
+      - S1588937062.336920,VS0,VE432
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/honeycombs/list.yaml
+++ b/fastly/fixtures/honeycombs/list.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/118/logging/honeycomb
+    method: GET
+  response:
+    body: '[{"response_condition":"","service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","version":"118","token":"super-secure-token","updated_at":"2020-05-08T11:24:21Z","created_at":"2020-05-08T11:24:21Z","format":"%h
+      %l %u %t \"%r\" %\u003es %b","dataset":"testDataset","deleted_at":null,"placement":"waf_debug","name":"test-honeycomb"}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:24:22 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17446-PAO
+      X-Timer:
+      - S1588937062.139179,VS0,VE181
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/honeycombs/update.yaml
+++ b/fastly/fixtures/honeycombs/update.yaml
@@ -1,0 +1,62 @@
+---
+version: 1
+interactions:
+- request:
+    body: Name=test-honeycomb&Service=7i6HN3TK9wS159v2gPAZ8A&Version=118&dataset=newDataset&name=new-test-honeycomb&token=new-token
+    form:
+      Name:
+      - test-honeycomb
+      Service:
+      - 7i6HN3TK9wS159v2gPAZ8A
+      Version:
+      - "118"
+      dataset:
+      - newDataset
+      name:
+      - new-test-honeycomb
+      token:
+      - new-token
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/118/logging/honeycomb/test-honeycomb
+    method: PUT
+  response:
+    body: '{"deleted_at":null,"dataset":"newDataset","response_condition":"","version":"118","format":"%h
+      %l %u %t \"%r\" %\u003es %b","placement":"waf_debug","service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2020-05-08T11:24:21Z","format_version":"2","created_at":"2020-05-08T11:24:21Z","name":"new-test-honeycomb","token":"new-token"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:24:23 GMT
+      Fastly-Ratelimit-Remaining:
+      - "946"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17446-PAO
+      X-Timer:
+      - S1588937063.784266,VS0,VE641
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/honeycombs/version.yaml
+++ b/fastly/fixtures/honeycombs/version.yaml
@@ -1,0 +1,51 @@
+---
+version: 1
+interactions:
+- request:
+    body: Service=7i6HN3TK9wS159v2gPAZ8A
+    form:
+      Service:
+      - 7i6HN3TK9wS159v2gPAZ8A
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
+    method: POST
+  response:
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":118}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:24:21 GMT
+      Fastly-Ratelimit-Remaining:
+      - "948"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17446-PAO
+      X-Timer:
+      - S1588937061.152041,VS0,VE279
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/honeycomb.go
+++ b/fastly/honeycomb.go
@@ -1,0 +1,232 @@
+package fastly
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"time"
+)
+
+// Honeycomb represents a honeycomb response from the Fastly API.
+type Honeycomb struct {
+	ServiceID string `mapstructure:"service_id"`
+	Version   int    `mapstructure:"version"`
+
+	Name              string     `mapstructure:"name"`
+	Format            string     `mapstructure:"format"`
+	FormatVersion     uint       `mapstructure:"format_version"`
+	Dataset           string     `mapstructure:"dataset"`
+	Token             string     `mapstructure:"token"`
+	ResponseCondition string     `mapstructure:"response_condition"`
+	Placement         string     `mapstructure:"placement"`
+	CreatedAt         *time.Time `mapstructure:"created_at"`
+	UpdatedAt         *time.Time `mapstructure:"updated_at"`
+	DeletedAt         *time.Time `mapstructure:"deleted_at"`
+}
+
+// honeycombsByName is a sortable list of honeycombs.
+type honeycombsByName []*Honeycomb
+
+// Len, Swap, and Less implement the sortable interface.
+func (h honeycombsByName) Len() int      { return len(h) }
+func (h honeycombsByName) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h honeycombsByName) Less(i, j int) bool {
+	return h[i].Name < h[j].Name
+}
+
+// ListHoneycombsInput is used as input to the ListHoneycombs function.
+type ListHoneycombsInput struct {
+	// Service is the ID of the service (required).
+	Service string
+
+	// Version is the specific configuration version (required).
+	Version int
+}
+
+// ListHoneycombs returns the list of honeycombs for the configuration version.
+func (c *Client) ListHoneycombs(i *ListHoneycombsInput) ([]*Honeycomb, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var hs []*Honeycomb
+	if err := decodeJSON(&hs, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(honeycombsByName(hs))
+	return hs, nil
+}
+
+// CreateHoneycombInput is used as input to the CreateHoneycomb function.
+type CreateHoneycombInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	Name              *string `form:"name,omitempty"`
+	Format            *string `form:"format,omitempty"`
+	FormatVersion     *uint   `form:"format_version,omitempty"`
+	Dataset           *string `form:"dataset,omitempty"`
+	Token             *string `form:"token,omitempty"`
+	ResponseCondition *string `form:"response_condition,omitempty"`
+	Placement         *string `form:"placement,omitempty"`
+}
+
+// CreateHoneycomb creates a new Fastly honeycomb.
+func (c *Client) CreateHoneycomb(i *CreateHoneycombInput) (*Honeycomb, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var h *Honeycomb
+	if err := decodeJSON(&h, resp.Body); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// GetHoneycombInput is used as input to the GetHoneycomb function.
+type GetHoneycombInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the honeycomb to fetch.
+	Name string
+}
+
+// GetHoneycomb gets the honeycomb configuration with the given parameters.
+func (c *Client) GetHoneycomb(i *GetHoneycombInput) (*Honeycomb, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb/%s", i.Service, i.Version, url.PathEscape(i.Name))
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var h *Honeycomb
+	if err := decodeJSON(&h, resp.Body); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// UpdateHoneycombInput is used as input to the UpdateHoneycomb function.
+type UpdateHoneycombInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the honeycomb to update.
+	Name string
+
+	NewName           *string `form:"name,omitempty"`
+	Format            *string `form:"format,omitempty"`
+	FormatVersion     *uint   `form:"format_version,omitempty"`
+	Dataset           *string `form:"dataset,omitempty"`
+	Token             *string `form:"token,omitempty"`
+	ResponseCondition *string `form:"response_condition,omitempty"`
+	Placement         *string `form:"placement,omitempty"`
+}
+
+// UpdateHoneycomb updates a specific honeycomb.
+func (c *Client) UpdateHoneycomb(i *UpdateHoneycombInput) (*Honeycomb, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb/%s", i.Service, i.Version, url.PathEscape(i.Name))
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var h *Honeycomb
+	if err := decodeJSON(&h, resp.Body); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// DeleteHoneycombInput is the input parameter to DeleteHoneycomb.
+type DeleteHoneycombInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the honeycomb to delete (required).
+	Name string
+}
+
+// DeleteHoneycomb deletes the given honeycomb version.
+func (c *Client) DeleteHoneycomb(i *DeleteHoneycombInput) error {
+	if i.Service == "" {
+		return ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb/%s", i.Service, i.Version, url.PathEscape(i.Name))
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return ErrStatusNotOk
+	}
+	return nil
+}

--- a/fastly/honeycomb_test.go
+++ b/fastly/honeycomb_test.go
@@ -1,0 +1,269 @@
+package fastly
+
+import (
+	"testing"
+)
+
+func TestClient_Honeycombs(t *testing.T) {
+	t.Parallel()
+
+	var err error
+	var tv *Version
+	record(t, "honeycombs/version", func(c *Client) {
+		tv = testVersion(t, c)
+	})
+
+	// Create
+	var h *Honeycomb
+	record(t, "honeycombs/create", func(c *Client) {
+		h, err = c.CreateHoneycomb(&CreateHoneycombInput{
+			Service:       testServiceID,
+			Version:       tv.Number,
+			Name:          String("test-honeycomb"),
+			Format:        String("%h %l %u %t \"%r\" %>s %b"),
+			FormatVersion: Uint(2),
+			Placement:     String("waf_debug"),
+			Token:         String("super-secure-token"),
+			Dataset:       String("testDataset"),
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure deleted
+	defer func() {
+		record(t, "honeycombs/cleanup", func(c *Client) {
+			c.DeleteHoneycomb(&DeleteHoneycombInput{
+				Service: testServiceID,
+				Version: tv.Number,
+				Name:    "test-honeycomb",
+			})
+
+			c.DeleteHoneycomb(&DeleteHoneycombInput{
+				Service: testServiceID,
+				Version: tv.Number,
+				Name:    "new-test-honeycomb",
+			})
+		})
+	}()
+
+	if h.Name != "test-honeycomb" {
+		t.Errorf("bad name: %q", h.Name)
+	}
+	if h.Format != "%h %l %u %t \"%r\" %>s %b" {
+		t.Errorf("bad format: %q", h.Format)
+	}
+	if h.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", h.FormatVersion)
+	}
+	if h.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", h.Placement)
+	}
+	if h.Token != "super-secure-token" {
+		t.Errorf("bad token: %q", h.Token)
+	}
+	if h.Dataset != "testDataset" {
+		t.Errorf("bad dataset: %q", h.Dataset)
+	}
+
+	// List
+	var hs []*Honeycomb
+	record(t, "honeycombs/list", func(c *Client) {
+		hs, err = c.ListHoneycombs(&ListHoneycombsInput{
+			Service: testServiceID,
+			Version: tv.Number,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hs) < 1 {
+		t.Errorf("bad honeycombs: %v", hs)
+	}
+
+	// Get
+	var nh *Honeycomb
+	record(t, "honeycombs/get", func(c *Client) {
+		nh, err = c.GetHoneycomb(&GetHoneycombInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "test-honeycomb",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Name != nh.Name {
+		t.Errorf("bad name: %q", h.Name)
+	}
+	if h.Format != nh.Format {
+		t.Errorf("bad format: %q", h.Format)
+	}
+	if h.FormatVersion != nh.FormatVersion {
+		t.Errorf("bad format_version: %q", h.FormatVersion)
+	}
+	if h.Placement != nh.Placement {
+		t.Errorf("bad placement: %q", h.Placement)
+	}
+	if h.Token != nh.Token {
+		t.Errorf("bad token: %q", h.Token)
+	}
+	if h.Dataset != nh.Dataset {
+		t.Errorf("bad dataset: %q", h.Dataset)
+	}
+
+	// Update
+	var us *Honeycomb
+	record(t, "honeycombs/update", func(c *Client) {
+		us, err = c.UpdateHoneycomb(&UpdateHoneycombInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "test-honeycomb",
+			NewName: String("new-test-honeycomb"),
+			Token:   String("new-token"),
+			Dataset: String("newDataset"),
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if us.Name != "new-test-honeycomb" {
+		t.Errorf("bad name: %q", us.Name)
+	}
+	if us.Token != "new-token" {
+		t.Errorf("bad token: %q", us.Token)
+	}
+	if us.Dataset != "newDataset" {
+		t.Errorf("bad dataset: %q", us.Dataset)
+	}
+
+	// Delete
+	record(t, "honeycombs/delete", func(c *Client) {
+		err = c.DeleteHoneycomb(&DeleteHoneycombInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "new-test-honeycomb",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClient_ListHoneycombs_validation(t *testing.T) {
+	var err error
+	_, err = testClient.ListHoneycombs(&ListHoneycombsInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.ListHoneycombs(&ListHoneycombsInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_CreateHoneycomb_validation(t *testing.T) {
+	var err error
+	_, err = testClient.CreateHoneycomb(&CreateHoneycombInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.CreateHoneycomb(&CreateHoneycombInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_GetHoneycomb_validation(t *testing.T) {
+	var err error
+	_, err = testClient.GetHoneycomb(&GetHoneycombInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetHoneycomb(&GetHoneycombInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetHoneycomb(&GetHoneycombInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "",
+	})
+	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_UpdateHoneycomb_validation(t *testing.T) {
+	var err error
+	_, err = testClient.UpdateHoneycomb(&UpdateHoneycombInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateHoneycomb(&UpdateHoneycombInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateHoneycomb(&UpdateHoneycombInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "",
+	})
+	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DeleteHoneycomb_validation(t *testing.T) {
+	var err error
+	err = testClient.DeleteHoneycomb(&DeleteHoneycombInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteHoneycomb(&DeleteHoneycombInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteHoneycomb(&DeleteHoneycombInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "",
+	})
+	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+}


### PR DESCRIPTION
See [the docs](https://docs.fastly.com/en/guides/log-streaming-honeycomb) for more information on Honeycomb logging endpoint support.