### PR TITLE
Fix scripts/fixFixtures.sh portability issue

### DIFF
--- a/scripts/fixFixtures.sh
+++ b/scripts/fixFixtures.sh
@@ -12,5 +12,5 @@ fi
 
 for file in $(grep --recursive --files-with-matches "${FASTLY_TEST_SERVICE_ID}" "${FIXTURESDIR}")
 do
-  sed -i "s/${FASTLY_TEST_SERVICE_ID}/${DEFAULT_TEST_SERVICE_ID}/g" "$file"
+  sed -i.bak "s/${FASTLY_TEST_SERVICE_ID}/${DEFAULT_TEST_SERVICE_ID}/g" "$file" && rm "${file}.bak"
 done


### PR DESCRIPTION
@philippschulte pointed out that `sed -i` isn't POSIX compliant and that the script failed on macOS. I've updated the script to create and delete a backup file and tested it on macOS as well as Linux.