### PR TITLE
update active rules route

### DIFF
--- a/fastly/fixtures/waf_active_rules/create.yaml
+++ b/fastly/fixtures/waf_active_rules/create.yaml
@@ -12,7 +12,7 @@ interactions:
       - application/vnd.api+json; ext=bulk
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules
+    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules
     method: POST
   response:
     body: '{"data":[{"id":"6E8M7nScn1buIUJrSKvqkt","type":"waf_active_rule","attributes":{"status":"log","modsec_rule_id":2029718,"revision":1,"created_at":"2019-11-28T12:43:23Z","updated_at":"2019-11-28T12:43:23Z"},"relationships":{"waf_firewall_version":{"data":{"id":"6Wo0vAYg6cS79HacNpZrBm","type":"waf_firewall_version"}},"waf_rule_revision":{"data":{"id":"6ZJML5tsy5uVq1nGNgmZ78","type":"waf_rule_revision"}}}},{"id":"7UZK2qQ20TMUBoZbKo9NZy","type":"waf_active_rule","attributes":{"status":"log","modsec_rule_id":2037405,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"},"relationships":{"waf_firewall_version":{"data":{"id":"6Wo0vAYg6cS79HacNpZrBm","type":"waf_firewall_version"}},"waf_rule_revision":{"data":{"id":"3ANlv7vVZdzk2qFXlJLIk3","type":"waf_rule_revision"}}}},{"id":"5CVFtVaW0WCns3ksB7tMv2","type":"waf_active_rule","attributes":{"status":"log","modsec_rule_id":1010070,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"},"relationships":{"waf_firewall_version":{"data":{"id":"6Wo0vAYg6cS79HacNpZrBm","type":"waf_firewall_version"}},"waf_rule_revision":{"data":{"id":"2qiuFDyJoxuKkKkJYjrgsC","type":"waf_rule_revision"}}}}]}'

--- a/fastly/fixtures/waf_active_rules/delete_all.yaml
+++ b/fastly/fixtures/waf_active_rules/delete_all.yaml
@@ -11,7 +11,7 @@ interactions:
       - application/vnd.api+json
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules
+    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules
     method: DELETE
   response:
     body: ""

--- a/fastly/fixtures/waf_active_rules/delete_one.yaml
+++ b/fastly/fixtures/waf_active_rules/delete_one.yaml
@@ -12,7 +12,7 @@ interactions:
       - application/vnd.api+json; ext=bulk
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules
+    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules
     method: DELETE
   response:
     body: ""

--- a/fastly/fixtures/waf_active_rules/list_after_delete.yaml
+++ b/fastly/fixtures/waf_active_rules/list_after_delete.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules
+    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules
     method: GET
   response:
-    body: '{"data":[{"id":"7UZK2qQ20TMUBoZbKo9NZy","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2037405,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"6E8M7nScn1buIUJrSKvqkt","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2029718,"revision":1,"created_at":"2019-11-28T12:43:23Z","updated_at":"2019-11-28T12:43:24Z"}}],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":2,"total_pages":1}}'
+    body: '{"data":[{"id":"7UZK2qQ20TMUBoZbKo9NZy","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2037405,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"6E8M7nScn1buIUJrSKvqkt","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2029718,"revision":1,"created_at":"2019-11-28T12:43:23Z","updated_at":"2019-11-28T12:43:24Z"}}],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":2,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/fixtures/waf_active_rules/list_after_delete_all.yaml
+++ b/fastly/fixtures/waf_active_rules/list_after_delete_all.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules
+    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules
     method: GET
   response:
-    body: '{"data":[],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":0,"total_pages":1}}'
+    body: '{"data":[],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":0,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/fixtures/waf_active_rules/list_empty.yaml
+++ b/fastly/fixtures/waf_active_rules/list_empty.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules
+    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules
     method: GET
   response:
-    body: '{"data":[],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":0,"total_pages":1}}'
+    body: '{"data":[],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":0,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/fixtures/waf_active_rules/list_not_empty.yaml
+++ b/fastly/fixtures/waf_active_rules/list_not_empty.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules
+    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules
     method: GET
   response:
-    body: '{"data":[{"id":"7UZK2qQ20TMUBoZbKo9NZy","type":"waf_active_rule","attributes":{"status":"log","modsec_rule_id":2037405,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"5CVFtVaW0WCns3ksB7tMv2","type":"waf_active_rule","attributes":{"status":"log","modsec_rule_id":1010070,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"6E8M7nScn1buIUJrSKvqkt","type":"waf_active_rule","attributes":{"status":"log","modsec_rule_id":2029718,"revision":1,"created_at":"2019-11-28T12:43:23Z","updated_at":"2019-11-28T12:43:23Z"}}],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":3,"total_pages":1}}'
+    body: '{"data":[{"id":"7UZK2qQ20TMUBoZbKo9NZy","type":"waf_active_rule","attributes":{"status":"log","modsec_rule_id":2037405,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"5CVFtVaW0WCns3ksB7tMv2","type":"waf_active_rule","attributes":{"status":"log","modsec_rule_id":1010070,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"6E8M7nScn1buIUJrSKvqkt","type":"waf_active_rule","attributes":{"status":"log","modsec_rule_id":2029718,"revision":1,"created_at":"2019-11-28T12:43:23Z","updated_at":"2019-11-28T12:43:23Z"}}],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":3,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/fixtures/waf_active_rules/list_not_empty2.yaml
+++ b/fastly/fixtures/waf_active_rules/list_not_empty2.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules
+    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules
     method: GET
   response:
