### PR TITLE
Support for the link to the rule set deploy status

### DIFF
--- a/fastly/fixtures/wafs/cleanup.yaml
+++ b/fastly/fixtures/wafs/cleanup.yaml
@@ -1,24 +1,22 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/wafs/1NGmubiAYnKMtCvXWAeszf
     method: DELETE
   response:
     body: ""
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Date:
-      - Sat, 11 May 2019 21:45:03 GMT
+      - Fri, 15 May 2020 15:35:18 GMT
       Status:
       - 204 No Content
       Strict-Transport-Security:
@@ -33,8 +31,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611103.468691,VS0,VE153
+      - S1589556919.811961,VS0,VE135
     status: 204 No Content
     code: 204
+    duration: ""

--- a/fastly/fixtures/wafs/condition/cleanup.yaml
+++ b/fastly/fixtures/wafs/condition/cleanup.yaml
@@ -1,32 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/condition/test-waf-condition
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/condition/test-waf-condition
     method: DELETE
   response:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:04 GMT
+      - Fri, 15 May 2020 15:35:19 GMT
       Fastly-Ratelimit-Remaining:
-      - "985"
+      - "956"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1589558400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611104.983094,VS0,VE264
+      - S1589556919.233553,VS0,VE226
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/condition/create.yaml
+++ b/fastly/fixtures/wafs/condition/create.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&name=test-waf-condition&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=34&name=test-waf-condition&priority=1&statement=req.url~%2B%22index.html%22&type=PREFETCH
     form:
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "54"
+      - "34"
       name:
       - test-waf-condition
       priority:
@@ -20,27 +19,26 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/condition
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/condition
     method: POST
   response:
-    body: '{"name":"test-waf-condition","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","created_at":"2019-05-11T21:44:59Z","updated_at":"2019-05-11T21:44:59Z","deleted_at":null,"comment":""}'
+    body: '{"name":"test-waf-condition","priority":"1","statement":"req.url~+\"index.html\"","type":"PREFETCH","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"34","created_at":"2020-05-15T15:35:15Z","deleted_at":null,"updated_at":"2020-05-15T15:35:15Z","comment":""}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:44:59 GMT
+      - Fri, 15 May 2020 15:35:15 GMT
       Fastly-Ratelimit-Remaining:
-      - "990"
+      - "961"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1589558400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -55,8 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611099.476242,VS0,VE199
+      - S1589556915.486965,VS0,VE184
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/create.yaml
+++ b/fastly/fixtures/wafs/create.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
@@ -11,23 +10,22 @@ interactions:
       - application/vnd.api+json
       Content-Type:
       - application/vnd.api+json
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/wafs
     method: POST
   response:
-    body: '{"data":{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"3vnl3cwPda9Q3WYCDRuGW","type":"configuration_set"}},"owasp":{"data":{"id":"4Jh5ZWRaYGgPdCdgQZNzyk","type":"owasp"}}}}}'
+    body: '{"data":{"id":"1NGmubiAYnKMtCvXWAeszf","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":34,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"6wvihQHbaCG7NBPTfm20S9","type":"configuration_set"}},"owasp":{"data":{"id":"7Voa4ckWs2CEQ3jewO2xr2","type":"owasp"}}}}}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Content-Length:
-      - "489"
+      - "490"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:00 GMT
+      - Fri, 15 May 2020 15:35:16 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -42,8 +40,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611100.058242,VS0,VE742
+      - S1589556916.960533,VS0,VE924
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/delete.yaml
+++ b/fastly/fixtures/wafs/delete.yaml
@@ -1,24 +1,22 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/wafs/1NGmubiAYnKMtCvXWAeszf
     method: DELETE
   response:
     body: ""
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Date:
-      - Sat, 11 May 2019 21:45:02 GMT
+      - Fri, 15 May 2020 15:35:18 GMT
       Status:
       - 204 No Content
       Strict-Transport-Security:
