### PR TITLE
Add Log Shuttle endpoint support

### DIFF
--- a/fastly/fixtures/logshuttles/cleanup.yaml
+++ b/fastly/fixtures/logshuttles/cleanup.yaml
@@ -1,0 +1,95 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/124/logging/logshuttle/test-logshuttle
+    method: DELETE
+  response:
+    body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
+      0000-00-00 00:00:00, name =\u003e test-logshuttle, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
+      version =\u003e 124 }''"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:40:58 GMT
+      Fastly-Ratelimit-Remaining:
+      - "902"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17428-PAO
+      X-Timer:
+      - S1588938059.644046,VS0,VE189
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/124/logging/logshuttle/new-test-logshuttle
+    method: DELETE
+  response:
+    body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
+      0000-00-00 00:00:00, name =\u003e new-test-logshuttle, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
+      version =\u003e 124 }''"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:40:59 GMT
+      Fastly-Ratelimit-Remaining:
+      - "901"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17428-PAO
+      X-Timer:
+      - S1588938059.848211,VS0,VE182
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/fastly/fixtures/logshuttles/create.yaml
+++ b/fastly/fixtures/logshuttles/create.yaml
@@ -1,0 +1,65 @@
+---
+version: 1
+interactions:
+- request:
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=124&format=%25h+%25l+%25u+%25t+%22%25r%22+%25%3Es+%25b&format_version=2&name=test-logshuttle&placement=waf_debug&token=super-secure-token&url=https%3A%2F%2Flogs.example.com
+    form:
+      Service:
+      - 7i6HN3TK9wS159v2gPAZ8A
+      Version:
+      - "124"
+      format:
+      - '%h %l %u %t "%r" %>s %b'
+      format_version:
+      - "2"
+      name:
+      - test-logshuttle
+      placement:
+      - waf_debug
+      token:
+      - super-secure-token
+      url:
+      - https://logs.example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/124/logging/logshuttle
+    method: POST
+  response:
+    body: '{"format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","name":"test-logshuttle","placement":"waf_debug","token":"super-secure-token","url":"https://logs.example.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"124","created_at":"2020-05-08T11:40:56Z","updated_at":"2020-05-08T11:40:56Z","deleted_at":null,"response_condition":""}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:40:57 GMT
+      Fastly-Ratelimit-Remaining:
+      - "905"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17428-PAO
+      X-Timer:
+      - S1588938056.973423,VS0,VE1096
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/logshuttles/delete.yaml
+++ b/fastly/fixtures/logshuttles/delete.yaml
@@ -1,0 +1,47 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/124/logging/logshuttle/new-test-logshuttle
+    method: DELETE
+  response:
+    body: '{"status":"ok"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:40:58 GMT
+      Fastly-Ratelimit-Remaining:
+      - "903"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17428-PAO
+      X-Timer:
+      - S1588938058.321624,VS0,VE307
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/logshuttles/get.yaml
+++ b/fastly/fixtures/logshuttles/get.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/124/logging/logshuttle/test-logshuttle
+    method: GET
+  response:
+    body: '{"url":"https://logs.example.com","name":"test-logshuttle","placement":"waf_debug","format_version":"2","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"124","response_condition":"","updated_at":"2020-05-08T11:40:56Z","token":"super-secure-token","created_at":"2020-05-08T11:40:56Z","deleted_at":null,"format":"%h
+      %l %u %t \"%r\" %\u003es %b"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:40:57 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17428-PAO
+      X-Timer:
+      - S1588938057.366602,VS0,VE185
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/logshuttles/list.yaml
+++ b/fastly/fixtures/logshuttles/list.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/124/logging/logshuttle
+    method: GET
+  response:
+    body: '[{"url":"https://logs.example.com","format":"%h %l %u %t \"%r\" %\u003es
+      %b","version":"124","placement":"waf_debug","created_at":"2020-05-08T11:40:56Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","deleted_at":null,"name":"test-logshuttle","response_condition":"","token":"super-secure-token","updated_at":"2020-05-08T11:40:56Z"}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - "0"
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:40:57 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17428-PAO
+      X-Timer:
+      - S1588938057.084306,VS0,VE267
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/logshuttles/update.yaml
+++ b/fastly/fixtures/logshuttles/update.yaml
@@ -1,0 +1,62 @@
+---
+version: 1
+interactions:
+- request:
+    body: Name=test-logshuttle&Service=7i6HN3TK9wS159v2gPAZ8A&Version=124&name=new-test-logshuttle&token=new-token&url=https%3A%2F%2Flogs2.example.com
+    form:
+      Name:
+      - test-logshuttle
+      Service:
+      - 7i6HN3TK9wS159v2gPAZ8A
+      Version:
+      - "124"
+      name:
+      - new-test-logshuttle
+      token:
+      - new-token
+      url:
+      - https://logs2.example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/124/logging/logshuttle/test-logshuttle
+    method: PUT
+  response:
+    body: '{"created_at":"2020-05-08T11:40:56Z","placement":"waf_debug","url":"https://logs2.example.com","format":"%h
+      %l %u %t \"%r\" %\u003es %b","version":"124","deleted_at":null,"format_version":"2","name":"new-test-logshuttle","response_condition":"","token":"new-token","updated_at":"2020-05-08T11:40:56Z","service_id":"7i6HN3TK9wS159v2gPAZ8A"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:40:58 GMT
+      Fastly-Ratelimit-Remaining:
+      - "904"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17428-PAO
+      X-Timer:
+      - S1588938058.566281,VS0,VE741
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/logshuttles/version.yaml
+++ b/fastly/fixtures/logshuttles/version.yaml
@@ -1,0 +1,51 @@
+---
+version: 1
+interactions:
+- request:
+    body: Service=7i6HN3TK9wS159v2gPAZ8A
+    form:
+      Service:
+      - 7i6HN3TK9wS159v2gPAZ8A
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
+    method: POST
+  response:
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":124}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 08 May 2020 11:40:55 GMT
+      Fastly-Ratelimit-Remaining:
+      - "906"
+      Fastly-Ratelimit-Reset:
+      - "1588939200"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17428-PAO
+      X-Timer:
+      - S1588938055.432814,VS0,VE525
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/logshuttle.go
+++ b/fastly/logshuttle.go
@@ -1,0 +1,232 @@
+package fastly
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"time"
+)
+
+// Logshuttle represents a logshuttle response from the Fastly API.
+type Logshuttle struct {
+	ServiceID string `mapstructure:"service_id"`
+	Version   int    `mapstructure:"version"`
+
+	Name              string     `mapstructure:"name"`
+	Format            string     `mapstructure:"format"`
+	FormatVersion     uint       `mapstructure:"format_version"`
+	URL               string     `mapstructure:"url"`
+	Token             string     `mapstructure:"token"`
+	ResponseCondition string     `mapstructure:"response_condition"`
+	Placement         string     `mapstructure:"placement"`
+	CreatedAt         *time.Time `mapstructure:"created_at"`
+	UpdatedAt         *time.Time `mapstructure:"updated_at"`
+	DeletedAt         *time.Time `mapstructure:"deleted_at"`
+}
+
+// logshuttlesByName is a sortable list of logshuttles.
+type logshuttlesByName []*Logshuttle
+
+// Len, Swap, and Less implement the sortable interface.
+func (l logshuttlesByName) Len() int      { return len(l) }
+func (l logshuttlesByName) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l logshuttlesByName) Less(i, j int) bool {
+	return l[i].Name < l[j].Name
+}
+
+// ListLogshuttlesInput is used as input to the ListLogshuttles function.
+type ListLogshuttlesInput struct {
+	// Service is the ID of the service (required).
+	Service string
+
+	// Version is the specific configuration version (required).
+	Version int
+}
+
+// ListLogshuttles returns the list of logshuttles for the configuration version.
+func (c *Client) ListLogshuttles(i *ListLogshuttlesInput) ([]*Logshuttle, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle", i.Service, i.Version)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var ls []*Logshuttle
+	if err := decodeJSON(&ls, resp.Body); err != nil {
+		return nil, err
+	}
+	sort.Stable(logshuttlesByName(ls))
+	return ls, nil
+}
+
+// CreateLogshuttleInput is used as input to the CreateLogshuttle function.
+type CreateLogshuttleInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	Name              *string `form:"name,omitempty"`
+	Format            *string `form:"format,omitempty"`
+	FormatVersion     *uint   `form:"format_version,omitempty"`
+	URL               *string `form:"url,omitempty"`
+	Token             *string `form:"token,omitempty"`
+	ResponseCondition *string `form:"response_condition,omitempty"`
+	Placement         *string `form:"placement,omitempty"`
+}
+
+// CreateLogshuttle creates a new Fastly logshuttle.
+func (c *Client) CreateLogshuttle(i *CreateLogshuttleInput) (*Logshuttle, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle", i.Service, i.Version)
+	resp, err := c.PostForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var l *Logshuttle
+	if err := decodeJSON(&l, resp.Body); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// GetLogshuttleInput is used as input to the GetLogshuttle function.
+type GetLogshuttleInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the logshuttle to fetch.
+	Name string
+}
+
+// GetLogshuttle gets the logshuttle configuration with the given parameters.
+func (c *Client) GetLogshuttle(i *GetLogshuttleInput) (*Logshuttle, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle/%s", i.Service, i.Version, url.PathEscape(i.Name))
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var l *Logshuttle
+	if err := decodeJSON(&l, resp.Body); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// UpdateLogshuttleInput is used as input to the UpdateLogshuttle function.
+type UpdateLogshuttleInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the logshuttle to update.
+	Name string
+
+	NewName           *string `form:"name,omitempty"`
+	Format            *string `form:"format,omitempty"`
+	FormatVersion     *uint   `form:"format_version,omitempty"`
+	URL               *string `form:"url,omitempty"`
+	Token             *string `form:"token,omitempty"`
+	ResponseCondition *string `form:"response_condition,omitempty"`
+	Placement         *string `form:"placement,omitempty"`
+}
+
+// UpdateLogshuttle updates a specific logshuttle.
+func (c *Client) UpdateLogshuttle(i *UpdateLogshuttleInput) (*Logshuttle, error) {
+	if i.Service == "" {
+		return nil, ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return nil, ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle/%s", i.Service, i.Version, url.PathEscape(i.Name))
+	resp, err := c.PutForm(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var l *Logshuttle
+	if err := decodeJSON(&l, resp.Body); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// DeleteLogshuttleInput is the input parameter to DeleteLogshuttle.
+type DeleteLogshuttleInput struct {
+	// Service is the ID of the service. Version is the specific configuration
+	// version. Both fields are required.
+	Service string
+	Version int
+
+	// Name is the name of the logshuttle to delete (required).
+	Name string
+}
+
+// DeleteLogshuttle deletes the given logshuttle version.
+func (c *Client) DeleteLogshuttle(i *DeleteLogshuttleInput) error {
+	if i.Service == "" {
+		return ErrMissingService
+	}
+
+	if i.Version == 0 {
+		return ErrMissingVersion
+	}
+
+	if i.Name == "" {
+		return ErrMissingName
+	}
+
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle/%s", i.Service, i.Version, url.PathEscape(i.Name))
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+
+	var r *statusResp
+	if err := decodeJSON(&r, resp.Body); err != nil {
+		return err
+	}
+	if !r.Ok() {
+		return ErrStatusNotOk
+	}
+	return nil
+}

--- a/fastly/logshuttle_test.go
+++ b/fastly/logshuttle_test.go
@@ -1,0 +1,269 @@
+package fastly
+
+import (
+	"testing"
+)
+
+func TestClient_Logshuttles(t *testing.T) {
+	t.Parallel()
+
+	var err error
+	var tv *Version
+	record(t, "logshuttles/version", func(c *Client) {
+		tv = testVersion(t, c)
+	})
+
+	// Create
+	var l *Logshuttle
+	record(t, "logshuttles/create", func(c *Client) {
+		l, err = c.CreateLogshuttle(&CreateLogshuttleInput{
+			Service:       testServiceID,
+			Version:       tv.Number,
+			Name:          String("test-logshuttle"),
+			Format:        String("%h %l %u %t \"%r\" %>s %b"),
+			FormatVersion: Uint(2),
+			Placement:     String("waf_debug"),
+			Token:         String("super-secure-token"),
+			URL:           String("https://logs.example.com"),
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure deleted
+	defer func() {
+		record(t, "logshuttles/cleanup", func(c *Client) {
+			c.DeleteLogshuttle(&DeleteLogshuttleInput{
+				Service: testServiceID,
+				Version: tv.Number,
+				Name:    "test-logshuttle",
+			})
+
+			c.DeleteLogshuttle(&DeleteLogshuttleInput{
+				Service: testServiceID,
+				Version: tv.Number,
+				Name:    "new-test-logshuttle",
+			})
+		})
+	}()
+
+	if l.Name != "test-logshuttle" {
+		t.Errorf("bad name: %q", l.Name)
+	}
+	if l.Format != "%h %l %u %t \"%r\" %>s %b" {
+		t.Errorf("bad format: %q", l.Format)
+	}
+	if l.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", l.FormatVersion)
+	}
+	if l.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", l.Placement)
+	}
+	if l.Token != "super-secure-token" {
+		t.Errorf("bad token: %q", l.Token)
+	}
+	if l.URL != "https://logs.example.com" {
+		t.Errorf("bad url: %q", l.URL)
+	}
+
+	// List
+	var ls []*Logshuttle
+	record(t, "logshuttles/list", func(c *Client) {
+		ls, err = c.ListLogshuttles(&ListLogshuttlesInput{
+			Service: testServiceID,
+			Version: tv.Number,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ls) < 1 {
+		t.Errorf("bad logshuttles: %v", ls)
+	}
+
+	// Get
+	var nl *Logshuttle
+	record(t, "logshuttles/get", func(c *Client) {
+		nl, err = c.GetLogshuttle(&GetLogshuttleInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "test-logshuttle",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.Name != nl.Name {
+		t.Errorf("bad name: %q", l.Name)
+	}
+	if l.Format != nl.Format {
+		t.Errorf("bad format: %q", l.Format)
+	}
+	if l.FormatVersion != nl.FormatVersion {
+		t.Errorf("bad format_version: %q", l.FormatVersion)
+	}
+	if l.Placement != nl.Placement {
+		t.Errorf("bad placement: %q", l.Placement)
+	}
+	if l.Token != nl.Token {
+		t.Errorf("bad token: %q", l.Token)
+	}
+	if l.URL != nl.URL {
+		t.Errorf("bad url: %q", l.URL)
+	}
+
+	// Update
+	var ul *Logshuttle
+	record(t, "logshuttles/update", func(c *Client) {
+		ul, err = c.UpdateLogshuttle(&UpdateLogshuttleInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "test-logshuttle",
+			NewName: String("new-test-logshuttle"),
+			Token:   String("new-token"),
+			URL:     String("https://logs2.example.com"),
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ul.Name != "new-test-logshuttle" {
+		t.Errorf("bad name: %q", ul.Name)
+	}
+	if ul.Token != "new-token" {
+		t.Errorf("bad token: %q", ul.Token)
+	}
+	if ul.URL != "https://logs2.example.com" {
+		t.Errorf("bad url: %q", ul.URL)
+	}
+
+	// Delete
+	record(t, "logshuttles/delete", func(c *Client) {
+		err = c.DeleteLogshuttle(&DeleteLogshuttleInput{
+			Service: testServiceID,
+			Version: tv.Number,
+			Name:    "new-test-logshuttle",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClient_ListLogshuttles_validation(t *testing.T) {
+	var err error
+	_, err = testClient.ListLogshuttles(&ListLogshuttlesInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.ListLogshuttles(&ListLogshuttlesInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_CreateLogshuttle_validation(t *testing.T) {
+	var err error
+	_, err = testClient.CreateLogshuttle(&CreateLogshuttleInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.CreateLogshuttle(&CreateLogshuttleInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_GetLogshuttle_validation(t *testing.T) {
+	var err error
+	_, err = testClient.GetLogshuttle(&GetLogshuttleInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetLogshuttle(&GetLogshuttleInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetLogshuttle(&GetLogshuttleInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "",
+	})
+	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_UpdateLogshuttle_validation(t *testing.T) {
+	var err error
+	_, err = testClient.UpdateLogshuttle(&UpdateLogshuttleInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateLogshuttle(&UpdateLogshuttleInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateLogshuttle(&UpdateLogshuttleInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "",
+	})
+	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DeleteLogshuttle_validation(t *testing.T) {
+	var err error
+	err = testClient.DeleteLogshuttle(&DeleteLogshuttleInput{
+		Service: "",
+	})
+	if err != ErrMissingService {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteLogshuttle(&DeleteLogshuttleInput{
+		Service: "foo",
+		Version: 0,
+	})
+	if err != ErrMissingVersion {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DeleteLogshuttle(&DeleteLogshuttleInput{
+		Service: "foo",
+		Version: 1,
+		Name:    "",
+	})
+	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+}


### PR DESCRIPTION
See [the docs](https://docs.fastly.com/en/guides/log-streaming-log-shuttle) for more information on Log Shuttle logging endpoints.