-    body: '{"data":[{"id":"7UZK2qQ20TMUBoZbKo9NZy","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2037405,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"5CVFtVaW0WCns3ksB7tMv2","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":1010070,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"6E8M7nScn1buIUJrSKvqkt","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2029718,"revision":1,"created_at":"2019-11-28T12:43:23Z","updated_at":"2019-11-28T12:43:24Z"}}],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":3,"total_pages":1}}'
+    body: '{"data":[{"id":"7UZK2qQ20TMUBoZbKo9NZy","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2037405,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"5CVFtVaW0WCns3ksB7tMv2","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":1010070,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"}},{"id":"6E8M7nScn1buIUJrSKvqkt","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2029718,"revision":1,"created_at":"2019-11-28T12:43:23Z","updated_at":"2019-11-28T12:43:24Z"}}],"links":{"last":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules?page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":3,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/fixtures/waf_active_rules/update.yaml
+++ b/fastly/fixtures/waf_active_rules/update.yaml
@@ -12,7 +12,7 @@ interactions:
       - application/vnd.api+json; ext=bulk
       User-Agent:
       - FastlyGo/1.3.0 (+github.com/fastly/go-fastly; go1.13.4)
-    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/rules
+    url: https://api.fastly.com/waf/firewalls/5n9TykpTt7zn0KFJ4k9bMz/versions/1/active-rules
     method: POST
   response:
     body: '{"data":[{"id":"6E8M7nScn1buIUJrSKvqkt","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2029718,"revision":1,"created_at":"2019-11-28T12:43:23Z","updated_at":"2019-11-28T12:43:24Z"},"relationships":{"waf_firewall_version":{"data":{"id":"6Wo0vAYg6cS79HacNpZrBm","type":"waf_firewall_version"}},"waf_rule_revision":{"data":{"id":"6ZJML5tsy5uVq1nGNgmZ78","type":"waf_rule_revision"}}}},{"id":"7UZK2qQ20TMUBoZbKo9NZy","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":2037405,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"},"relationships":{"waf_firewall_version":{"data":{"id":"6Wo0vAYg6cS79HacNpZrBm","type":"waf_firewall_version"}},"waf_rule_revision":{"data":{"id":"3ANlv7vVZdzk2qFXlJLIk3","type":"waf_rule_revision"}}}},{"id":"5CVFtVaW0WCns3ksB7tMv2","type":"waf_active_rule","attributes":{"status":"block","modsec_rule_id":1010070,"revision":1,"created_at":"2019-11-28T12:43:24Z","updated_at":"2019-11-28T12:43:24Z"},"relationships":{"waf_firewall_version":{"data":{"id":"6Wo0vAYg6cS79HacNpZrBm","type":"waf_firewall_version"}},"waf_rule_revision":{"data":{"id":"2qiuFDyJoxuKkKkJYjrgsC","type":"waf_rule_revision"}}}}]}'

--- a/fastly/waf_active_rule.go
+++ b/fastly/waf_active_rule.go
@@ -89,7 +89,7 @@ func (c *Client) ListWAFActiveRules(i *ListWAFActiveRulesInput) (*WAFActiveRuleR
 		return nil, ErrMissingWAFVersionNumber
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/rules", i.WAFID, i.WAFVersionNumber)
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/active-rules", i.WAFID, i.WAFVersionNumber)
 	resp, err := c.Get(path, &RequestOptions{
 		Params: i.formatFilters(),
 	})
@@ -203,7 +203,7 @@ func (c *Client) CreateWAFActiveRules(i *CreateWAFActiveRulesInput) ([]*WAFActiv
 		return nil, ErrMissingWAFActiveRuleList
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/rules", i.WAFID, i.WAFVersionNumber)
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/active-rules", i.WAFID, i.WAFVersionNumber)
 	resp, err := c.PostJSONAPIBulk(path, i.Rules, nil)
 	if err != nil {
 		return nil, err
@@ -289,7 +289,7 @@ func (c *Client) DeleteWAFActiveRules(i *DeleteWAFActiveRulesInput) error {
 		return ErrMissingWAFActiveRuleList
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/rules", i.WAFID, i.WAFVersionNumber)
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/active-rules", i.WAFID, i.WAFVersionNumber)
 	_, err := c.DeleteJSONAPIBulk(path, i.Rules, nil)
 	return err
 }
@@ -313,7 +313,7 @@ func (c *Client) DeleteAllWAFActiveRules(i *DeleteAllWAFActiveRulesInput) error 
 		return ErrMissingWAFVersionNumber
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/rules", i.WAFID, i.WAFVersionNumber)
+	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/active-rules", i.WAFID, i.WAFVersionNumber)
 	_, err := c.DeleteJSONAPI(path, nil, nil)
 	return err
 }


### PR DESCRIPTION
Previously, we had multiple `/rules` routes on the NG API for our WAF. WAF team recently updated the routes used to manage active rules on the NG API to be specific to `/active-rules`. This PR makes the route changes necessary to make the appropriate API calls.