@@ -33,8 +31,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611103.608075,VS0,VE254
+      - S1589556918.208271,VS0,VE291
     status: 204 No Content
     code: 204
+    duration: ""

--- a/fastly/fixtures/wafs/list.yaml
+++ b/fastly/fixtures/wafs/list.yaml
@@ -1,30 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/wafs
     method: GET
   response:
-    body: '{"data":[{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0}}],"links":{"last":"https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":1,"total_pages":1}}'
+    body: '{"data":[{"id":"1NGmubiAYnKMtCvXWAeszf","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":34,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0}}],"links":{"last":"https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/wafs?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/wafs?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":1,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
+      - bytes
       Age:
+      - "0"
       - "0"
       Content-Length:
       - "635"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:01 GMT
+      - Fri, 15 May 2020 15:35:17 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,8 +39,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611101.825257,VS0,VE468
+      - S1589556917.899550,VS0,VE203
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/logging/cleanup.yaml
+++ b/fastly/fixtures/wafs/logging/cleanup.yaml
@@ -1,32 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/logging/syslog/test-syslog
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/logging/syslog/test-syslog
     method: DELETE
   response:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:04 GMT
+      - Fri, 15 May 2020 15:35:19 GMT
       Fastly-Ratelimit-Remaining:
-      - "984"
+      - "955"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1589558400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611104.386426,VS0,VE311
+      - S1589556919.477481,VS0,VE287
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/logging/create.yaml
+++ b/fastly/fixtures/wafs/logging/create.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=34&address=example.com&format=format&format_version=2&hostname=example.com&message_type=classic&name=test-syslog&port=1234&token=abcd1234
     form:
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "54"
+      - "34"
       address:
       - example.com
       format:
@@ -28,27 +27,26 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/logging/syslog
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/logging/syslog
     method: POST
   response:
-    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","tls_hostname":null,"use_tls":"0","created_at":"2019-05-11T21:44:58Z","response_condition":"","updated_at":"2019-05-11T21:44:59Z","tls_ca_cert":null,"placement":null,"deleted_at":null,"ipv4":null,"public_key":null}'
+    body: '{"address":"example.com","format":"format","format_version":"2","hostname":"example.com","message_type":"classic","name":"test-syslog","port":"1234","token":"abcd1234","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"34","tls_client_key":null,"tls_client_cert":null,"tls_ca_cert":null,"deleted_at":null,"updated_at":"2020-05-15T15:35:15Z","response_condition":"","tls_hostname":null,"use_tls":"0","public_key":null,"created_at":"2020-05-15T15:35:15Z","ipv4":null,"placement":null}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:44:59 GMT
+      - Fri, 15 May 2020 15:35:15 GMT
       Fastly-Ratelimit-Remaining:
-      - "991"
+      - "962"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1589558400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -63,8 +61,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611099.652892,VS0,VE682
+      - S1589556915.903632,VS0,VE563
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/cleanup.yaml
+++ b/fastly/fixtures/wafs/response_object/cleanup.yaml
@@ -1,32 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object/test-response-object
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/response_object/test-response-object
     method: DELETE
   response:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:03 GMT
+      - Fri, 15 May 2020 15:35:19 GMT
       Fastly-Ratelimit-Remaining:
-      - "986"
+      - "957"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1589558400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611104.646216,VS0,VE312
+      - S1589556919.961846,VS0,VE250
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/cleanup_another.yaml
+++ b/fastly/fixtures/wafs/response_object/cleanup_another.yaml
@@ -1,32 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object/test-response-object-2
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/response_object/test-response-object-2
     method: DELETE
   response:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:03 GMT
+      - Fri, 15 May 2020 15:35:18 GMT
       Fastly-Ratelimit-Remaining:
