### PR TITLE
Add raw access to stats JSON responses

### DIFF
--- a/fastly/acl.go
+++ b/fastly/acl.go
@@ -54,7 +54,7 @@ func (c *Client) ListACLs(i *ListACLsInput) ([]*ACL, error) {
 	}
 
 	var as []*ACL
-	if err := decodeJSON(&as, resp.Body); err != nil {
+	if err := decodeBodyMap(&as, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(ACLsByName(as))
@@ -88,7 +88,7 @@ func (c *Client) CreateACL(i *CreateACLInput) (*ACL, error) {
 	}
 
 	var a *ACL
-	if err := decodeJSON(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(&a, resp.Body); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -126,7 +126,7 @@ func (c *Client) DeleteACL(i *DeleteACLInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -167,7 +167,7 @@ func (c *Client) GetACL(i *GetACLInput) (*ACL, error) {
 	}
 
 	var a *ACL
-	if err := decodeJSON(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(&a, resp.Body); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -213,7 +213,7 @@ func (c *Client) UpdateACL(i *UpdateACLInput) (*ACL, error) {
 	}
 
 	var a *ACL
-	if err := decodeJSON(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(&a, resp.Body); err != nil {
 		return nil, err
 	}
 

--- a/fastly/acl.go
+++ b/fastly/acl.go
@@ -54,7 +54,7 @@ func (c *Client) ListACLs(i *ListACLsInput) ([]*ACL, error) {
 	}
 
 	var as []*ACL
-	if err := decodeBodyMap(&as, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &as); err != nil {
 		return nil, err
 	}
 	sort.Stable(ACLsByName(as))
@@ -88,7 +88,7 @@ func (c *Client) CreateACL(i *CreateACLInput) (*ACL, error) {
 	}
 
 	var a *ACL
-	if err := decodeBodyMap(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -126,7 +126,7 @@ func (c *Client) DeleteACL(i *DeleteACLInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -167,7 +167,7 @@ func (c *Client) GetACL(i *GetACLInput) (*ACL, error) {
 	}
 
 	var a *ACL
-	if err := decodeBodyMap(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -213,7 +213,7 @@ func (c *Client) UpdateACL(i *UpdateACLInput) (*ACL, error) {
 	}
 
 	var a *ACL
-	if err := decodeBodyMap(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -54,7 +54,7 @@ func (c *Client) ListACLEntries(i *ListACLEntriesInput) ([]*ACLEntry, error) {
 	}
 
 	var es []*ACLEntry
-	if err := decodeBodyMap(&es, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &es); err != nil {
 		return nil, err
 	}
 
@@ -92,7 +92,7 @@ func (c *Client) GetACLEntry(i *GetACLEntryInput) (*ACLEntry, error) {
 	}
 
 	var e *ACLEntry
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 
@@ -134,7 +134,7 @@ func (c *Client) CreateACLEntry(i *CreateACLEntryInput) (*ACLEntry, error) {
 	}
 
 	var e *ACLEntry
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 
@@ -170,7 +170,7 @@ func (c *Client) DeleteACLEntry(i *DeleteACLEntryInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 
@@ -218,7 +218,7 @@ func (c *Client) UpdateACLEntry(i *UpdateACLEntryInput) (*ACLEntry, error) {
 	}
 
 	var e *ACLEntry
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 
@@ -262,7 +262,7 @@ func (c *Client) BatchModifyACLEntries(i *BatchModifyACLEntriesInput) error {
 	}
 
 	var batchModifyResult map[string]string
-	if err := decodeBodyMap(&batchModifyResult, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &batchModifyResult); err != nil {
 		return err
 	}
 

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -54,7 +54,7 @@ func (c *Client) ListACLEntries(i *ListACLEntriesInput) ([]*ACLEntry, error) {
 	}
 
 	var es []*ACLEntry
-	if err := decodeJSON(&es, resp.Body); err != nil {
+	if err := decodeBodyMap(&es, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -92,7 +92,7 @@ func (c *Client) GetACLEntry(i *GetACLEntryInput) (*ACLEntry, error) {
 	}
 
 	var e *ACLEntry
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -134,7 +134,7 @@ func (c *Client) CreateACLEntry(i *CreateACLEntryInput) (*ACLEntry, error) {
 	}
 
 	var e *ACLEntry
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -170,7 +170,7 @@ func (c *Client) DeleteACLEntry(i *DeleteACLEntryInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 
@@ -218,7 +218,7 @@ func (c *Client) UpdateACLEntry(i *UpdateACLEntryInput) (*ACLEntry, error) {
 	}
 
 	var e *ACLEntry
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -262,7 +262,7 @@ func (c *Client) BatchModifyACLEntries(i *BatchModifyACLEntriesInput) error {
 	}
 
 	var batchModifyResult map[string]string
-	if err := decodeJSON(&batchModifyResult, resp.Body); err != nil {
+	if err := decodeBodyMap(&batchModifyResult, resp.Body); err != nil {
 		return err
 	}
 

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -80,7 +80,7 @@ func (c *Client) ListBackends(i *ListBackendsInput) ([]*Backend, error) {
 	}
 
 	var bs []*Backend
-	if err := decodeJSON(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(&bs, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(backendsByName(bs))
@@ -139,7 +139,7 @@ func (c *Client) CreateBackend(i *CreateBackendInput) (*Backend, error) {
 	}
 
 	var b *Backend
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -177,7 +177,7 @@ func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
 	}
 
 	var b *Backend
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -242,7 +242,7 @@ func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
 	}
 
 	var b *Backend
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -280,7 +280,7 @@ func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -80,7 +80,7 @@ func (c *Client) ListBackends(i *ListBackendsInput) ([]*Backend, error) {
 	}
 
 	var bs []*Backend
-	if err := decodeBodyMap(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	sort.Stable(backendsByName(bs))
@@ -139,7 +139,7 @@ func (c *Client) CreateBackend(i *CreateBackendInput) (*Backend, error) {
 	}
 
 	var b *Backend
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -177,7 +177,7 @@ func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
 	}
 
 	var b *Backend
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -242,7 +242,7 @@ func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
 	}
 
 	var b *Backend
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -280,7 +280,7 @@ func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/bigquery.go
+++ b/fastly/bigquery.go
@@ -64,7 +64,7 @@ func (c *Client) ListBigQueries(i *ListBigQueriesInput) ([]*BigQuery, error) {
 	}
 
 	var bigQueries []*BigQuery
-	if err := decodeJSON(&bigQueries, resp.Body); err != nil {
+	if err := decodeBodyMap(&bigQueries, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(bigQueriesByName(bigQueries))
@@ -108,7 +108,7 @@ func (c *Client) CreateBigQuery(i *CreateBigQueryInput) (*BigQuery, error) {
 	}
 
 	var bigQuery *BigQuery
-	if err := decodeJSON(&bigQuery, resp.Body); err != nil {
+	if err := decodeBodyMap(&bigQuery, resp.Body); err != nil {
 		return nil, err
 	}
 	return bigQuery, nil
@@ -146,7 +146,7 @@ func (c *Client) GetBigQuery(i *GetBigQueryInput) (*BigQuery, error) {
 	}
 
 	var bigQuery *BigQuery
-	if err := decodeJSON(&bigQuery, resp.Body); err != nil {
+	if err := decodeBodyMap(&bigQuery, resp.Body); err != nil {
 		return nil, err
 	}
 	return bigQuery, nil
@@ -196,7 +196,7 @@ func (c *Client) UpdateBigQuery(i *UpdateBigQueryInput) (*BigQuery, error) {
 	}
 
 	var bigQuery *BigQuery
-	if err := decodeJSON(&bigQuery, resp.Body); err != nil {
+	if err := decodeBodyMap(&bigQuery, resp.Body); err != nil {
 		return nil, err
 	}
 	return bigQuery, nil
@@ -234,7 +234,7 @@ func (c *Client) DeleteBigQuery(i *DeleteBigQueryInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/bigquery.go
+++ b/fastly/bigquery.go
@@ -64,7 +64,7 @@ func (c *Client) ListBigQueries(i *ListBigQueriesInput) ([]*BigQuery, error) {
 	}
 
 	var bigQueries []*BigQuery
-	if err := decodeBodyMap(&bigQueries, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bigQueries); err != nil {
 		return nil, err
 	}
 	sort.Stable(bigQueriesByName(bigQueries))
@@ -108,7 +108,7 @@ func (c *Client) CreateBigQuery(i *CreateBigQueryInput) (*BigQuery, error) {
 	}
 
 	var bigQuery *BigQuery
-	if err := decodeBodyMap(&bigQuery, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bigQuery); err != nil {
 		return nil, err
 	}
 	return bigQuery, nil
@@ -146,7 +146,7 @@ func (c *Client) GetBigQuery(i *GetBigQueryInput) (*BigQuery, error) {
 	}
 
 	var bigQuery *BigQuery
-	if err := decodeBodyMap(&bigQuery, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bigQuery); err != nil {
 		return nil, err
 	}
 	return bigQuery, nil
@@ -196,7 +196,7 @@ func (c *Client) UpdateBigQuery(i *UpdateBigQueryInput) (*BigQuery, error) {
 	}
 
 	var bigQuery *BigQuery
-	if err := decodeBodyMap(&bigQuery, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bigQuery); err != nil {
 		return nil, err
 	}
 	return bigQuery, nil
@@ -234,7 +234,7 @@ func (c *Client) DeleteBigQuery(i *DeleteBigQueryInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/billing.go
+++ b/fastly/billing.go
@@ -74,7 +74,7 @@ func (c *Client) GetBilling(i *GetBillingInput) (*Billing, error) {
 	}
 
 	var b *Billing
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/billing.go
+++ b/fastly/billing.go
@@ -74,7 +74,7 @@ func (c *Client) GetBilling(i *GetBillingInput) (*Billing, error) {
 	}
 
 	var b *Billing
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/blobstorage.go
+++ b/fastly/blobstorage.go
@@ -67,7 +67,7 @@ func (c *Client) ListBlobStorages(i *ListBlobStoragesInput) ([]*BlobStorage, err
 	}
 
 	var as []*BlobStorage
-	if err := decodeJSON(&as, resp.Body); err != nil {
+	if err := decodeBodyMap(&as, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(blobStorageByName(as))
@@ -114,7 +114,7 @@ func (c *Client) CreateBlobStorage(i *CreateBlobStorageInput) (*BlobStorage, err
 	}
 
 	var a *BlobStorage
-	if err := decodeJSON(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(&a, resp.Body); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -152,7 +152,7 @@ func (c *Client) GetBlobStorage(i *GetBlobStorageInput) (*BlobStorage, error) {
 	}
 
 	var a *BlobStorage
-	if err := decodeJSON(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(&a, resp.Body); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -205,7 +205,7 @@ func (c *Client) UpdateBlobStorage(i *UpdateBlobStorageInput) (*BlobStorage, err
 	}
 
 	var a *BlobStorage
-	if err := decodeJSON(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(&a, resp.Body); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -243,7 +243,7 @@ func (c *Client) DeleteBlobStorage(i *DeleteBlobStorageInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/blobstorage.go
+++ b/fastly/blobstorage.go
@@ -67,7 +67,7 @@ func (c *Client) ListBlobStorages(i *ListBlobStoragesInput) ([]*BlobStorage, err
 	}
 
 	var as []*BlobStorage
-	if err := decodeBodyMap(&as, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &as); err != nil {
 		return nil, err
 	}
 	sort.Stable(blobStorageByName(as))
@@ -114,7 +114,7 @@ func (c *Client) CreateBlobStorage(i *CreateBlobStorageInput) (*BlobStorage, err
 	}
 
 	var a *BlobStorage
-	if err := decodeBodyMap(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -152,7 +152,7 @@ func (c *Client) GetBlobStorage(i *GetBlobStorageInput) (*BlobStorage, error) {
 	}
 
 	var a *BlobStorage
-	if err := decodeBodyMap(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -205,7 +205,7 @@ func (c *Client) UpdateBlobStorage(i *UpdateBlobStorageInput) (*BlobStorage, err
 	}
 
 	var a *BlobStorage
-	if err := decodeBodyMap(&a, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -243,7 +243,7 @@ func (c *Client) DeleteBlobStorage(i *DeleteBlobStorageInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/cache_setting.go
+++ b/fastly/cache_setting.go
@@ -73,7 +73,7 @@ func (c *Client) ListCacheSettings(i *ListCacheSettingsInput) ([]*CacheSetting, 
 	}
 
 	var cs []*CacheSetting
-	if err := decodeBodyMap(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	sort.Stable(cacheSettingsByName(cs))
@@ -111,7 +111,7 @@ func (c *Client) CreateCacheSetting(i *CreateCacheSettingInput) (*CacheSetting, 
 	}
 
 	var cs *CacheSetting
-	if err := decodeBodyMap(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -150,7 +150,7 @@ func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error)
 	}
 
 	var cs *CacheSetting
-	if err := decodeBodyMap(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -194,7 +194,7 @@ func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, 
 	}
 
 	var cs *CacheSetting
-	if err := decodeBodyMap(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -232,7 +232,7 @@ func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/cache_setting.go
+++ b/fastly/cache_setting.go
@@ -73,7 +73,7 @@ func (c *Client) ListCacheSettings(i *ListCacheSettingsInput) ([]*CacheSetting, 
 	}
 
 	var cs []*CacheSetting
-	if err := decodeJSON(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(&cs, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(cacheSettingsByName(cs))
@@ -111,7 +111,7 @@ func (c *Client) CreateCacheSetting(i *CreateCacheSettingInput) (*CacheSetting, 
 	}
 
 	var cs *CacheSetting
-	if err := decodeJSON(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(&cs, resp.Body); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -150,7 +150,7 @@ func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error)
 	}
 
 	var cs *CacheSetting
-	if err := decodeJSON(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(&cs, resp.Body); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -194,7 +194,7 @@ func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, 
 	}
 
 	var cs *CacheSetting
-	if err := decodeJSON(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(&cs, resp.Body); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -232,7 +232,7 @@ func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -342,8 +342,9 @@ func checkResp(resp *http.Response, err error) (*http.Response, error) {
 	}
 }
 
-// decodeJSON is used to decode an HTTP response body into an interface as JSON.
-func decodeJSON(out interface{}, body io.ReadCloser) error {
+// decodeBodyMap is used to decode an HTTP response body into a mapstructure struct.
+// It closes `body`.
+func decodeBodyMap(out interface{}, body io.ReadCloser) error {
 	defer body.Close()
 
 	var parsed interface{}
@@ -352,6 +353,12 @@ func decodeJSON(out interface{}, body io.ReadCloser) error {
 		return err
 	}
 
+	return decodeMap(out, parsed)
+}
+
+// decodeMap decodes an `in` struct or map to a mapstructure tagged `out`.
+// It applies the decoder defaults used throughout go-fastly.
+func decodeMap(out interface{}, in interface{}) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			mapToHTTPHeaderHookFunc(),
@@ -363,5 +370,5 @@ func decodeJSON(out interface{}, body io.ReadCloser) error {
 	if err != nil {
 		return err
 	}
-	return decoder.Decode(parsed)
+	return decoder.Decode(in)
 }

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -344,7 +344,7 @@ func checkResp(resp *http.Response, err error) (*http.Response, error) {
 
 // decodeBodyMap is used to decode an HTTP response body into a mapstructure struct.
 // It closes `body`.
-func decodeBodyMap(out interface{}, body io.ReadCloser) error {
+func decodeBodyMap(body io.ReadCloser, out interface{}) error {
 	defer body.Close()
 
 	var parsed interface{}
@@ -353,12 +353,13 @@ func decodeBodyMap(out interface{}, body io.ReadCloser) error {
 		return err
 	}
 
-	return decodeMap(out, parsed)
+	return decodeMap(parsed, out)
 }
 
 // decodeMap decodes an `in` struct or map to a mapstructure tagged `out`.
 // It applies the decoder defaults used throughout go-fastly.
-func decodeMap(out interface{}, in interface{}) error {
+// Note that this uses opposite argument order from Go's copy().
+func decodeMap(in interface{}, out interface{}) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			mapToHTTPHeaderHookFunc(),

--- a/fastly/cloudfiles.go
+++ b/fastly/cloudfiles.go
@@ -68,7 +68,7 @@ func (c *Client) ListCloudfiles(i *ListCloudfilesInput) ([]*Cloudfiles, error) {
 	}
 
 	var cloudfiles []*Cloudfiles
-	if err := decodeJSON(&cloudfiles, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &cloudfiles); err != nil {
 		return nil, err
 	}
 	sort.Stable(cloudfilesByName(cloudfiles))
@@ -116,7 +116,7 @@ func (c *Client) CreateCloudfiles(i *CreateCloudfilesInput) (*Cloudfiles, error)
 	}
 
 	var cloudfiles *Cloudfiles
-	if err := decodeJSON(&cloudfiles, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &cloudfiles); err != nil {
 		return nil, err
 	}
 	return cloudfiles, nil
@@ -154,7 +154,7 @@ func (c *Client) GetCloudfiles(i *GetCloudfilesInput) (*Cloudfiles, error) {
 	}
 
 	var cloudfiles *Cloudfiles
-	if err := decodeJSON(&cloudfiles, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &cloudfiles); err != nil {
 		return nil, err
 	}
 	return cloudfiles, nil
@@ -207,7 +207,7 @@ func (c *Client) UpdateCloudfiles(i *UpdateCloudfilesInput) (*Cloudfiles, error)
 	}
 
 	var cloudfiles *Cloudfiles
-	if err := decodeJSON(&cloudfiles, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &cloudfiles); err != nil {
 		return nil, err
 	}
 	return cloudfiles, nil
@@ -245,7 +245,7 @@ func (c *Client) DeleteCloudfiles(i *DeleteCloudfilesInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/condition.go
+++ b/fastly/condition.go
@@ -58,7 +58,7 @@ func (c *Client) ListConditions(i *ListConditionsInput) ([]*Condition, error) {
 	}
 
 	var cs []*Condition
-	if err := decodeJSON(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(&cs, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(conditionsByName(cs))
@@ -95,7 +95,7 @@ func (c *Client) CreateCondition(i *CreateConditionInput) (*Condition, error) {
 	}
 
 	var co *Condition
-	if err := decodeJSON(&co, resp.Body); err != nil {
+	if err := decodeBodyMap(&co, resp.Body); err != nil {
 		return nil, err
 	}
 	return co, nil
@@ -133,7 +133,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 	}
 
 	var co *Condition
-	if err := decodeJSON(&co, resp.Body); err != nil {
+	if err := decodeBodyMap(&co, resp.Body); err != nil {
 		return nil, err
 	}
 	return co, nil
@@ -176,7 +176,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 	}
 
 	var co *Condition
-	if err := decodeJSON(&co, resp.Body); err != nil {
+	if err := decodeBodyMap(&co, resp.Body); err != nil {
 		return nil, err
 	}
 	return co, nil
@@ -214,7 +214,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/condition.go
+++ b/fastly/condition.go
@@ -58,7 +58,7 @@ func (c *Client) ListConditions(i *ListConditionsInput) ([]*Condition, error) {
 	}
 
 	var cs []*Condition
-	if err := decodeBodyMap(&cs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	sort.Stable(conditionsByName(cs))
@@ -95,7 +95,7 @@ func (c *Client) CreateCondition(i *CreateConditionInput) (*Condition, error) {
 	}
 
 	var co *Condition
-	if err := decodeBodyMap(&co, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &co); err != nil {
 		return nil, err
 	}
 	return co, nil
@@ -133,7 +133,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 	}
 
 	var co *Condition
-	if err := decodeBodyMap(&co, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &co); err != nil {
 		return nil, err
 	}
 	return co, nil
@@ -176,7 +176,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 	}
 
 	var co *Condition
-	if err := decodeBodyMap(&co, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &co); err != nil {
 		return nil, err
 	}
 	return co, nil
@@ -214,7 +214,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/content.go
+++ b/fastly/content.go
@@ -42,7 +42,7 @@ func (c *Client) EdgeCheck(i *EdgeCheckInput) ([]*EdgeCheck, error) {
 	}
 
 	var e []*EdgeCheck
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil

--- a/fastly/content.go
+++ b/fastly/content.go
@@ -42,7 +42,7 @@ func (c *Client) EdgeCheck(i *EdgeCheckInput) ([]*EdgeCheck, error) {
 	}
 
 	var e []*EdgeCheck
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 	return e, nil

--- a/fastly/dictionary.go
+++ b/fastly/dictionary.go
@@ -56,7 +56,7 @@ func (c *Client) ListDictionaries(i *ListDictionariesInput) ([]*Dictionary, erro
 	}
 
 	var bs []*Dictionary
-	if err := decodeJSON(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(&bs, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(dictionariesByName(bs))
@@ -91,7 +91,7 @@ func (c *Client) CreateDictionary(i *CreateDictionaryInput) (*Dictionary, error)
 	}
 
 	var b *Dictionary
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -129,7 +129,7 @@ func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
 	}
 
 	var b *Dictionary
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -170,7 +170,7 @@ func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error)
 	}
 
 	var b *Dictionary
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/dictionary.go
+++ b/fastly/dictionary.go
@@ -56,7 +56,7 @@ func (c *Client) ListDictionaries(i *ListDictionariesInput) ([]*Dictionary, erro
 	}
 
 	var bs []*Dictionary
-	if err := decodeBodyMap(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	sort.Stable(dictionariesByName(bs))
@@ -91,7 +91,7 @@ func (c *Client) CreateDictionary(i *CreateDictionaryInput) (*Dictionary, error)
 	}
 
 	var b *Dictionary
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -129,7 +129,7 @@ func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
 	}
 
 	var b *Dictionary
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -170,7 +170,7 @@ func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error)
 	}
 
 	var b *Dictionary
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/dictionary_info.go
+++ b/fastly/dictionary_info.go
@@ -50,7 +50,7 @@ func (c *Client) GetDictionaryInfo(i *GetDictionaryInfoInput) (*DictionaryInfo, 
 	}
 
 	var b *DictionaryInfo
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/dictionary_info.go
+++ b/fastly/dictionary_info.go
@@ -50,7 +50,7 @@ func (c *Client) GetDictionaryInfo(i *GetDictionaryInfoInput) (*DictionaryInfo, 
 	}
 
 	var b *DictionaryInfo
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -56,7 +56,7 @@ func (c *Client) ListDictionaryItems(i *ListDictionaryItemsInput) ([]*Dictionary
 	}
 
 	var bs []*DictionaryItem
-	if err := decodeJSON(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(&bs, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(dictionaryItemsByKey(bs))
@@ -91,7 +91,7 @@ func (c *Client) CreateDictionaryItem(i *CreateDictionaryItemInput) (*Dictionary
 	}
 
 	var b *DictionaryItem
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -143,7 +143,7 @@ func (c *Client) GetDictionaryItem(i *GetDictionaryItemInput) (*DictionaryItem, 
 	}
 
 	var b *DictionaryItem
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -183,7 +183,7 @@ func (c *Client) UpdateDictionaryItem(i *UpdateDictionaryItemInput) (*Dictionary
 	}
 
 	var b *DictionaryItem
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -225,7 +225,7 @@ func (c *Client) BatchModifyDictionaryItems(i *BatchModifyDictionaryItemsInput) 
 	}
 
 	var batchModifyResult map[string]string
-	if err := decodeJSON(&batchModifyResult, resp.Body); err != nil {
+	if err := decodeBodyMap(&batchModifyResult, resp.Body); err != nil {
 		return err
 	}
 

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -56,7 +56,7 @@ func (c *Client) ListDictionaryItems(i *ListDictionaryItemsInput) ([]*Dictionary
 	}
 
 	var bs []*DictionaryItem
-	if err := decodeBodyMap(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	sort.Stable(dictionaryItemsByKey(bs))
@@ -91,7 +91,7 @@ func (c *Client) CreateDictionaryItem(i *CreateDictionaryItemInput) (*Dictionary
 	}
 
 	var b *DictionaryItem
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -143,7 +143,7 @@ func (c *Client) GetDictionaryItem(i *GetDictionaryItemInput) (*DictionaryItem, 
 	}
 
 	var b *DictionaryItem
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -183,7 +183,7 @@ func (c *Client) UpdateDictionaryItem(i *UpdateDictionaryItemInput) (*Dictionary
 	}
 
 	var b *DictionaryItem
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -225,7 +225,7 @@ func (c *Client) BatchModifyDictionaryItems(i *BatchModifyDictionaryItemsInput) 
 	}
 
 	var batchModifyResult map[string]string
-	if err := decodeBodyMap(&batchModifyResult, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &batchModifyResult); err != nil {
 		return err
 	}
 

--- a/fastly/diff.go
+++ b/fastly/diff.go
@@ -50,7 +50,7 @@ func (c *Client) GetDiff(i *GetDiffInput) (*Diff, error) {
 	}
 
 	var d *Diff
-	if err := decodeBodyMap(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil

--- a/fastly/diff.go
+++ b/fastly/diff.go
@@ -50,7 +50,7 @@ func (c *Client) GetDiff(i *GetDiffInput) (*Diff, error) {
 	}
 
 	var d *Diff
-	if err := decodeJSON(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(&d, resp.Body); err != nil {
 		return nil, err
 	}
 	return d, nil

--- a/fastly/director.go
+++ b/fastly/director.go
@@ -77,7 +77,7 @@ func (c *Client) ListDirectors(i *ListDirectorsInput) ([]*Director, error) {
 	}
 
 	var ds []*Director
-	if err := decodeJSON(&ds, resp.Body); err != nil {
+	if err := decodeBodyMap(&ds, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(directorsByName(ds))
@@ -117,7 +117,7 @@ func (c *Client) CreateDirector(i *CreateDirectorInput) (*Director, error) {
 	}
 
 	var d *Director
-	if err := decodeJSON(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(&d, resp.Body); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -155,7 +155,7 @@ func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
 	}
 
 	var d *Director
-	if err := decodeJSON(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(&d, resp.Body); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -201,7 +201,7 @@ func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
 	}
 
 	var d *Director
-	if err := decodeJSON(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(&d, resp.Body); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -239,7 +239,7 @@ func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/director.go
+++ b/fastly/director.go
@@ -77,7 +77,7 @@ func (c *Client) ListDirectors(i *ListDirectorsInput) ([]*Director, error) {
 	}
 
 	var ds []*Director
-	if err := decodeBodyMap(&ds, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ds); err != nil {
 		return nil, err
 	}
 	sort.Stable(directorsByName(ds))
@@ -117,7 +117,7 @@ func (c *Client) CreateDirector(i *CreateDirectorInput) (*Director, error) {
 	}
 
 	var d *Director
-	if err := decodeBodyMap(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -155,7 +155,7 @@ func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
 	}
 
 	var d *Director
-	if err := decodeBodyMap(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -201,7 +201,7 @@ func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
 	}
 
 	var d *Director
-	if err := decodeBodyMap(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -239,7 +239,7 @@ func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/director_backend.go
+++ b/fastly/director_backend.go
@@ -60,7 +60,7 @@ func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*Director
 	}
 
 	var b *DirectorBackend
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -106,7 +106,7 @@ func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBacken
 	}
 
 	var b *DirectorBackend
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -152,7 +152,7 @@ func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/director_backend.go
+++ b/fastly/director_backend.go
@@ -60,7 +60,7 @@ func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*Director
 	}
 
 	var b *DirectorBackend
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -106,7 +106,7 @@ func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBacken
 	}
 
 	var b *DirectorBackend
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -152,7 +152,7 @@ func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/domain.go
+++ b/fastly/domain.go
@@ -54,7 +54,7 @@ func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 	}
 
 	var ds []*Domain
-	if err := decodeBodyMap(&ds, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ds); err != nil {
 		return nil, err
 	}
 	sort.Stable(domainsByName(ds))
@@ -92,7 +92,7 @@ func (c *Client) CreateDomain(i *CreateDomainInput) (*Domain, error) {
 	}
 
 	var d *Domain
-	if err := decodeBodyMap(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -130,7 +130,7 @@ func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
 	}
 
 	var d *Domain
-	if err := decodeBodyMap(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -175,7 +175,7 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 	}
 
 	var d *Domain
-	if err := decodeBodyMap(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil

--- a/fastly/domain.go
+++ b/fastly/domain.go
@@ -54,7 +54,7 @@ func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 	}
 
 	var ds []*Domain
-	if err := decodeJSON(&ds, resp.Body); err != nil {
+	if err := decodeBodyMap(&ds, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(domainsByName(ds))
@@ -92,7 +92,7 @@ func (c *Client) CreateDomain(i *CreateDomainInput) (*Domain, error) {
 	}
 
 	var d *Domain
-	if err := decodeJSON(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(&d, resp.Body); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -130,7 +130,7 @@ func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
 	}
 
 	var d *Domain
-	if err := decodeJSON(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(&d, resp.Body); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -175,7 +175,7 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 	}
 
 	var d *Domain
-	if err := decodeJSON(&d, resp.Body); err != nil {
+	if err := decodeBodyMap(&d, resp.Body); err != nil {
 		return nil, err
 	}
 	return d, nil

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -194,12 +194,12 @@ func NewHTTPError(resp *http.Response) *HTTPError {
 
 	// If this is a jsonapi response, decode it accordingly
 	if resp.Header.Get("Content-Type") == jsonapi.MediaType {
-		if err := decodeBodyMap(&e, resp.Body); err != nil {
+		if err := decodeBodyMap(resp.Body, &e); err != nil {
 			panic(err)
 		}
 	} else {
 		var lerr *legacyError
-		decodeBodyMap(&lerr, resp.Body)
+		decodeBodyMap(resp.Body, &lerr)
 		if lerr != nil {
 			e.Errors = append(e.Errors, &ErrorObject{
 				Title:  lerr.Message,

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -194,12 +194,12 @@ func NewHTTPError(resp *http.Response) *HTTPError {
 
 	// If this is a jsonapi response, decode it accordingly
 	if resp.Header.Get("Content-Type") == jsonapi.MediaType {
-		if err := decodeJSON(&e, resp.Body); err != nil {
+		if err := decodeBodyMap(&e, resp.Body); err != nil {
 			panic(err)
 		}
 	} else {
 		var lerr *legacyError
-		decodeJSON(&lerr, resp.Body)
+		decodeBodyMap(&lerr, resp.Body)
 		if lerr != nil {
 			e.Errors = append(e.Errors, &ErrorObject{
 				Title:  lerr.Message,

--- a/fastly/ftp.go
+++ b/fastly/ftp.go
@@ -66,7 +66,7 @@ func (c *Client) ListFTPs(i *ListFTPsInput) ([]*FTP, error) {
 	}
 
 	var ftps []*FTP
-	if err := decodeBodyMap(&ftps, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ftps); err != nil {
 		return nil, err
 	}
 	sort.Stable(ftpsByName(ftps))
@@ -112,7 +112,7 @@ func (c *Client) CreateFTP(i *CreateFTPInput) (*FTP, error) {
 	}
 
 	var ftp *FTP
-	if err := decodeBodyMap(&ftp, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ftp); err != nil {
 		return nil, err
 	}
 	return ftp, nil
@@ -150,7 +150,7 @@ func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
 	}
 
 	var b *FTP
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -202,7 +202,7 @@ func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
 	}
 
 	var b *FTP
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -240,7 +240,7 @@ func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/ftp.go
+++ b/fastly/ftp.go
@@ -66,7 +66,7 @@ func (c *Client) ListFTPs(i *ListFTPsInput) ([]*FTP, error) {
 	}
 
 	var ftps []*FTP
-	if err := decodeJSON(&ftps, resp.Body); err != nil {
+	if err := decodeBodyMap(&ftps, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(ftpsByName(ftps))
@@ -112,7 +112,7 @@ func (c *Client) CreateFTP(i *CreateFTPInput) (*FTP, error) {
 	}
 
 	var ftp *FTP
-	if err := decodeJSON(&ftp, resp.Body); err != nil {
+	if err := decodeBodyMap(&ftp, resp.Body); err != nil {
 		return nil, err
 	}
 	return ftp, nil
@@ -150,7 +150,7 @@ func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
 	}
 
 	var b *FTP
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -202,7 +202,7 @@ func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
 	}
 
 	var b *FTP
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -240,7 +240,7 @@ func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/gcs.go
+++ b/fastly/gcs.go
@@ -66,7 +66,7 @@ func (c *Client) ListGCSs(i *ListGCSsInput) ([]*GCS, error) {
 	}
 
 	var gcses []*GCS
-	if err := decodeBodyMap(&gcses, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &gcses); err != nil {
 		return nil, err
 	}
 	sort.Stable(gcsesByName(gcses))
@@ -112,7 +112,7 @@ func (c *Client) CreateGCS(i *CreateGCSInput) (*GCS, error) {
 	}
 
 	var gcs *GCS
-	if err := decodeBodyMap(&gcs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &gcs); err != nil {
 		return nil, err
 	}
 	return gcs, nil
@@ -150,7 +150,7 @@ func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
 	}
 
 	var b *GCS
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -201,7 +201,7 @@ func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
 	}
 
 	var b *GCS
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -239,7 +239,7 @@ func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/gcs.go
+++ b/fastly/gcs.go
@@ -66,7 +66,7 @@ func (c *Client) ListGCSs(i *ListGCSsInput) ([]*GCS, error) {
 	}
 
 	var gcses []*GCS
-	if err := decodeJSON(&gcses, resp.Body); err != nil {
+	if err := decodeBodyMap(&gcses, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(gcsesByName(gcses))
@@ -112,7 +112,7 @@ func (c *Client) CreateGCS(i *CreateGCSInput) (*GCS, error) {
 	}
 
 	var gcs *GCS
-	if err := decodeJSON(&gcs, resp.Body); err != nil {
+	if err := decodeBodyMap(&gcs, resp.Body); err != nil {
 		return nil, err
 	}
 	return gcs, nil
@@ -150,7 +150,7 @@ func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
 	}
 
 	var b *GCS
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -201,7 +201,7 @@ func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
 	}
 
 	var b *GCS
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -239,7 +239,7 @@ func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/gzip.go
+++ b/fastly/gzip.go
@@ -57,7 +57,7 @@ func (c *Client) ListGzips(i *ListGzipsInput) ([]*Gzip, error) {
 	}
 
 	var gzips []*Gzip
-	if err := decodeJSON(&gzips, resp.Body); err != nil {
+	if err := decodeBodyMap(&gzips, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(gzipsByName(gzips))
@@ -94,7 +94,7 @@ func (c *Client) CreateGzip(i *CreateGzipInput) (*Gzip, error) {
 	}
 
 	var gzip *Gzip
-	if err := decodeJSON(&gzip, resp.Body); err != nil {
+	if err := decodeBodyMap(&gzip, resp.Body); err != nil {
 		return nil, err
 	}
 	return gzip, nil
@@ -132,7 +132,7 @@ func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
 	}
 
 	var b *Gzip
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -175,7 +175,7 @@ func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
 	}
 
 	var b *Gzip
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -213,7 +213,7 @@ func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/gzip.go
+++ b/fastly/gzip.go
@@ -57,7 +57,7 @@ func (c *Client) ListGzips(i *ListGzipsInput) ([]*Gzip, error) {
 	}
 
 	var gzips []*Gzip
-	if err := decodeBodyMap(&gzips, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &gzips); err != nil {
 		return nil, err
 	}
 	sort.Stable(gzipsByName(gzips))
@@ -94,7 +94,7 @@ func (c *Client) CreateGzip(i *CreateGzipInput) (*Gzip, error) {
 	}
 
 	var gzip *Gzip
-	if err := decodeBodyMap(&gzip, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &gzip); err != nil {
 		return nil, err
 	}
 	return gzip, nil
@@ -132,7 +132,7 @@ func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
 	}
 
 	var b *Gzip
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -175,7 +175,7 @@ func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
 	}
 
 	var b *Gzip
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -213,7 +213,7 @@ func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/header.go
+++ b/fastly/header.go
@@ -108,7 +108,7 @@ func (c *Client) ListHeaders(i *ListHeadersInput) ([]*Header, error) {
 	}
 
 	var bs []*Header
-	if err := decodeBodyMap(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	sort.Stable(headersByName(bs))
@@ -153,7 +153,7 @@ func (c *Client) CreateHeader(i *CreateHeaderInput) (*Header, error) {
 	}
 
 	var b *Header
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -191,7 +191,7 @@ func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
 	}
 
 	var b *Header
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -242,7 +242,7 @@ func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
 	}
 
 	var b *Header
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -280,7 +280,7 @@ func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/header.go
+++ b/fastly/header.go
@@ -108,7 +108,7 @@ func (c *Client) ListHeaders(i *ListHeadersInput) ([]*Header, error) {
 	}
 
 	var bs []*Header
-	if err := decodeJSON(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(&bs, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(headersByName(bs))
@@ -153,7 +153,7 @@ func (c *Client) CreateHeader(i *CreateHeaderInput) (*Header, error) {
 	}
 
 	var b *Header
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -191,7 +191,7 @@ func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
 	}
 
 	var b *Header
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -242,7 +242,7 @@ func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
 	}
 
 	var b *Header
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -280,7 +280,7 @@ func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/health_check.go
+++ b/fastly/health_check.go
@@ -66,7 +66,7 @@ func (c *Client) ListHealthChecks(i *ListHealthChecksInput) ([]*HealthCheck, err
 	}
 
 	var hcs []*HealthCheck
-	if err := decodeJSON(&hcs, resp.Body); err != nil {
+	if err := decodeBodyMap(&hcs, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(healthChecksByName(hcs))
@@ -111,7 +111,7 @@ func (c *Client) CreateHealthCheck(i *CreateHealthCheckInput) (*HealthCheck, err
 	}
 
 	var h *HealthCheck
-	if err := decodeJSON(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(&h, resp.Body); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -149,7 +149,7 @@ func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
 	}
 
 	var h *HealthCheck
-	if err := decodeJSON(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(&h, resp.Body); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -200,7 +200,7 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 	}
 
 	var h *HealthCheck
-	if err := decodeJSON(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(&h, resp.Body); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -238,7 +238,7 @@ func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/health_check.go
+++ b/fastly/health_check.go
@@ -66,7 +66,7 @@ func (c *Client) ListHealthChecks(i *ListHealthChecksInput) ([]*HealthCheck, err
 	}
 
 	var hcs []*HealthCheck
-	if err := decodeBodyMap(&hcs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &hcs); err != nil {
 		return nil, err
 	}
 	sort.Stable(healthChecksByName(hcs))
@@ -111,7 +111,7 @@ func (c *Client) CreateHealthCheck(i *CreateHealthCheckInput) (*HealthCheck, err
 	}
 
 	var h *HealthCheck
-	if err := decodeBodyMap(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -149,7 +149,7 @@ func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
 	}
 
 	var h *HealthCheck
-	if err := decodeBodyMap(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -200,7 +200,7 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 	}
 
 	var h *HealthCheck
-	if err := decodeBodyMap(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -238,7 +238,7 @@ func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/https.go
+++ b/fastly/https.go
@@ -71,7 +71,7 @@ func (c *Client) ListHTTPS(i *ListHTTPSInput) ([]*HTTPS, error) {
 	}
 
 	var https []*HTTPS
-	if err := decodeJSON(&https, resp.Body); err != nil {
+	if err := decodeBodyMap(&https, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(httpsByName(https))
@@ -122,7 +122,7 @@ func (c *Client) CreateHTTPS(i *CreateHTTPSInput) (*HTTPS, error) {
 	}
 
 	var https *HTTPS
-	if err := decodeJSON(&https, resp.Body); err != nil {
+	if err := decodeBodyMap(&https, resp.Body); err != nil {
 		return nil, err
 	}
 	return https, nil
@@ -159,7 +159,7 @@ func (c *Client) GetHTTPS(i *GetHTTPSInput) (*HTTPS, error) {
 	}
 
 	var h *HTTPS
-	if err := decodeJSON(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(&h, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -215,7 +215,7 @@ func (c *Client) UpdateHTTPS(i *UpdateHTTPSInput) (*HTTPS, error) {
 	}
 
 	var h *HTTPS
-	if err := decodeJSON(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(&h, resp.Body); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -251,7 +251,7 @@ func (c *Client) DeleteHTTPS(i *DeleteHTTPSInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/https.go
+++ b/fastly/https.go
@@ -71,7 +71,7 @@ func (c *Client) ListHTTPS(i *ListHTTPSInput) ([]*HTTPS, error) {
 	}
 
 	var https []*HTTPS
-	if err := decodeBodyMap(&https, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &https); err != nil {
 		return nil, err
 	}
 	sort.Stable(httpsByName(https))
@@ -122,7 +122,7 @@ func (c *Client) CreateHTTPS(i *CreateHTTPSInput) (*HTTPS, error) {
 	}
 
 	var https *HTTPS
-	if err := decodeBodyMap(&https, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &https); err != nil {
 		return nil, err
 	}
 	return https, nil
@@ -159,7 +159,7 @@ func (c *Client) GetHTTPS(i *GetHTTPSInput) (*HTTPS, error) {
 	}
 
 	var h *HTTPS
-	if err := decodeBodyMap(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 
@@ -215,7 +215,7 @@ func (c *Client) UpdateHTTPS(i *UpdateHTTPSInput) (*HTTPS, error) {
 	}
 
 	var h *HTTPS
-	if err := decodeBodyMap(&h, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -251,7 +251,7 @@ func (c *Client) DeleteHTTPS(i *DeleteHTTPSInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/ip.go
+++ b/fastly/ip.go
@@ -11,7 +11,7 @@ func (c *Client) IPs() (IPAddrs, error) {
 	}
 
 	var m map[string][]string
-	if err := decodeBodyMap(&m, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &m); err != nil {
 		return nil, err
 	}
 	return IPAddrs(m["addresses"]), nil

--- a/fastly/ip.go
+++ b/fastly/ip.go
@@ -11,7 +11,7 @@ func (c *Client) IPs() (IPAddrs, error) {
 	}
 
 	var m map[string][]string
-	if err := decodeJSON(&m, resp.Body); err != nil {
+	if err := decodeBodyMap(&m, resp.Body); err != nil {
 		return nil, err
 	}
 	return IPAddrs(m["addresses"]), nil

--- a/fastly/logentries.go
+++ b/fastly/logentries.go
@@ -61,7 +61,7 @@ func (c *Client) ListLogentries(i *ListLogentriesInput) ([]*Logentries, error) {
 	}
 
 	var ls []*Logentries
-	if err := decodeBodyMap(&ls, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ls); err != nil {
 		return nil, err
 	}
 	sort.Stable(logentriesByName(ls))
@@ -102,7 +102,7 @@ func (c *Client) CreateLogentries(i *CreateLogentriesInput) (*Logentries, error)
 	}
 
 	var l *Logentries
-	if err := decodeBodyMap(&l, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -140,7 +140,7 @@ func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
 	}
 
 	var l *Logentries
-	if err := decodeBodyMap(&l, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -187,7 +187,7 @@ func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error)
 	}
 
 	var l *Logentries
-	if err := decodeBodyMap(&l, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -225,7 +225,7 @@ func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logentries.go
+++ b/fastly/logentries.go
@@ -61,7 +61,7 @@ func (c *Client) ListLogentries(i *ListLogentriesInput) ([]*Logentries, error) {
 	}
 
 	var ls []*Logentries
-	if err := decodeJSON(&ls, resp.Body); err != nil {
+	if err := decodeBodyMap(&ls, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(logentriesByName(ls))
@@ -102,7 +102,7 @@ func (c *Client) CreateLogentries(i *CreateLogentriesInput) (*Logentries, error)
 	}
 
 	var l *Logentries
-	if err := decodeJSON(&l, resp.Body); err != nil {
+	if err := decodeBodyMap(&l, resp.Body); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -140,7 +140,7 @@ func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
 	}
 
 	var l *Logentries
-	if err := decodeJSON(&l, resp.Body); err != nil {
+	if err := decodeBodyMap(&l, resp.Body); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -187,7 +187,7 @@ func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error)
 	}
 
 	var l *Logentries
-	if err := decodeJSON(&l, resp.Body); err != nil {
+	if err := decodeBodyMap(&l, resp.Body); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -225,7 +225,7 @@ func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/papertrail.go
+++ b/fastly/papertrail.go
@@ -60,7 +60,7 @@ func (c *Client) ListPapertrails(i *ListPapertrailsInput) ([]*Papertrail, error)
 	}
 
 	var ps []*Papertrail
-	if err := decodeBodyMap(&ps, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ps); err != nil {
 		return nil, err
 	}
 	sort.Stable(papertrailsByName(ps))
@@ -103,7 +103,7 @@ func (c *Client) CreatePapertrail(i *CreatePapertrailInput) (*Papertrail, error)
 	}
 
 	var p *Papertrail
-	if err := decodeBodyMap(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -141,7 +141,7 @@ func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
 	}
 
 	var p *Papertrail
-	if err := decodeBodyMap(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -190,7 +190,7 @@ func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error)
 	}
 
 	var p *Papertrail
-	if err := decodeBodyMap(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -228,7 +228,7 @@ func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/papertrail.go
+++ b/fastly/papertrail.go
@@ -60,7 +60,7 @@ func (c *Client) ListPapertrails(i *ListPapertrailsInput) ([]*Papertrail, error)
 	}
 
 	var ps []*Papertrail
-	if err := decodeJSON(&ps, resp.Body); err != nil {
+	if err := decodeBodyMap(&ps, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(papertrailsByName(ps))
@@ -103,7 +103,7 @@ func (c *Client) CreatePapertrail(i *CreatePapertrailInput) (*Papertrail, error)
 	}
 
 	var p *Papertrail
-	if err := decodeJSON(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(&p, resp.Body); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -141,7 +141,7 @@ func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
 	}
 
 	var p *Papertrail
-	if err := decodeJSON(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(&p, resp.Body); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -190,7 +190,7 @@ func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error)
 	}
 
 	var p *Papertrail
-	if err := decodeJSON(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(&p, resp.Body); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -228,7 +228,7 @@ func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/pool.go
+++ b/fastly/pool.go
@@ -89,7 +89,7 @@ func (c *Client) ListPools(i *ListPoolsInput) ([]*Pool, error) {
 	}
 
 	var ps []*Pool
-	if err := decodeJSON(&ps, resp.Body); err != nil {
+	if err := decodeBodyMap(&ps, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(poolsByName(ps))
@@ -150,7 +150,7 @@ func (c *Client) CreatePool(i *CreatePoolInput) (*Pool, error) {
 	}
 
 	var p *Pool
-	if err := decodeJSON(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(&p, resp.Body); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -189,7 +189,7 @@ func (c *Client) GetPool(i *GetPoolInput) (*Pool, error) {
 	}
 
 	var p *Pool
-	if err := decodeJSON(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(&p, resp.Body); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -249,7 +249,7 @@ func (c *Client) UpdatePool(i *UpdatePoolInput) (*Pool, error) {
 	}
 
 	var p *Pool
-	if err := decodeJSON(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(&p, resp.Body); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -287,7 +287,7 @@ func (c *Client) DeletePool(i *DeletePoolInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/pool.go
+++ b/fastly/pool.go
@@ -89,7 +89,7 @@ func (c *Client) ListPools(i *ListPoolsInput) ([]*Pool, error) {
 	}
 
 	var ps []*Pool
-	if err := decodeBodyMap(&ps, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ps); err != nil {
 		return nil, err
 	}
 	sort.Stable(poolsByName(ps))
@@ -150,7 +150,7 @@ func (c *Client) CreatePool(i *CreatePoolInput) (*Pool, error) {
 	}
 
 	var p *Pool
-	if err := decodeBodyMap(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -189,7 +189,7 @@ func (c *Client) GetPool(i *GetPoolInput) (*Pool, error) {
 	}
 
 	var p *Pool
-	if err := decodeBodyMap(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -249,7 +249,7 @@ func (c *Client) UpdatePool(i *UpdatePoolInput) (*Pool, error) {
 	}
 
 	var p *Pool
-	if err := decodeBodyMap(&p, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -287,7 +287,7 @@ func (c *Client) DeletePool(i *DeletePoolInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -38,7 +38,7 @@ func (c *Client) Purge(i *PurgeInput) (*Purge, error) {
 	}
 
 	var r *Purge
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -85,7 +85,7 @@ func (c *Client) PurgeKey(i *PurgeKeyInput) (*Purge, error) {
 	}
 
 	var r *Purge
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -122,7 +122,7 @@ func (c *Client) PurgeAll(i *PurgeAllInput) (*Purge, error) {
 	}
 
 	var r *Purge
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return nil, err
 	}
 	return r, nil

--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -38,7 +38,7 @@ func (c *Client) Purge(i *PurgeInput) (*Purge, error) {
 	}
 
 	var r *Purge
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -85,7 +85,7 @@ func (c *Client) PurgeKey(i *PurgeKeyInput) (*Purge, error) {
 	}
 
 	var r *Purge
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -122,7 +122,7 @@ func (c *Client) PurgeAll(i *PurgeAllInput) (*Purge, error) {
 	}
 
 	var r *Purge
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return nil, err
 	}
 	return r, nil

--- a/fastly/realtime_stats.go
+++ b/fastly/realtime_stats.go
@@ -46,7 +46,7 @@ func (c *RTSClient) GetRealtimeStats(i *GetRealtimeStatsInput) (*RealtimeStatsRe
 	}
 
 	var s *RealtimeStatsResponse
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil

--- a/fastly/realtime_stats.go
+++ b/fastly/realtime_stats.go
@@ -1,8 +1,11 @@
 package fastly
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
-// RealtimeStats is a response from Fastly's real-time analytics endpoint
+// RealtimeStatsResponse is a response from Fastly's real-time analytics endpoint
 type RealtimeStatsResponse struct {
 	Timestamp      uint64          `mapstructure:"Timestamp"`
 	Data           []*RealtimeData `mapstructure:"Data"`
@@ -30,8 +33,22 @@ type GetRealtimeStatsInput struct {
 // a timestamp which should be passed to the next call and so on.
 // More details at https://docs.fastly.com/api/analytics
 func (c *RTSClient) GetRealtimeStats(i *GetRealtimeStatsInput) (*RealtimeStatsResponse, error) {
+	var resp interface{}
+	if err := c.GetRealtimeStatsJSON(&resp, i); err != nil {
+		return nil, err
+	}
+
+	var s *RealtimeStatsResponse
+	if err := decodeMap(&s, resp); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// GetRealtimeStatsJSON fetches stats and decodes the response directly to the JSON struct dst.
+func (c *RTSClient) GetRealtimeStatsJSON(dst interface{}, i *GetRealtimeStatsInput) error {
 	if i.Service == "" {
-		return nil, ErrMissingService
+		return ErrMissingService
 	}
 
 	path := fmt.Sprintf("/v1/channel/%s/ts/%d", i.Service, i.Timestamp)
@@ -42,12 +59,9 @@ func (c *RTSClient) GetRealtimeStats(i *GetRealtimeStatsInput) (*RealtimeStatsRe
 
 	resp, err := c.client.Get(path, nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
+	defer resp.Body.Close()
 
-	var s *RealtimeStatsResponse
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
-		return nil, err
-	}
-	return s, nil
+	return json.NewDecoder(resp.Body).Decode(dst)
 }

--- a/fastly/realtime_stats.go
+++ b/fastly/realtime_stats.go
@@ -34,19 +34,19 @@ type GetRealtimeStatsInput struct {
 // More details at https://docs.fastly.com/api/analytics
 func (c *RTSClient) GetRealtimeStats(i *GetRealtimeStatsInput) (*RealtimeStatsResponse, error) {
 	var resp interface{}
-	if err := c.GetRealtimeStatsJSON(&resp, i); err != nil {
+	if err := c.GetRealtimeStatsJSON(i, &resp); err != nil {
 		return nil, err
 	}
 
 	var s *RealtimeStatsResponse
-	if err := decodeMap(&s, resp); err != nil {
+	if err := decodeMap(resp, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
 }
 
 // GetRealtimeStatsJSON fetches stats and decodes the response directly to the JSON struct dst.
-func (c *RTSClient) GetRealtimeStatsJSON(dst interface{}, i *GetRealtimeStatsInput) error {
+func (c *RTSClient) GetRealtimeStatsJSON(i *GetRealtimeStatsInput, dst interface{}) error {
 	if i.Service == "" {
 		return ErrMissingService
 	}

--- a/fastly/realtime_stats_test.go
+++ b/fastly/realtime_stats_test.go
@@ -41,11 +41,11 @@ func TestStatsClient_GetRealtimeStatsJSON(t *testing.T) {
 
 	var err error
 	recordRealtimeStats(t, "realtime_stats/get", func(c *RTSClient) {
-		err = c.GetRealtimeStatsJSON(&ret, &GetRealtimeStatsInput{
+		err = c.GetRealtimeStatsJSON(&GetRealtimeStatsInput{
 			Service:   testServiceID,
 			Timestamp: 0,
 			Limit:     3,
-		})
+		}, &ret)
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/fastly/realtime_stats_test.go
+++ b/fastly/realtime_stats_test.go
@@ -1,6 +1,8 @@
 package fastly
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestClient_GetRealtimeStats_validation(t *testing.T) {
 	var err error
@@ -27,5 +29,29 @@ func TestStatsClient_GetRealtimeStats(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestStatsClient_GetRealtimeStatsJSON(t *testing.T) {
+	t.Parallel()
+
+	var ret struct {
+		RenameTimestamp uint64 `json:"Timestamp"`
+	}
+
+	var err error
+	recordRealtimeStats(t, "realtime_stats/get", func(c *RTSClient) {
+		err = c.GetRealtimeStatsJSON(&ret, &GetRealtimeStatsInput{
+			Service:   testServiceID,
+			Timestamp: 0,
+			Limit:     3,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ret.RenameTimestamp == 0 {
+		t.Fatalf("got RenameTimestamp=%d, want nonzero", ret.RenameTimestamp)
 	}
 }

--- a/fastly/request_setting.go
+++ b/fastly/request_setting.go
@@ -99,7 +99,7 @@ func (c *Client) ListRequestSettings(i *ListRequestSettingsInput) ([]*RequestSet
 	}
 
 	var bs []*RequestSetting
-	if err := decodeBodyMap(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	sort.Stable(requestSettingsByName(bs))
@@ -145,7 +145,7 @@ func (c *Client) CreateRequestSetting(i *CreateRequestSettingInput) (*RequestSet
 	}
 
 	var b *RequestSetting
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -184,7 +184,7 @@ func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, 
 	}
 
 	var b *RequestSetting
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -236,7 +236,7 @@ func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSet
 	}
 
 	var b *RequestSetting
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -274,7 +274,7 @@ func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/request_setting.go
+++ b/fastly/request_setting.go
@@ -99,7 +99,7 @@ func (c *Client) ListRequestSettings(i *ListRequestSettingsInput) ([]*RequestSet
 	}
 
 	var bs []*RequestSetting
-	if err := decodeJSON(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(&bs, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(requestSettingsByName(bs))
@@ -145,7 +145,7 @@ func (c *Client) CreateRequestSetting(i *CreateRequestSettingInput) (*RequestSet
 	}
 
 	var b *RequestSetting
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -184,7 +184,7 @@ func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, 
 	}
 
 	var b *RequestSetting
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -236,7 +236,7 @@ func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSet
 	}
 
 	var b *RequestSetting
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -274,7 +274,7 @@ func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/response_object.go
+++ b/fastly/response_object.go
@@ -62,7 +62,7 @@ func (c *Client) ListResponseObjects(i *ListResponseObjectsInput) ([]*ResponseOb
 	}
 
 	var bs []*ResponseObject
-	if err := decodeBodyMap(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	sort.Stable(responseObjectsByName(bs))
@@ -103,7 +103,7 @@ func (c *Client) CreateResponseObject(i *CreateResponseObjectInput) (*ResponseOb
 	}
 
 	var b *ResponseObject
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -142,7 +142,7 @@ func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, 
 	}
 
 	var b *ResponseObject
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -189,7 +189,7 @@ func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseOb
 	}
 
 	var b *ResponseObject
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -227,7 +227,7 @@ func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/response_object.go
+++ b/fastly/response_object.go
@@ -62,7 +62,7 @@ func (c *Client) ListResponseObjects(i *ListResponseObjectsInput) ([]*ResponseOb
 	}
 
 	var bs []*ResponseObject
-	if err := decodeJSON(&bs, resp.Body); err != nil {
+	if err := decodeBodyMap(&bs, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(responseObjectsByName(bs))
@@ -103,7 +103,7 @@ func (c *Client) CreateResponseObject(i *CreateResponseObjectInput) (*ResponseOb
 	}
 
 	var b *ResponseObject
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -142,7 +142,7 @@ func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, 
 	}
 
 	var b *ResponseObject
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -189,7 +189,7 @@ func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseOb
 	}
 
 	var b *ResponseObject
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -227,7 +227,7 @@ func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/s3.go
+++ b/fastly/s3.go
@@ -80,7 +80,7 @@ func (c *Client) ListS3s(i *ListS3sInput) ([]*S3, error) {
 	}
 
 	var s3s []*S3
-	if err := decodeJSON(&s3s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s3s, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(s3sByName(s3s))
@@ -134,7 +134,7 @@ func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
 	}
 
 	var s3 *S3
-	if err := decodeJSON(&s3, resp.Body); err != nil {
+	if err := decodeBodyMap(&s3, resp.Body); err != nil {
 		return nil, err
 	}
 	return s3, nil
@@ -172,7 +172,7 @@ func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
 	}
 
 	var s3 *S3
-	if err := decodeJSON(&s3, resp.Body); err != nil {
+	if err := decodeBodyMap(&s3, resp.Body); err != nil {
 		return nil, err
 	}
 	return s3, nil
@@ -232,7 +232,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 	}
 
 	var s3 *S3
-	if err := decodeJSON(&s3, resp.Body); err != nil {
+	if err := decodeBodyMap(&s3, resp.Body); err != nil {
 		return nil, err
 	}
 	return s3, nil
@@ -270,7 +270,7 @@ func (c *Client) DeleteS3(i *DeleteS3Input) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/s3.go
+++ b/fastly/s3.go
@@ -80,7 +80,7 @@ func (c *Client) ListS3s(i *ListS3sInput) ([]*S3, error) {
 	}
 
 	var s3s []*S3
-	if err := decodeBodyMap(&s3s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s3s); err != nil {
 		return nil, err
 	}
 	sort.Stable(s3sByName(s3s))
@@ -134,7 +134,7 @@ func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
 	}
 
 	var s3 *S3
-	if err := decodeBodyMap(&s3, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s3); err != nil {
 		return nil, err
 	}
 	return s3, nil
@@ -172,7 +172,7 @@ func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
 	}
 
 	var s3 *S3
-	if err := decodeBodyMap(&s3, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s3); err != nil {
 		return nil, err
 	}
 	return s3, nil
@@ -232,7 +232,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 	}
 
 	var s3 *S3
-	if err := decodeBodyMap(&s3, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s3); err != nil {
 		return nil, err
 	}
 	return s3, nil
@@ -270,7 +270,7 @@ func (c *Client) DeleteS3(i *DeleteS3Input) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/server.go
+++ b/fastly/server.go
@@ -60,7 +60,7 @@ func (c *Client) ListServers(i *ListServersInput) ([]*Server, error) {
 	}
 
 	var ss []*Server
-	if err := decodeJSON(&ss, resp.Body); err != nil {
+	if err := decodeBodyMap(&ss, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(serversByAddress(ss))
@@ -108,7 +108,7 @@ func (c *Client) CreateServer(i *CreateServerInput) (*Server, error) {
 	}
 
 	var s *Server
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -144,7 +144,7 @@ func (c *Client) GetServer(i *GetServerInput) (*Server, error) {
 	}
 
 	var s *Server
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -189,7 +189,7 @@ func (c *Client) UpdateServer(i *UpdateServerInput) (*Server, error) {
 	}
 
 	var s *Server
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -225,7 +225,7 @@ func (c *Client) DeleteServer(i *DeleteServerInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/server.go
+++ b/fastly/server.go
@@ -60,7 +60,7 @@ func (c *Client) ListServers(i *ListServersInput) ([]*Server, error) {
 	}
 
 	var ss []*Server
-	if err := decodeBodyMap(&ss, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 	sort.Stable(serversByAddress(ss))
@@ -108,7 +108,7 @@ func (c *Client) CreateServer(i *CreateServerInput) (*Server, error) {
 	}
 
 	var s *Server
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -144,7 +144,7 @@ func (c *Client) GetServer(i *GetServerInput) (*Server, error) {
 	}
 
 	var s *Server
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -189,7 +189,7 @@ func (c *Client) UpdateServer(i *UpdateServerInput) (*Server, error) {
 	}
 
 	var s *Server
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -225,7 +225,7 @@ func (c *Client) DeleteServer(i *DeleteServerInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -67,7 +67,7 @@ func (c *Client) ListServices(i *ListServicesInput) ([]*Service, error) {
 	}
 
 	var s []*Service
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	sort.Stable(servicesByName(s))
@@ -89,7 +89,7 @@ func (c *Client) CreateService(i *CreateServiceInput) (*Service, error) {
 	}
 
 	var s *Service
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -115,7 +115,7 @@ func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
 	}
 
 	var s *Service
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 
@@ -136,7 +136,7 @@ func (c *Client) GetServiceDetails(i *GetServiceInput) (*ServiceDetail, error) {
 	}
 
 	var s *ServiceDetail
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 
@@ -164,7 +164,7 @@ func (c *Client) UpdateService(i *UpdateServiceInput) (*Service, error) {
 	}
 
 	var s *Service
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -188,7 +188,7 @@ func (c *Client) DeleteService(i *DeleteServiceInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -219,7 +219,7 @@ func (c *Client) SearchService(i *SearchServiceInput) (*Service, error) {
 	}
 
 	var s *Service
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 
@@ -243,7 +243,7 @@ func (c *Client) ListServiceDomains(i *ListServiceDomainInput) (ServiceDomainsLi
 
 	var ds ServiceDomainsList
 
-	if err := decodeBodyMap(&ds, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ds); err != nil {
 		return nil, err
 	}
 

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -67,7 +67,7 @@ func (c *Client) ListServices(i *ListServicesInput) ([]*Service, error) {
 	}
 
 	var s []*Service
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(servicesByName(s))
@@ -89,7 +89,7 @@ func (c *Client) CreateService(i *CreateServiceInput) (*Service, error) {
 	}
 
 	var s *Service
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -115,7 +115,7 @@ func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
 	}
 
 	var s *Service
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -136,7 +136,7 @@ func (c *Client) GetServiceDetails(i *GetServiceInput) (*ServiceDetail, error) {
 	}
 
 	var s *ServiceDetail
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -164,7 +164,7 @@ func (c *Client) UpdateService(i *UpdateServiceInput) (*Service, error) {
 	}
 
 	var s *Service
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -188,7 +188,7 @@ func (c *Client) DeleteService(i *DeleteServiceInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -219,7 +219,7 @@ func (c *Client) SearchService(i *SearchServiceInput) (*Service, error) {
 	}
 
 	var s *Service
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -243,7 +243,7 @@ func (c *Client) ListServiceDomains(i *ListServiceDomainInput) (ServiceDomainsLi
 
 	var ds ServiceDomainsList
 
-	if err := decodeJSON(&ds, resp.Body); err != nil {
+	if err := decodeBodyMap(&ds, resp.Body); err != nil {
 		return nil, err
 	}
 

--- a/fastly/settings.go
+++ b/fastly/settings.go
@@ -38,7 +38,7 @@ func (c *Client) GetSettings(i *GetSettingsInput) (*Settings, error) {
 	}
 
 	var b *Settings
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -74,7 +74,7 @@ func (c *Client) UpdateSettings(i *UpdateSettingsInput) (*Settings, error) {
 	}
 
 	var b *Settings
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(&b, resp.Body); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/settings.go
+++ b/fastly/settings.go
@@ -38,7 +38,7 @@ func (c *Client) GetSettings(i *GetSettingsInput) (*Settings, error) {
 	}
 
 	var b *Settings
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -74,7 +74,7 @@ func (c *Client) UpdateSettings(i *UpdateSettingsInput) (*Settings, error) {
 	}
 
 	var b *Settings
-	if err := decodeBodyMap(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/sftp.go
+++ b/fastly/sftp.go
@@ -69,7 +69,7 @@ func (c *Client) ListSFTPs(i *ListSFTPsInput) ([]*SFTP, error) {
 	}
 
 	var sftps []*SFTP
-	if err := decodeJSON(&sftps, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &sftps); err != nil {
 		return nil, err
 	}
 	sort.Stable(sftpsByName(sftps))
@@ -118,7 +118,7 @@ func (c *Client) CreateSFTP(i *CreateSFTPInput) (*SFTP, error) {
 	}
 
 	var ftp *SFTP
-	if err := decodeJSON(&ftp, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ftp); err != nil {
 		return nil, err
 	}
 	return ftp, nil
@@ -156,7 +156,7 @@ func (c *Client) GetSFTP(i *GetSFTPInput) (*SFTP, error) {
 	}
 
 	var b *SFTP
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -211,7 +211,7 @@ func (c *Client) UpdateSFTP(i *UpdateSFTPInput) (*SFTP, error) {
 	}
 
 	var b *SFTP
-	if err := decodeJSON(&b, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -249,7 +249,7 @@ func (c *Client) DeleteSFTP(i *DeleteSFTPInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/splunk.go
+++ b/fastly/splunk.go
@@ -62,7 +62,7 @@ func (c *Client) ListSplunks(i *ListSplunksInput) ([]*Splunk, error) {
 	}
 
 	var ss []*Splunk
-	if err := decodeJSON(&ss, resp.Body); err != nil {
+	if err := decodeBodyMap(&ss, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(splunkByName(ss))
@@ -104,7 +104,7 @@ func (c *Client) CreateSplunk(i *CreateSplunkInput) (*Splunk, error) {
 	}
 
 	var s *Splunk
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -142,7 +142,7 @@ func (c *Client) GetSplunk(i *GetSplunkInput) (*Splunk, error) {
 	}
 
 	var s *Splunk
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -190,7 +190,7 @@ func (c *Client) UpdateSplunk(i *UpdateSplunkInput) (*Splunk, error) {
 	}
 
 	var s *Splunk
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -228,7 +228,7 @@ func (c *Client) DeleteSplunk(i *DeleteSplunkInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/splunk.go
+++ b/fastly/splunk.go
@@ -62,7 +62,7 @@ func (c *Client) ListSplunks(i *ListSplunksInput) ([]*Splunk, error) {
 	}
 
 	var ss []*Splunk
-	if err := decodeBodyMap(&ss, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 	sort.Stable(splunkByName(ss))
@@ -104,7 +104,7 @@ func (c *Client) CreateSplunk(i *CreateSplunkInput) (*Splunk, error) {
 	}
 
 	var s *Splunk
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -142,7 +142,7 @@ func (c *Client) GetSplunk(i *GetSplunkInput) (*Splunk, error) {
 	}
 
 	var s *Splunk
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -190,7 +190,7 @@ func (c *Client) UpdateSplunk(i *UpdateSplunkInput) (*Splunk, error) {
 	}
 
 	var s *Splunk
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -228,7 +228,7 @@ func (c *Client) DeleteSplunk(i *DeleteSplunkInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/stats.go
+++ b/fastly/stats.go
@@ -105,19 +105,19 @@ type StatsResponse struct {
 // GetStats returns stats data based on GetStatsInput
 func (c *Client) GetStats(i *GetStatsInput) (*StatsResponse, error) {
 	var resp interface{}
-	if err := c.GetStatsJSON(&resp, i); err != nil {
+	if err := c.GetStatsJSON(i, &resp); err != nil {
 		return nil, err
 	}
 
 	var sr *StatsResponse
-	if err := decodeMap(&sr, resp); err != nil {
+	if err := decodeMap(resp, &sr); err != nil {
 		return nil, err
 	}
 	return sr, nil
 }
 
 // GetStatsJSON fetches stats and decodes the response directly to the JSON struct dst.
-func (c *Client) GetStatsJSON(dst interface{}, i *GetStatsInput) error {
+func (c *Client) GetStatsJSON(i *GetStatsInput, dst interface{}) error {
 	p := "/stats"
 
 	if i.Service != "" {
@@ -192,7 +192,7 @@ func (c *Client) GetUsage(i *GetUsageInput) (*UsageResponse, error) {
 		return nil, err
 	}
 	var sr *UsageResponse
-	if err := decodeBodyMap(&sr, r.Body); err != nil {
+	if err := decodeBodyMap(r.Body, &sr); err != nil {
 		return nil, err
 	}
 
@@ -228,7 +228,7 @@ func (c *Client) GetUsageByService(i *GetUsageInput) (*UsageByServiceResponse, e
 		return nil, err
 	}
 	var sr *UsageByServiceResponse
-	if err := decodeBodyMap(&sr, r.Body); err != nil {
+	if err := decodeBodyMap(r.Body, &sr); err != nil {
 		return nil, err
 	}
 
@@ -251,7 +251,7 @@ func (c *Client) GetRegions() (*RegionsResponse, error) {
 	}
 
 	var rr *RegionsResponse
-	if err := decodeBodyMap(&rr, r.Body); err != nil {
+	if err := decodeBodyMap(r.Body, &rr); err != nil {
 		return nil, err
 	}
 

--- a/fastly/stats.go
+++ b/fastly/stats.go
@@ -125,7 +125,7 @@ func (c *Client) GetStats(i *GetStatsInput) (*StatsResponse, error) {
 	}
 
 	var sr *StatsResponse
-	if err := decodeJSON(&sr, r.Body); err != nil {
+	if err := decodeBodyMap(&sr, r.Body); err != nil {
 		return nil, err
 	}
 
@@ -180,7 +180,7 @@ func (c *Client) GetUsage(i *GetUsageInput) (*UsageResponse, error) {
 		return nil, err
 	}
 	var sr *UsageResponse
-	if err := decodeJSON(&sr, r.Body); err != nil {
+	if err := decodeBodyMap(&sr, r.Body); err != nil {
 		return nil, err
 	}
 
@@ -216,7 +216,7 @@ func (c *Client) GetUsageByService(i *GetUsageInput) (*UsageByServiceResponse, e
 		return nil, err
 	}
 	var sr *UsageByServiceResponse
-	if err := decodeJSON(&sr, r.Body); err != nil {
+	if err := decodeBodyMap(&sr, r.Body); err != nil {
 		return nil, err
 	}
 
@@ -239,7 +239,7 @@ func (c *Client) GetRegions() (*RegionsResponse, error) {
 	}
 
 	var rr *RegionsResponse
-	if err := decodeJSON(&rr, r.Body); err != nil {
+	if err := decodeBodyMap(&rr, r.Body); err != nil {
 		return nil, err
 	}
 

--- a/fastly/stats_test.go
+++ b/fastly/stats_test.go
@@ -1,6 +1,8 @@
 package fastly
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestClient_GetStats(t *testing.T) {
 	t.Parallel()
@@ -19,6 +21,32 @@ func TestClient_GetStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
+}
+
+func TestClient_GetStatsJSON(t *testing.T) {
+	t.Parallel()
+
+	var ret struct {
+		RenameStatus string `json:"status"`
+	}
+
+	var err error
+	record(t, "stats/service_stats", func(c *Client) {
+		err = c.GetStatsJSON(&ret, &GetStatsInput{
+			Service: testServiceID,
+			From:    "10 days ago",
+			To:      "now",
+			By:      "minute",
+			Region:  "europe",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ret.RenameStatus != "success" {
+		t.Fatalf("got RenameStatus=%q, want %q", ret.RenameStatus, "success")
+	}
 }
 
 func TestClient_GetRegions(t *testing.T) {

--- a/fastly/stats_test.go
+++ b/fastly/stats_test.go
@@ -32,13 +32,13 @@ func TestClient_GetStatsJSON(t *testing.T) {
 
 	var err error
 	record(t, "stats/service_stats", func(c *Client) {
-		err = c.GetStatsJSON(&ret, &GetStatsInput{
+		err = c.GetStatsJSON(&GetStatsInput{
 			Service: testServiceID,
 			From:    "10 days ago",
 			To:      "now",
 			By:      "minute",
 			Region:  "europe",
-		})
+		}, &ret)
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/fastly/sumologic.go
+++ b/fastly/sumologic.go
@@ -61,7 +61,7 @@ func (c *Client) ListSumologics(i *ListSumologicsInput) ([]*Sumologic, error) {
 	}
 
 	var ss []*Sumologic
-	if err := decodeBodyMap(&ss, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 	sort.Stable(sumologicsByName(ss))
@@ -102,7 +102,7 @@ func (c *Client) CreateSumologic(i *CreateSumologicInput) (*Sumologic, error) {
 	}
 
 	var s *Sumologic
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -140,7 +140,7 @@ func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
 	}
 
 	var s *Sumologic
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -187,7 +187,7 @@ func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
 	}
 
 	var s *Sumologic
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -225,7 +225,7 @@ func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/sumologic.go
+++ b/fastly/sumologic.go
@@ -61,7 +61,7 @@ func (c *Client) ListSumologics(i *ListSumologicsInput) ([]*Sumologic, error) {
 	}
 
 	var ss []*Sumologic
-	if err := decodeJSON(&ss, resp.Body); err != nil {
+	if err := decodeBodyMap(&ss, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(sumologicsByName(ss))
@@ -102,7 +102,7 @@ func (c *Client) CreateSumologic(i *CreateSumologicInput) (*Sumologic, error) {
 	}
 
 	var s *Sumologic
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -140,7 +140,7 @@ func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
 	}
 
 	var s *Sumologic
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -187,7 +187,7 @@ func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
 	}
 
 	var s *Sumologic
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -225,7 +225,7 @@ func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/syslog.go
+++ b/fastly/syslog.go
@@ -69,7 +69,7 @@ func (c *Client) ListSyslogs(i *ListSyslogsInput) ([]*Syslog, error) {
 	}
 
 	var ss []*Syslog
-	if err := decodeBodyMap(&ss, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 	sort.Stable(syslogsByName(ss))
@@ -118,7 +118,7 @@ func (c *Client) CreateSyslog(i *CreateSyslogInput) (*Syslog, error) {
 	}
 
 	var s *Syslog
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -156,7 +156,7 @@ func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
 	}
 
 	var s *Syslog
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -211,7 +211,7 @@ func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
 	}
 
 	var s *Syslog
-	if err := decodeBodyMap(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -249,7 +249,7 @@ func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/syslog.go
+++ b/fastly/syslog.go
@@ -69,7 +69,7 @@ func (c *Client) ListSyslogs(i *ListSyslogsInput) ([]*Syslog, error) {
 	}
 
 	var ss []*Syslog
-	if err := decodeJSON(&ss, resp.Body); err != nil {
+	if err := decodeBodyMap(&ss, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(syslogsByName(ss))
@@ -118,7 +118,7 @@ func (c *Client) CreateSyslog(i *CreateSyslogInput) (*Syslog, error) {
 	}
 
 	var s *Syslog
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -156,7 +156,7 @@ func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
 	}
 
 	var s *Syslog
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -211,7 +211,7 @@ func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
 	}
 
 	var s *Syslog
-	if err := decodeJSON(&s, resp.Body); err != nil {
+	if err := decodeBodyMap(&s, resp.Body); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -249,7 +249,7 @@ func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/token.go
+++ b/fastly/token.go
@@ -55,7 +55,7 @@ func (c *Client) ListTokens() ([]*Token, error) {
 	}
 
 	var t []*Token
-	if err := decodeJSON(&t, resp.Body); err != nil {
+	if err := decodeBodyMap(&t, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(tokensByName(t))
@@ -81,7 +81,7 @@ func (c *Client) ListCustomerTokens(i *ListCustomerTokensInput) ([]*Token, error
 	}
 
 	var t []*Token
-	if err := decodeJSON(&t, resp.Body); err != nil {
+	if err := decodeBodyMap(&t, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(tokensByName(t))
@@ -98,7 +98,7 @@ func (c *Client) GetTokenSelf() (*Token, error) {
 	}
 
 	var t *Token
-	if err := decodeJSON(&t, resp.Body); err != nil {
+	if err := decodeBodyMap(&t, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +128,7 @@ func (c *Client) CreateToken(i *CreateTokenInput) (*Token, error) {
 	}
 
 	var t *Token
-	if err := decodeJSON(&t, resp.Body); err != nil {
+	if err := decodeBodyMap(&t, resp.Body); err != nil {
 		return nil, err
 	}
 	return t, nil

--- a/fastly/token.go
+++ b/fastly/token.go
@@ -55,7 +55,7 @@ func (c *Client) ListTokens() ([]*Token, error) {
 	}
 
 	var t []*Token
-	if err := decodeBodyMap(&t, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 	sort.Stable(tokensByName(t))
@@ -81,7 +81,7 @@ func (c *Client) ListCustomerTokens(i *ListCustomerTokensInput) ([]*Token, error
 	}
 
 	var t []*Token
-	if err := decodeBodyMap(&t, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 	sort.Stable(tokensByName(t))
@@ -98,7 +98,7 @@ func (c *Client) GetTokenSelf() (*Token, error) {
 	}
 
 	var t *Token
-	if err := decodeBodyMap(&t, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +128,7 @@ func (c *Client) CreateToken(i *CreateTokenInput) (*Token, error) {
 	}
 
 	var t *Token
-	if err := decodeBodyMap(&t, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 	return t, nil

--- a/fastly/user.go
+++ b/fastly/user.go
@@ -53,7 +53,7 @@ func (c *Client) ListCustomerUsers(i *ListCustomerUsersInput) ([]*User, error) {
 	}
 
 	var u []*User
-	if err := decodeBodyMap(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 	sort.Stable(usersByName(u))
@@ -68,7 +68,7 @@ func (c *Client) GetCurrentUser() (*User, error) {
 	}
 
 	var u *User
-	if err := decodeBodyMap(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 
@@ -94,7 +94,7 @@ func (c *Client) GetUser(i *GetUserInput) (*User, error) {
 	}
 
 	var u *User
-	if err := decodeBodyMap(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 
@@ -125,7 +125,7 @@ func (c *Client) CreateUser(i *CreateUserInput) (*User, error) {
 	}
 
 	var u *User
-	if err := decodeBodyMap(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 	return u, nil
@@ -152,7 +152,7 @@ func (c *Client) UpdateUser(i *UpdateUserInput) (*User, error) {
 	}
 
 	var u *User
-	if err := decodeBodyMap(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 	return u, nil
@@ -176,7 +176,7 @@ func (c *Client) DeleteUser(i *DeleteUserInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/user.go
+++ b/fastly/user.go
@@ -53,7 +53,7 @@ func (c *Client) ListCustomerUsers(i *ListCustomerUsersInput) ([]*User, error) {
 	}
 
 	var u []*User
-	if err := decodeJSON(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(&u, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(usersByName(u))
@@ -68,7 +68,7 @@ func (c *Client) GetCurrentUser() (*User, error) {
 	}
 
 	var u *User
-	if err := decodeJSON(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(&u, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -94,7 +94,7 @@ func (c *Client) GetUser(i *GetUserInput) (*User, error) {
 	}
 
 	var u *User
-	if err := decodeJSON(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(&u, resp.Body); err != nil {
 		return nil, err
 	}
 
@@ -125,7 +125,7 @@ func (c *Client) CreateUser(i *CreateUserInput) (*User, error) {
 	}
 
 	var u *User
-	if err := decodeJSON(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(&u, resp.Body); err != nil {
 		return nil, err
 	}
 	return u, nil
@@ -152,7 +152,7 @@ func (c *Client) UpdateUser(i *UpdateUserInput) (*User, error) {
 	}
 
 	var u *User
-	if err := decodeJSON(&u, resp.Body); err != nil {
+	if err := decodeBodyMap(&u, resp.Body); err != nil {
 		return nil, err
 	}
 	return u, nil
@@ -176,7 +176,7 @@ func (c *Client) DeleteUser(i *DeleteUserInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl.go
+++ b/fastly/vcl.go
@@ -56,7 +56,7 @@ func (c *Client) ListVCLs(i *ListVCLsInput) ([]*VCL, error) {
 	}
 
 	var vcls []*VCL
-	if err := decodeJSON(&vcls, resp.Body); err != nil {
+	if err := decodeBodyMap(&vcls, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(vclsByName(vcls))
@@ -95,7 +95,7 @@ func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeJSON(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -126,7 +126,7 @@ func (c *Client) GetGeneratedVCL(i *GetGeneratedVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeJSON(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -161,7 +161,7 @@ func (c *Client) CreateVCL(i *CreateVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeJSON(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -202,7 +202,7 @@ func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeJSON(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -240,7 +240,7 @@ func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeJSON(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -278,7 +278,7 @@ func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl.go
+++ b/fastly/vcl.go
@@ -56,7 +56,7 @@ func (c *Client) ListVCLs(i *ListVCLsInput) ([]*VCL, error) {
 	}
 
 	var vcls []*VCL
-	if err := decodeBodyMap(&vcls, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &vcls); err != nil {
 		return nil, err
 	}
 	sort.Stable(vclsByName(vcls))
@@ -95,7 +95,7 @@ func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -126,7 +126,7 @@ func (c *Client) GetGeneratedVCL(i *GetGeneratedVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -161,7 +161,7 @@ func (c *Client) CreateVCL(i *CreateVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -202,7 +202,7 @@ func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -240,7 +240,7 @@ func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
 	}
 
 	var vcl *VCL
-	if err := decodeBodyMap(&vcl, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -278,7 +278,7 @@ func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -110,7 +110,7 @@ func (c *Client) CreateSnippet(i *CreateSnippetInput) (*Snippet, error) {
 	}
 
 	var snippet *Snippet
-	if err := decodeBodyMap(&snippet, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &snippet); err != nil {
 		return nil, err
 	}
 	return snippet, err
@@ -167,7 +167,7 @@ func (c *Client) UpdateSnippet(i *UpdateSnippetInput) (*Snippet, error) {
 	}
 
 	var snippet *Snippet
-	if err := decodeBodyMap(&snippet, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &snippet); err != nil {
 		return nil, err
 	}
 	return snippet, err
@@ -212,7 +212,7 @@ func (c *Client) UpdateDynamicSnippet(i *UpdateDynamicSnippetInput) (*DynamicSni
 	}
 
 	var updateSnippet *DynamicSnippet
-	if err := decodeBodyMap(&updateSnippet, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &updateSnippet); err != nil {
 		return nil, err
 	}
 	return updateSnippet, err
@@ -249,7 +249,7 @@ func (c *Client) DeleteSnippet(i *DeleteSnippetInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -295,7 +295,7 @@ func (c *Client) ListSnippets(i *ListSnippetsInput) ([]*Snippet, error) {
 	}
 
 	var snippets []*Snippet
-	if err := decodeBodyMap(&snippets, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &snippets); err != nil {
 		return nil, err
 	}
 	sort.Stable(snippetsByName(snippets))
@@ -335,7 +335,7 @@ func (c *Client) GetSnippet(i *GetSnippetInput) (*Snippet, error) {
 	}
 
 	var snippet *Snippet
-	if err := decodeBodyMap(&snippet, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &snippet); err != nil {
 		return nil, err
 	}
 	return snippet, nil
@@ -368,7 +368,7 @@ func (c *Client) GetDynamicSnippet(i *GetDynamicSnippetInput) (*DynamicSnippet, 
 	}
 
 	var snippet *DynamicSnippet
-	if err := decodeBodyMap(&snippet, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &snippet); err != nil {
 		return nil, err
 	}
 	return snippet, nil

--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -110,7 +110,7 @@ func (c *Client) CreateSnippet(i *CreateSnippetInput) (*Snippet, error) {
 	}
 
 	var snippet *Snippet
-	if err := decodeJSON(&snippet, resp.Body); err != nil {
+	if err := decodeBodyMap(&snippet, resp.Body); err != nil {
 		return nil, err
 	}
 	return snippet, err
@@ -167,7 +167,7 @@ func (c *Client) UpdateSnippet(i *UpdateSnippetInput) (*Snippet, error) {
 	}
 
 	var snippet *Snippet
-	if err := decodeJSON(&snippet, resp.Body); err != nil {
+	if err := decodeBodyMap(&snippet, resp.Body); err != nil {
 		return nil, err
 	}
 	return snippet, err
@@ -212,7 +212,7 @@ func (c *Client) UpdateDynamicSnippet(i *UpdateDynamicSnippetInput) (*DynamicSni
 	}
 
 	var updateSnippet *DynamicSnippet
-	if err := decodeJSON(&updateSnippet, resp.Body); err != nil {
+	if err := decodeBodyMap(&updateSnippet, resp.Body); err != nil {
 		return nil, err
 	}
 	return updateSnippet, err
@@ -249,7 +249,7 @@ func (c *Client) DeleteSnippet(i *DeleteSnippetInput) error {
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -295,7 +295,7 @@ func (c *Client) ListSnippets(i *ListSnippetsInput) ([]*Snippet, error) {
 	}
 
 	var snippets []*Snippet
-	if err := decodeJSON(&snippets, resp.Body); err != nil {
+	if err := decodeBodyMap(&snippets, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Stable(snippetsByName(snippets))
@@ -335,7 +335,7 @@ func (c *Client) GetSnippet(i *GetSnippetInput) (*Snippet, error) {
 	}
 
 	var snippet *Snippet
-	if err := decodeJSON(&snippet, resp.Body); err != nil {
+	if err := decodeBodyMap(&snippet, resp.Body); err != nil {
 		return nil, err
 	}
 	return snippet, nil
@@ -368,7 +368,7 @@ func (c *Client) GetDynamicSnippet(i *GetDynamicSnippetInput) (*DynamicSnippet, 
 	}
 
 	var snippet *DynamicSnippet
-	if err := decodeJSON(&snippet, resp.Body); err != nil {
+	if err := decodeBodyMap(&snippet, resp.Body); err != nil {
 		return nil, err
 	}
 	return snippet, nil

--- a/fastly/version.go
+++ b/fastly/version.go
@@ -51,7 +51,7 @@ func (c *Client) ListVersions(i *ListVersionsInput) ([]*Version, error) {
 	}
 
 	var e []*Version
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 	sort.Sort(versionsByNumber(e))
@@ -108,7 +108,7 @@ func (c *Client) CreateVersion(i *CreateVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -140,7 +140,7 @@ func (c *Client) GetVersion(i *GetVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -174,7 +174,7 @@ func (c *Client) UpdateVersion(i *UpdateVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -205,7 +205,7 @@ func (c *Client) ActivateVersion(i *ActivateVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -236,7 +236,7 @@ func (c *Client) DeactivateVersion(i *DeactivateVersionInput) (*Version, error) 
 	}
 
 	var e *Version
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -269,7 +269,7 @@ func (c *Client) CloneVersion(i *CloneVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -302,7 +302,7 @@ func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, string, error) 
 	}
 
 	var r *statusResp
-	if err := decodeJSON(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(&r, resp.Body); err != nil {
 		return false, msg, err
 	}
 
@@ -335,7 +335,7 @@ func (c *Client) LockVersion(i *LockVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeJSON(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(&e, resp.Body); err != nil {
 		return nil, err
 	}
 	return e, nil

--- a/fastly/version.go
+++ b/fastly/version.go
@@ -51,7 +51,7 @@ func (c *Client) ListVersions(i *ListVersionsInput) ([]*Version, error) {
 	}
 
 	var e []*Version
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	sort.Sort(versionsByNumber(e))
@@ -108,7 +108,7 @@ func (c *Client) CreateVersion(i *CreateVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -140,7 +140,7 @@ func (c *Client) GetVersion(i *GetVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -174,7 +174,7 @@ func (c *Client) UpdateVersion(i *UpdateVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -205,7 +205,7 @@ func (c *Client) ActivateVersion(i *ActivateVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -236,7 +236,7 @@ func (c *Client) DeactivateVersion(i *DeactivateVersionInput) (*Version, error) 
 	}
 
 	var e *Version
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -269,7 +269,7 @@ func (c *Client) CloneVersion(i *CloneVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -302,7 +302,7 @@ func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, string, error) 
 	}
 
 	var r *statusResp
-	if err := decodeBodyMap(&r, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &r); err != nil {
 		return false, msg, err
 	}
 
@@ -335,7 +335,7 @@ func (c *Client) LockVersion(i *LockVersionInput) (*Version, error) {
 	}
 
 	var e *Version
-	if err := decodeBodyMap(&e, resp.Body); err != nil {
+	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil


### PR DESCRIPTION
This PR adds GetStatsJSON and GetRealtimeStatsJSON, which give the caller control over the JSON objects decoded from stats responses. The existing GetStats and GetRealtimeStats (unchanged) discard the original structure.