-      - "987"
+      - "958"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1589558400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611103.897977,VS0,VE289
+      - S1589556919.517725,VS0,VE276
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/create.yaml
+++ b/fastly/fixtures/wafs/response_object/create.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&content=abcd&content_type=text%2Fplain&name=test-response-object&response=Ok&status=200
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=34&content=abcd&content_type=text%2Fplain&name=test-response-object&response=Ok&status=200
     form:
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "54"
+      - "34"
       content:
       - abcd
       content_type:
@@ -22,27 +21,26 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/response_object
     method: POST
   response:
-    body: '{"content":"abcd","content_type":"text/plain","name":"test-response-object","response":"Ok","status":"200","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","deleted_at":null,"created_at":"2019-05-11T21:44:59Z","request_condition":"","updated_at":"2019-05-11T21:44:59Z","cache_condition":""}'
+    body: '{"content":"abcd","content_type":"text/plain","name":"test-response-object","response":"Ok","status":"200","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"34","deleted_at":null,"updated_at":"2020-05-15T15:35:15Z","request_condition":"","cache_condition":"","created_at":"2020-05-15T15:35:15Z"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:00 GMT
+      - Fri, 15 May 2020 15:35:15 GMT
       Fastly-Ratelimit-Remaining:
-      - "989"
+      - "960"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1589558400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,8 +55,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611100.704714,VS0,VE321
+      - S1589556916.685716,VS0,VE256
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/response_object/create_another.yaml
+++ b/fastly/fixtures/wafs/response_object/create_another.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=54&content=efgh&content_type=text%2Fplain&name=test-response-object-2&response=Ok&status=200
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=34&content=efgh&content_type=text%2Fplain&name=test-response-object-2&response=Ok&status=200
     form:
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "54"
+      - "34"
       content:
       - efgh
       content_type:
@@ -22,27 +21,26 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/response_object
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/response_object
     method: POST
   response:
-    body: '{"content":"efgh","content_type":"text/plain","name":"test-response-object-2","response":"Ok","status":"200","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"54","cache_condition":"","created_at":"2019-05-11T21:45:01Z","request_condition":"","deleted_at":null,"updated_at":"2019-05-11T21:45:01Z"}'
+    body: '{"content":"efgh","content_type":"text/plain","name":"test-response-object-2","response":"Ok","status":"200","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"34","request_condition":"","created_at":"2020-05-15T15:35:17Z","deleted_at":null,"cache_condition":"","updated_at":"2020-05-15T15:35:17Z"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:45:01 GMT
+      - Fri, 15 May 2020 15:35:17 GMT
       Fastly-Ratelimit-Remaining:
-      - "988"
+      - "959"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1589558400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,8 +55,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611102.735005,VS0,VE257
+      - S1589556917.459714,VS0,VE278
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/ruleset/get.yaml
+++ b/fastly/fixtures/wafs/ruleset/get.yaml
@@ -7,10 +7,11 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/wafs/1NGmubiAYnKMtCvXWAeszf
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/wafs/1NGmubiAYnKMtCvXWAeszf/ruleset
     method: GET
   response:
-    body: '{"data":{"id":"1NGmubiAYnKMtCvXWAeszf","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object","version":34,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"6wvihQHbaCG7NBPTfm20S9","type":"configuration_set"}}}}}'
+    body: '{"data":{"id":"1NGmubiAYnKMtCvXWAeszf","type":"ruleset","attributes":{"vcl":"sub
+      waf_ruleset {\n  /* This WAF is not configured */\n}","last_push":null}}}'
     headers:
       Accept-Ranges:
       - bytes
@@ -20,7 +21,7 @@ interactions:
       - "0"
       - "0"
       Content-Length:
-      - "426"
+      - "154"
       Content-Type:
       - application/vnd.api+json
       Date:
@@ -39,9 +40,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sea4480-SEA
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1589556917.123551,VS0,VE170
+      - S1589556917.308235,VS0,VE134
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/wafs/ruleset/patch.yaml
+++ b/fastly/fixtures/wafs/ruleset/patch.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"data":{"type":"ruleset","id":"1NGmubiAYnKMtCvXWAeszf"}}
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.api+json
+      Content-Type:
+      - application/vnd.api+json
+      User-Agent:
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/wafs/1NGmubiAYnKMtCvXWAeszf/ruleset
+    method: PATCH
+  response:
+    body: '{"data":{"id":"1NGmubiAYnKMtCvXWAeszf","type":"ruleset"},"links":{"related":{"href":"https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/wafs/1NGmubiAYnKMtCvXWAeszf/update_statuses/37i4YLJHlPWsHB4ndwHkpt"}}}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      - bytes
+      Content-Length:
+      - "209"
+      Content-Type:
+      - application/vnd.api+json
+      Date:
+      - Fri, 15 May 2020 15:35:18 GMT
+      Status:
+      - 202 Accepted
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Content-Type-Options:
+      - nosniff
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4480-SEA
+      X-Timer:
+      - S1589556918.085171,VS0,VE109
+    status: 202 Accepted
+    code: 202
+    duration: ""

--- a/fastly/fixtures/wafs/update.yaml
+++ b/fastly/fixtures/wafs/update.yaml
@@ -1,38 +1,36 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: |
-      {"data":{"type":"waf","id":"2WK9ofHfHcPi3s6S2X0Z8m","attributes":{"response":"test-response-object-2"}}}
+      {"data":{"type":"waf","id":"1NGmubiAYnKMtCvXWAeszf","attributes":{"response":"test-response-object-2"}}}
     form: {}
     headers:
       Accept:
       - application/vnd.api+json
       Content-Type:
       - application/vnd.api+json
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/54/wafs/2WK9ofHfHcPi3s6S2X0Z8m
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/34/wafs/1NGmubiAYnKMtCvXWAeszf
     method: PATCH
   response:
-    body: '{"data":{"id":"2WK9ofHfHcPi3s6S2X0Z8m","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object-2","version":54,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"3vnl3cwPda9Q3WYCDRuGW","type":"configuration_set"}},"owasp":{"data":{"id":"4Jh5ZWRaYGgPdCdgQZNzyk","type":"owasp"}}}},"meta":{"warnings":[{"title":"This
+    body: '{"data":{"id":"1NGmubiAYnKMtCvXWAeszf","type":"waf","attributes":{"last_push":null,"prefetch_condition":"test-waf-condition","response":"test-response-object-2","version":34,"service_id":"7i6HN3TK9wS159v2gPAZ8A","disabled":false,"rule_statuses_log_count":0,"rule_statuses_block_count":0,"rule_statuses_disabled_count":0},"relationships":{"configuration_set":{"data":{"id":"6wvihQHbaCG7NBPTfm20S9","type":"configuration_set"}},"owasp":{"data":{"id":"7Voa4ckWs2CEQ3jewO2xr2","type":"owasp"}}}},"meta":{"warnings":[{"title":"This
       version of this service must be active","detail":"You may only update the WAF
-      VCL on an active version of a service.  The version 54 of service 7i6HN3TK9wS159v2gPAZ8A
-      is not active.  You may activate it through https://app.fastly.com or through
+      VCL on an active version of a service.  The version 34 of service 7i6HN3TK9wS159v2gPAZ8A
+      is not active.  You may activate it through https://manage.fastly.com or through
       the API: https://docs.fastly.com/api/config#version  Be sure to review the version''s
       changes before activating it."}]}}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Content-Length:
-      - "890"
+      - "894"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Sat, 11 May 2019 21:45:02 GMT
+      - Fri, 15 May 2020 15:35:18 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,8 +45,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611102.061591,VS0,VE521
+      - S1589556918.755702,VS0,VE318
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/wafs/version.yaml
+++ b/fastly/fixtures/wafs/version.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: Service=7i6HN3TK9wS159v2gPAZ8A
@@ -10,27 +9,26 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
+      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.12)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":54}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":34}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Sat, 11 May 2019 21:44:58 GMT
+      - Fri, 15 May 2020 15:35:14 GMT
       Fastly-Ratelimit-Remaining:
-      - "992"
+      - "963"
       Fastly-Ratelimit-Reset:
-      - "1557612000"
+      - "1589558400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,8 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-lax8631-LAX
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sea4480-SEA
       X-Timer:
-      - S1557611098.123270,VS0,VE502
+      - S1589556915.603940,VS0,VE279
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -151,6 +151,30 @@ func TestClient_WAFs(t *testing.T) {
 		t.Errorf("expected %q to be %q", nwaf.ID, waf.ID)
 	}
 
+	// Get the WAF ruleset
+	var ruleset *Ruleset
+	record(t, "wafs/ruleset/get", func(c *Client) {
+		ruleset, err = c.GetWAFRuleRuleSets(&GetWAFRuleRuleSetsInput{
+			Service: testServiceID,
+			ID:      waf.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ruleset.ID != waf.ID {
+		t.Errorf("expected %q to be %q", ruleset.ID, waf.ID)
+	}
+	if ruleset.VCL == "" {
+		t.Error("bad vcl")
+	}
+	if ruleset.LastPush != waf.LastPush {
+		t.Errorf("expected %q to be %q", ruleset.LastPush, waf.LastPush)
+	}
+	if ruleset.Link != "" {
+		t.Error("bad link")
+	}
+
 	// Update
 	// Create a new response object to attach
 	var nro *ResponseObject
@@ -191,6 +215,30 @@ func TestClient_WAFs(t *testing.T) {
 	}
 	if uwaf.Response != "test-response-object-2" {
 		t.Errorf("bad name: %q", uwaf.Response)
+	}
+
+	// Update the WAF ruleset
+	var uRuleset *Ruleset
+	record(t, "wafs/ruleset/patch", func(c *Client) {
+		uRuleset, err = c.UpdateWAFRuleSets(&UpdateWAFRuleRuleSetsInput{
+			Service: testServiceID,
+			ID:      uwaf.ID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uRuleset.ID != uwaf.ID {
+		t.Errorf("expected %q to be %q", uRuleset.ID, uwaf.ID)
+	}
+	if uRuleset.VCL != "" {
+		t.Error("bad vcl")
+	}
+	if uRuleset.LastPush != nil {
+		t.Error("bad last_push")
+	}
+	if uRuleset.Link == "" {
+		t.Error("bad link")
 	}
 
 	// Delete


### PR DESCRIPTION
This PR is necessary in order to be able to use the link of the rule set deploy status in [waflyctl](https://github.com/fastly/waflyctl).

The request methods for [GET/service/service_id/wafs/waf_id/ruleset](https://docs.fastly.com/api/waf#waf_ruleset_5e37b65346b88d394dcf3ba6b07e35d4) and [PATCH/service/service_id/wafs/waf_id/ruleset](https://docs.fastly.com/api/waf#waf_ruleset_3c076195f3616cf75dc9cf274916a768) share the same response struct. However, the responses of these endpoints are actually differnet. The `PATCH` endpoint doesn't support the `vcl` and the `last_push` fields.

I am just adding the `Link` field to the shared `Ruleset` response struct. This field will be empty and useless for the [GET/service/service_id/wafs/waf_id/ruleset](https://docs.fastly.com/api/waf#waf_ruleset_5e37b65346b88d394dcf3ba6b07e35d4) request function but I don't think this matters because the response struct for [PATCH/service/service_id/wafs/waf_id/ruleset](https://docs.fastly.com/api/waf#waf_ruleset_3c076195f3616cf75dc9cf274916a768) also includes empty and useless fields as well. The `jsonapi` package doesn't allow me to decode the `Link` field and therefore I am using the standard library for the job.

I understand that this is not the nicest implementation but it doesn't introduce any breaking changes.