### PR TITLE
Add MessageType field to GCS Updates

### DIFF
--- a/fastly/fixtures/gcses/cleanup.yaml
+++ b/fastly/fixtures/gcses/cleanup.yaml
@@ -1,34 +1,32 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/67/logging/gcs/test-gcs
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/gcs/test-gcs
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e test-gcs, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 67 }''"}'
+      version =\u003e 6 }''"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Jun 2019 22:12:33 GMT
+      - Wed, 03 Jun 2020 13:25:54 GMT
       Fastly-Ratelimit-Remaining:
-      - "983"
+      - "962"
       Fastly-Ratelimit-Reset:
-      - "1559862000"
+      - "1591192800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -43,38 +41,38 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3624-SJC
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-dca17741-DCA
       X-Timer:
-      - S1559859154.540010,VS0,VE161
+      - S1591190754.311097,VS0,VE101
     status: 404 Not Found
     code: 404
+    duration: ""
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/67/logging/gcs/new-test-gcs
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/gcs/new-test-gcs
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e new-test-gcs, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 67 }''"}'
+      version =\u003e 6 }''"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Jun 2019 22:12:33 GMT
+      - Wed, 03 Jun 2020 13:25:54 GMT
       Fastly-Ratelimit-Remaining:
-      - "982"
+      - "961"
       Fastly-Ratelimit-Reset:
-      - "1559862000"
+      - "1591192800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -89,8 +87,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3624-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-dca17741-DCA
       X-Timer:
-      - S1559859154.713609,VS0,VE164
+      - S1591190754.436096,VS0,VE84
     status: 404 Not Found
     code: 404
+    duration: ""

--- a/fastly/fixtures/gcses/create.yaml
+++ b/fastly/fixtures/gcses/create.yaml
@@ -1,14 +1,13 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=67&bucket_name=bucket&format=format&format_version=2&gzip_level=9&message_type=blank&name=test-gcs&path=%2Fpath&period=12&placement=waf_debug&secret_key=-----BEGIN+PRIVATE+KEY-----%0AMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq%0ATdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1%0ANnqWYvHDyA5Ug%2BT8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA%0AeURUzFsqyymXMUGrqDPqrHsVWC2E3NTJEb4QlywtrwI13qbhlvTx6%2F9oRfUjytXJ%0ARuUIE5xL8yhRCagNr5ZW250aa%2BwBwu5DSCk5fDNr0eDuZjw84WHDll%2BmHxBFGV%2BX%0AKJ5jCOmGumGqjVWZesJpNN1My3M9bsY9layNJJ0eiDeHDEi%2FyXhhO%2FmNEXhvhq%2FR%0AfN0Jh2A3AgMBAAECggEAef%2BCEL5aF6%2FaVs0yh7fiXkKSp1ECXkud8ztgpEn63KJF%0AXM1EdnBt50fA2xSQUeGmeEXi6%2Bcngf0nRb8FToAEgLoGoOEjSJuLrzP3I8U9Fe3m%0ABRG2uZI2Ti%2FbD0eRGEc1oSDhCpsqnkTGK1bwcD4AKpwY%2Bc08Izh%2F2BOoY6McDoqh%0AdQ89jzTuMtD4cNlnPiIrY9HbxoNjshK2ax1OaeXyYKZFG1TxqMFv5gA%2FG5%2BS3Cwr%0AVG4fkAxYi5vdIK3b8jUXrTM%2FkpoTl%2Bd3dlQ7rRZYf7KyT31%2FHtJ%2FGNzxFI6upzO7%0AiDNrrUOyeOPjWXdzUh9budv3j%2B6UfbYK7uZIoebHIQKBgQDykYX1L%2FakGaOC2tfS%0AjzCWUzPxGFYVZQ7zD1PM6UyouuS1KLURDEGk9RxqVzTPh%2FpYd8Ivnz3vOVski5Zt%0A19ozLGxdtDhn122DcnVpfCdYzHBdAzPCzORenFohX%2BMhiX5fEotTlVi7wfOmzTP5%0AhUCMSd%2F17bJrV4XMLhkdrMRBFQKBgQDH5fwV7o%2BEj%2FZfcdGIa3mAFazToPDzxhHU%0AnwADxaxpNGKRU03XCaiYkykarLYdG6Rk%2B7dXUv8eLy%2B6Dcq1SWQtfCWKEor%2B%2BIIp%0A1RwWmFHfYriHGkmxSkkEkLFvL8old9xM5YWbEXc4QIXvnfR4BZxdyJHVzIDdbI2i%0AFgcn17U3GwKBgDd1njMY7ENIuWHJt16k7m7wRwfwkH4DxQ89ieNn0%2BcgE%2Fp3fC6R%0AptCYWg7WMXThmhNwDi3lMrvnWTdZ0uL6XyEkHwKtmdfkIV3UZZPglv5uf6JEgSkg%0Av3YCOXk3%2By5HyWTjUIejtc334kVY1XFPThrFKTeJSSnRsP2l7IgkYBqhAoGAYGsr%0AM3z1FrDF2nWw5odIfKJ30UAw2LRyB0eGH0uqhLgyzvwKcK2E98sLqYUi9llN6zOK%0A1IEA8xM5hxl97AFxY4sdJEMbbi55wim7uZ5Q51nbvbbNUsmM%2FLm6C%2FJWI8pzpVeU%0AIR7EjYp50AE1WOsD6CyFQ0W35pWkn0jWvL4L938CgYEAlax4dLE5%2BYCG5DeLT1%2FN%0Ain6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn%2BuNatKvlVyfPm6rdxeHCmER1FpR7Q%0AA%2FaNVjPeViKT%2FR4nK9ytsa%2Bs%2F1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ%0Abv1KwcKoQbNVXwauH79JKc0%3D%0A-----END+PRIVATE+KEY-----%0A&timestamp_format=%25Y&user=user
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=6&bucket_name=bucket&format=format&format_version=2&gzip_level=9&message_type=blank&name=test-gcs&path=%2Fpath&period=12&placement=waf_debug&secret_key=-----BEGIN+PRIVATE+KEY-----%0AMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq%0ATdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1%0ANnqWYvHDyA5Ug%2BT8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA%0AeURUzFsqyymXMUGrqDPqrHsVWC2E3NTJEb4QlywtrwI13qbhlvTx6%2F9oRfUjytXJ%0ARuUIE5xL8yhRCagNr5ZW250aa%2BwBwu5DSCk5fDNr0eDuZjw84WHDll%2BmHxBFGV%2BX%0AKJ5jCOmGumGqjVWZesJpNN1My3M9bsY9layNJJ0eiDeHDEi%2FyXhhO%2FmNEXhvhq%2FR%0AfN0Jh2A3AgMBAAECggEAef%2BCEL5aF6%2FaVs0yh7fiXkKSp1ECXkud8ztgpEn63KJF%0AXM1EdnBt50fA2xSQUeGmeEXi6%2Bcngf0nRb8FToAEgLoGoOEjSJuLrzP3I8U9Fe3m%0ABRG2uZI2Ti%2FbD0eRGEc1oSDhCpsqnkTGK1bwcD4AKpwY%2Bc08Izh%2F2BOoY6McDoqh%0AdQ89jzTuMtD4cNlnPiIrY9HbxoNjshK2ax1OaeXyYKZFG1TxqMFv5gA%2FG5%2BS3Cwr%0AVG4fkAxYi5vdIK3b8jUXrTM%2FkpoTl%2Bd3dlQ7rRZYf7KyT31%2FHtJ%2FGNzxFI6upzO7%0AiDNrrUOyeOPjWXdzUh9budv3j%2B6UfbYK7uZIoebHIQKBgQDykYX1L%2FakGaOC2tfS%0AjzCWUzPxGFYVZQ7zD1PM6UyouuS1KLURDEGk9RxqVzTPh%2FpYd8Ivnz3vOVski5Zt%0A19ozLGxdtDhn122DcnVpfCdYzHBdAzPCzORenFohX%2BMhiX5fEotTlVi7wfOmzTP5%0AhUCMSd%2F17bJrV4XMLhkdrMRBFQKBgQDH5fwV7o%2BEj%2FZfcdGIa3mAFazToPDzxhHU%0AnwADxaxpNGKRU03XCaiYkykarLYdG6Rk%2B7dXUv8eLy%2B6Dcq1SWQtfCWKEor%2B%2BIIp%0A1RwWmFHfYriHGkmxSkkEkLFvL8old9xM5YWbEXc4QIXvnfR4BZxdyJHVzIDdbI2i%0AFgcn17U3GwKBgDd1njMY7ENIuWHJt16k7m7wRwfwkH4DxQ89ieNn0%2BcgE%2Fp3fC6R%0AptCYWg7WMXThmhNwDi3lMrvnWTdZ0uL6XyEkHwKtmdfkIV3UZZPglv5uf6JEgSkg%0Av3YCOXk3%2By5HyWTjUIejtc334kVY1XFPThrFKTeJSSnRsP2l7IgkYBqhAoGAYGsr%0AM3z1FrDF2nWw5odIfKJ30UAw2LRyB0eGH0uqhLgyzvwKcK2E98sLqYUi9llN6zOK%0A1IEA8xM5hxl97AFxY4sdJEMbbi55wim7uZ5Q51nbvbbNUsmM%2FLm6C%2FJWI8pzpVeU%0AIR7EjYp50AE1WOsD6CyFQ0W35pWkn0jWvL4L938CgYEAlax4dLE5%2BYCG5DeLT1%2FN%0Ain6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn%2BuNatKvlVyfPm6rdxeHCmER1FpR7Q%0AA%2FaNVjPeViKT%2FR4nK9ytsa%2Bs%2F1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ%0Abv1KwcKoQbNVXwauH79JKc0%3D%0A-----END+PRIVATE+KEY-----%0A&timestamp_format=%25Y&user=user
     form:
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "67"
+      - "6"
       bucket_name:
       - bucket
       format:
@@ -64,29 +63,28 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/67/logging/gcs
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/gcs
     method: POST
   response:
-    body: '{"bucket_name":"bucket","format":"format","format_version":"2","gzip_level":9,"message_type":"blank","name":"test-gcs","path":"/path","period":12,"placement":"waf_debug","secret_key":"-----BEGIN
+    body: '{"bucket_name":"bucket","format":"format","format_version":"2","gzip_level":"9","message_type":"blank","name":"test-gcs","path":"/path","period":"12","placement":"waf_debug","secret_key":"-----BEGIN
       PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq\nTdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1\nNnqWYvHDyA5Ug+T8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA\neURUzFsqyymXMUGrqDPqrHsVWC2E3NTJEb4QlywtrwI13qbhlvTx6/9oRfUjytXJ\nRuUIE5xL8yhRCagNr5ZW250aa+wBwu5DSCk5fDNr0eDuZjw84WHDll+mHxBFGV+X\nKJ5jCOmGumGqjVWZesJpNN1My3M9bsY9layNJJ0eiDeHDEi/yXhhO/mNEXhvhq/R\nfN0Jh2A3AgMBAAECggEAef+CEL5aF6/aVs0yh7fiXkKSp1ECXkud8ztgpEn63KJF\nXM1EdnBt50fA2xSQUeGmeEXi6+cngf0nRb8FToAEgLoGoOEjSJuLrzP3I8U9Fe3m\nBRG2uZI2Ti/bD0eRGEc1oSDhCpsqnkTGK1bwcD4AKpwY+c08Izh/2BOoY6McDoqh\ndQ89jzTuMtD4cNlnPiIrY9HbxoNjshK2ax1OaeXyYKZFG1TxqMFv5gA/G5+S3Cwr\nVG4fkAxYi5vdIK3b8jUXrTM/kpoTl+d3dlQ7rRZYf7KyT31/HtJ/GNzxFI6upzO7\niDNrrUOyeOPjWXdzUh9budv3j+6UfbYK7uZIoebHIQKBgQDykYX1L/akGaOC2tfS\njzCWUzPxGFYVZQ7zD1PM6UyouuS1KLURDEGk9RxqVzTPh/pYd8Ivnz3vOVski5Zt\n19ozLGxdtDhn122DcnVpfCdYzHBdAzPCzORenFohX+MhiX5fEotTlVi7wfOmzTP5\nhUCMSd/17bJrV4XMLhkdrMRBFQKBgQDH5fwV7o+Ej/ZfcdGIa3mAFazToPDzxhHU\nnwADxaxpNGKRU03XCaiYkykarLYdG6Rk+7dXUv8eLy+6Dcq1SWQtfCWKEor++IIp\n1RwWmFHfYriHGkmxSkkEkLFvL8old9xM5YWbEXc4QIXvnfR4BZxdyJHVzIDdbI2i\nFgcn17U3GwKBgDd1njMY7ENIuWHJt16k7m7wRwfwkH4DxQ89ieNn0+cgE/p3fC6R\nptCYWg7WMXThmhNwDi3lMrvnWTdZ0uL6XyEkHwKtmdfkIV3UZZPglv5uf6JEgSkg\nv3YCOXk3+y5HyWTjUIejtc334kVY1XFPThrFKTeJSSnRsP2l7IgkYBqhAoGAYGsr\nM3z1FrDF2nWw5odIfKJ30UAw2LRyB0eGH0uqhLgyzvwKcK2E98sLqYUi9llN6zOK\n1IEA8xM5hxl97AFxY4sdJEMbbi55wim7uZ5Q51nbvbbNUsmM/Lm6C/JWI8pzpVeU\nIR7EjYp50AE1WOsD6CyFQ0W35pWkn0jWvL4L938CgYEAlax4dLE5+YCG5DeLT1/N\nin6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn+uNatKvlVyfPm6rdxeHCmER1FpR7Q\nA/aNVjPeViKT/R4nK9ytsa+s/1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ\nbv1KwcKoQbNVXwauH79JKc0=\n-----END
-      PRIVATE KEY-----\n","timestamp_format":"%Y","user":"user","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"67","response_condition":"","created_at":"2019-06-06T22:12:31Z","deleted_at":null,"public_key":null,"updated_at":"2019-06-06T22:12:31Z"}'
+      PRIVATE KEY-----\n","timestamp_format":"%Y","user":"user","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"6","public_key":null,"created_at":"2020-06-03T13:25:53Z","response_condition":"","deleted_at":null,"updated_at":"2020-06-03T13:25:53Z"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Jun 2019 22:12:32 GMT
+      - Wed, 03 Jun 2020 13:25:53 GMT
       Fastly-Ratelimit-Remaining:
-      - "986"
+      - "965"
       Fastly-Ratelimit-Reset:
-      - "1559862000"
+      - "1591192800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -101,8 +99,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-sjc3624-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-dca17741-DCA
       X-Timer:
-      - S1559859151.360249,VS0,VE698
+      - S1591190753.049026,VS0,VE337
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/gcses/delete.yaml
+++ b/fastly/fixtures/gcses/delete.yaml
@@ -1,32 +1,30 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/67/logging/gcs/new-test-gcs
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/gcs/new-test-gcs
     method: DELETE
   response:
     body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Jun 2019 22:12:33 GMT
+      - Wed, 03 Jun 2020 13:25:54 GMT
       Fastly-Ratelimit-Remaining:
-      - "984"
+      - "963"
       Fastly-Ratelimit-Reset:
-      - "1559862000"
+      - "1591192800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3624-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-dca17741-DCA
       X-Timer:
-      - S1559859153.272850,VS0,VE259
+      - S1591190754.108575,VS0,VE174
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/gcses/get.yaml
+++ b/fastly/fixtures/gcses/get.yaml
@@ -1,31 +1,32 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/67/logging/gcs/test-gcs
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/gcs/test-gcs
     method: GET
   response:
-    body: '{"secret_key":"-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq\nTdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1\nNnqWYvHDyA5Ug+T8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA\neURUzFsqyymXMUGrqDPqrHsVWC2E3NTJEb4QlywtrwI13qbhlvTx6/9oRfUjytXJ\nRuUIE5xL8yhRCagNr5ZW250aa+wBwu5DSCk5fDNr0eDuZjw84WHDll+mHxBFGV+X\nKJ5jCOmGumGqjVWZesJpNN1My3M9bsY9layNJJ0eiDeHDEi/yXhhO/mNEXhvhq/R\nfN0Jh2A3AgMBAAECggEAef+CEL5aF6/aVs0yh7fiXkKSp1ECXkud8ztgpEn63KJF\nXM1EdnBt50fA2xSQUeGmeEXi6+cngf0nRb8FToAEgLoGoOEjSJuLrzP3I8U9Fe3m\nBRG2uZI2Ti/bD0eRGEc1oSDhCpsqnkTGK1bwcD4AKpwY+c08Izh/2BOoY6McDoqh\ndQ89jzTuMtD4cNlnPiIrY9HbxoNjshK2ax1OaeXyYKZFG1TxqMFv5gA/G5+S3Cwr\nVG4fkAxYi5vdIK3b8jUXrTM/kpoTl+d3dlQ7rRZYf7KyT31/HtJ/GNzxFI6upzO7\niDNrrUOyeOPjWXdzUh9budv3j+6UfbYK7uZIoebHIQKBgQDykYX1L/akGaOC2tfS\njzCWUzPxGFYVZQ7zD1PM6UyouuS1KLURDEGk9RxqVzTPh/pYd8Ivnz3vOVski5Zt\n19ozLGxdtDhn122DcnVpfCdYzHBdAzPCzORenFohX+MhiX5fEotTlVi7wfOmzTP5\nhUCMSd/17bJrV4XMLhkdrMRBFQKBgQDH5fwV7o+Ej/ZfcdGIa3mAFazToPDzxhHU\nnwADxaxpNGKRU03XCaiYkykarLYdG6Rk+7dXUv8eLy+6Dcq1SWQtfCWKEor++IIp\n1RwWmFHfYriHGkmxSkkEkLFvL8old9xM5YWbEXc4QIXvnfR4BZxdyJHVzIDdbI2i\nFgcn17U3GwKBgDd1njMY7ENIuWHJt16k7m7wRwfwkH4DxQ89ieNn0+cgE/p3fC6R\nptCYWg7WMXThmhNwDi3lMrvnWTdZ0uL6XyEkHwKtmdfkIV3UZZPglv5uf6JEgSkg\nv3YCOXk3+y5HyWTjUIejtc334kVY1XFPThrFKTeJSSnRsP2l7IgkYBqhAoGAYGsr\nM3z1FrDF2nWw5odIfKJ30UAw2LRyB0eGH0uqhLgyzvwKcK2E98sLqYUi9llN6zOK\n1IEA8xM5hxl97AFxY4sdJEMbbi55wim7uZ5Q51nbvbbNUsmM/Lm6C/JWI8pzpVeU\nIR7EjYp50AE1WOsD6CyFQ0W35pWkn0jWvL4L938CgYEAlax4dLE5+YCG5DeLT1/N\nin6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn+uNatKvlVyfPm6rdxeHCmER1FpR7Q\nA/aNVjPeViKT/R4nK9ytsa+s/1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ\nbv1KwcKoQbNVXwauH79JKc0=\n-----END
-      PRIVATE KEY-----\n","format_version":"2","service_id":"7i6HN3TK9wS159v2gPAZ8A","response_condition":"","bucket_name":"bucket","name":"test-gcs","deleted_at":null,"updated_at":"2019-06-06T22:12:31Z","format":"format","path":"/path","placement":"waf_debug","timestamp_format":"%Y","created_at":"2019-06-06T22:12:31Z","gzip_level":"9","version":"67","user":"user","public_key":null,"message_type":"blank","period":"12"}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2020-06-03T13:25:53Z","deleted_at":null,"format":"format","message_type":"blank","user":"user","response_condition":"","created_at":"2020-06-03T13:25:53Z","path":"/path","bucket_name":"bucket","name":"test-gcs","gzip_level":"9","timestamp_format":"%Y","secret_key":"-----BEGIN
+      PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq\nTdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1\nNnqWYvHDyA5Ug+T8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA\neURUzFsqyymXMUGrqDPqrHsVWC2E3NTJEb4QlywtrwI13qbhlvTx6/9oRfUjytXJ\nRuUIE5xL8yhRCagNr5ZW250aa+wBwu5DSCk5fDNr0eDuZjw84WHDll+mHxBFGV+X\nKJ5jCOmGumGqjVWZesJpNN1My3M9bsY9layNJJ0eiDeHDEi/yXhhO/mNEXhvhq/R\nfN0Jh2A3AgMBAAECggEAef+CEL5aF6/aVs0yh7fiXkKSp1ECXkud8ztgpEn63KJF\nXM1EdnBt50fA2xSQUeGmeEXi6+cngf0nRb8FToAEgLoGoOEjSJuLrzP3I8U9Fe3m\nBRG2uZI2Ti/bD0eRGEc1oSDhCpsqnkTGK1bwcD4AKpwY+c08Izh/2BOoY6McDoqh\ndQ89jzTuMtD4cNlnPiIrY9HbxoNjshK2ax1OaeXyYKZFG1TxqMFv5gA/G5+S3Cwr\nVG4fkAxYi5vdIK3b8jUXrTM/kpoTl+d3dlQ7rRZYf7KyT31/HtJ/GNzxFI6upzO7\niDNrrUOyeOPjWXdzUh9budv3j+6UfbYK7uZIoebHIQKBgQDykYX1L/akGaOC2tfS\njzCWUzPxGFYVZQ7zD1PM6UyouuS1KLURDEGk9RxqVzTPh/pYd8Ivnz3vOVski5Zt\n19ozLGxdtDhn122DcnVpfCdYzHBdAzPCzORenFohX+MhiX5fEotTlVi7wfOmzTP5\nhUCMSd/17bJrV4XMLhkdrMRBFQKBgQDH5fwV7o+Ej/ZfcdGIa3mAFazToPDzxhHU\nnwADxaxpNGKRU03XCaiYkykarLYdG6Rk+7dXUv8eLy+6Dcq1SWQtfCWKEor++IIp\n1RwWmFHfYriHGkmxSkkEkLFvL8old9xM5YWbEXc4QIXvnfR4BZxdyJHVzIDdbI2i\nFgcn17U3GwKBgDd1njMY7ENIuWHJt16k7m7wRwfwkH4DxQ89ieNn0+cgE/p3fC6R\nptCYWg7WMXThmhNwDi3lMrvnWTdZ0uL6XyEkHwKtmdfkIV3UZZPglv5uf6JEgSkg\nv3YCOXk3+y5HyWTjUIejtc334kVY1XFPThrFKTeJSSnRsP2l7IgkYBqhAoGAYGsr\nM3z1FrDF2nWw5odIfKJ30UAw2LRyB0eGH0uqhLgyzvwKcK2E98sLqYUi9llN6zOK\n1IEA8xM5hxl97AFxY4sdJEMbbi55wim7uZ5Q51nbvbbNUsmM/Lm6C/JWI8pzpVeU\nIR7EjYp50AE1WOsD6CyFQ0W35pWkn0jWvL4L938CgYEAlax4dLE5+YCG5DeLT1/N\nin6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn+uNatKvlVyfPm6rdxeHCmER1FpR7Q\nA/aNVjPeViKT/R4nK9ytsa+s/1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ\nbv1KwcKoQbNVXwauH79JKc0=\n-----END
+      PRIVATE KEY-----\n","placement":"waf_debug","period":"12","public_key":null,"version":"6","format_version":"2"}'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
+      - bytes
       Age:
+      - "0"
       - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Jun 2019 22:12:32 GMT
+      - Wed, 03 Jun 2020 13:25:53 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -40,8 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sjc3624-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-dca17741-DCA
       X-Timer:
-      - S1559859152.484770,VS0,VE169
+      - S1591190754.542196,VS0,VE98
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/gcses/list.yaml
+++ b/fastly/fixtures/gcses/list.yaml
@@ -1,32 +1,32 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: ""
     form: {}
     headers:
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/67/logging/gcs
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/gcs
     method: GET
   response:
-    body: '[{"version":"67","created_at":"2019-06-06T22:12:31Z","gzip_level":"9","message_type":"blank","period":"12","user":"user","public_key":null,"deleted_at":null,"secret_key":"-----BEGIN
+    body: '[{"path":"/path","bucket_name":"bucket","name":"test-gcs","created_at":"2020-06-03T13:25:53Z","message_type":"blank","format":"format","response_condition":"","user":"user","service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2020-06-03T13:25:53Z","deleted_at":null,"version":"6","format_version":"2","timestamp_format":"%Y","secret_key":"-----BEGIN
       PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq\nTdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1\nNnqWYvHDyA5Ug+T8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA\neURUzFsqyymXMUGrqDPqrHsVWC2E3NTJEb4QlywtrwI13qbhlvTx6/9oRfUjytXJ\nRuUIE5xL8yhRCagNr5ZW250aa+wBwu5DSCk5fDNr0eDuZjw84WHDll+mHxBFGV+X\nKJ5jCOmGumGqjVWZesJpNN1My3M9bsY9layNJJ0eiDeHDEi/yXhhO/mNEXhvhq/R\nfN0Jh2A3AgMBAAECggEAef+CEL5aF6/aVs0yh7fiXkKSp1ECXkud8ztgpEn63KJF\nXM1EdnBt50fA2xSQUeGmeEXi6+cngf0nRb8FToAEgLoGoOEjSJuLrzP3I8U9Fe3m\nBRG2uZI2Ti/bD0eRGEc1oSDhCpsqnkTGK1bwcD4AKpwY+c08Izh/2BOoY6McDoqh\ndQ89jzTuMtD4cNlnPiIrY9HbxoNjshK2ax1OaeXyYKZFG1TxqMFv5gA/G5+S3Cwr\nVG4fkAxYi5vdIK3b8jUXrTM/kpoTl+d3dlQ7rRZYf7KyT31/HtJ/GNzxFI6upzO7\niDNrrUOyeOPjWXdzUh9budv3j+6UfbYK7uZIoebHIQKBgQDykYX1L/akGaOC2tfS\njzCWUzPxGFYVZQ7zD1PM6UyouuS1KLURDEGk9RxqVzTPh/pYd8Ivnz3vOVski5Zt\n19ozLGxdtDhn122DcnVpfCdYzHBdAzPCzORenFohX+MhiX5fEotTlVi7wfOmzTP5\nhUCMSd/17bJrV4XMLhkdrMRBFQKBgQDH5fwV7o+Ej/ZfcdGIa3mAFazToPDzxhHU\nnwADxaxpNGKRU03XCaiYkykarLYdG6Rk+7dXUv8eLy+6Dcq1SWQtfCWKEor++IIp\n1RwWmFHfYriHGkmxSkkEkLFvL8old9xM5YWbEXc4QIXvnfR4BZxdyJHVzIDdbI2i\nFgcn17U3GwKBgDd1njMY7ENIuWHJt16k7m7wRwfwkH4DxQ89ieNn0+cgE/p3fC6R\nptCYWg7WMXThmhNwDi3lMrvnWTdZ0uL6XyEkHwKtmdfkIV3UZZPglv5uf6JEgSkg\nv3YCOXk3+y5HyWTjUIejtc334kVY1XFPThrFKTeJSSnRsP2l7IgkYBqhAoGAYGsr\nM3z1FrDF2nWw5odIfKJ30UAw2LRyB0eGH0uqhLgyzvwKcK2E98sLqYUi9llN6zOK\n1IEA8xM5hxl97AFxY4sdJEMbbi55wim7uZ5Q51nbvbbNUsmM/Lm6C/JWI8pzpVeU\nIR7EjYp50AE1WOsD6CyFQ0W35pWkn0jWvL4L938CgYEAlax4dLE5+YCG5DeLT1/N\nin6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn+uNatKvlVyfPm6rdxeHCmER1FpR7Q\nA/aNVjPeViKT/R4nK9ytsa+s/1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ\nbv1KwcKoQbNVXwauH79JKc0=\n-----END
-      PRIVATE KEY-----\n","service_id":"7i6HN3TK9wS159v2gPAZ8A","response_condition":"","format_version":"2","name":"test-gcs","bucket_name":"bucket","path":"/path","placement":"waf_debug","timestamp_format":"%Y","updated_at":"2019-06-06T22:12:31Z","format":"format"}]'
+      PRIVATE KEY-----\n","placement":"waf_debug","public_key":null,"period":"12","gzip_level":"9"}]'
     headers:
       Accept-Ranges:
       - bytes
+      - bytes
+      - bytes
       Age:
+      - "0"
       - "0"
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Jun 2019 22:12:32 GMT
+      - Wed, 03 Jun 2020 13:25:53 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,8 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-sjc3624-SJC
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-dca17741-DCA
       X-Timer:
-      - S1559859152.063829,VS0,VE412
+      - S1591190753.414098,VS0,VE90
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/gcses/update.yaml
+++ b/fastly/fixtures/gcses/update.yaml
@@ -1,44 +1,44 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
-    body: Name=test-gcs&Service=7i6HN3TK9wS159v2gPAZ8A&Version=67&name=new-test-gcs
+    body: Name=test-gcs&Service=7i6HN3TK9wS159v2gPAZ8A&Version=6&message_type=classic&name=new-test-gcs
     form:
       Name:
       - test-gcs
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "67"
+      - "6"
+      message_type:
+      - classic
       name:
       - new-test-gcs
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/67/logging/gcs/test-gcs
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/logging/gcs/test-gcs
     method: PUT
   response:
-    body: '{"period":"12","message_type":"blank","public_key":null,"user":"user","version":"67","gzip_level":"9","created_at":"2019-06-06T22:12:31Z","timestamp_format":"%Y","placement":"waf_debug","path":"/path","format":"format","updated_at":"2019-06-06T22:12:31Z","deleted_at":null,"response_condition":"","service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","bucket_name":"bucket","name":"new-test-gcs","secret_key":"-----BEGIN
+    body: '{"format":"format","bucket_name":"bucket","response_condition":"","path":"/path","secret_key":"-----BEGIN
       PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq\nTdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1\nNnqWYvHDyA5Ug+T8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA\neURUzFsqyymXMUGrqDPqrHsVWC2E3NTJEb4QlywtrwI13qbhlvTx6/9oRfUjytXJ\nRuUIE5xL8yhRCagNr5ZW250aa+wBwu5DSCk5fDNr0eDuZjw84WHDll+mHxBFGV+X\nKJ5jCOmGumGqjVWZesJpNN1My3M9bsY9layNJJ0eiDeHDEi/yXhhO/mNEXhvhq/R\nfN0Jh2A3AgMBAAECggEAef+CEL5aF6/aVs0yh7fiXkKSp1ECXkud8ztgpEn63KJF\nXM1EdnBt50fA2xSQUeGmeEXi6+cngf0nRb8FToAEgLoGoOEjSJuLrzP3I8U9Fe3m\nBRG2uZI2Ti/bD0eRGEc1oSDhCpsqnkTGK1bwcD4AKpwY+c08Izh/2BOoY6McDoqh\ndQ89jzTuMtD4cNlnPiIrY9HbxoNjshK2ax1OaeXyYKZFG1TxqMFv5gA/G5+S3Cwr\nVG4fkAxYi5vdIK3b8jUXrTM/kpoTl+d3dlQ7rRZYf7KyT31/HtJ/GNzxFI6upzO7\niDNrrUOyeOPjWXdzUh9budv3j+6UfbYK7uZIoebHIQKBgQDykYX1L/akGaOC2tfS\njzCWUzPxGFYVZQ7zD1PM6UyouuS1KLURDEGk9RxqVzTPh/pYd8Ivnz3vOVski5Zt\n19ozLGxdtDhn122DcnVpfCdYzHBdAzPCzORenFohX+MhiX5fEotTlVi7wfOmzTP5\nhUCMSd/17bJrV4XMLhkdrMRBFQKBgQDH5fwV7o+Ej/ZfcdGIa3mAFazToPDzxhHU\nnwADxaxpNGKRU03XCaiYkykarLYdG6Rk+7dXUv8eLy+6Dcq1SWQtfCWKEor++IIp\n1RwWmFHfYriHGkmxSkkEkLFvL8old9xM5YWbEXc4QIXvnfR4BZxdyJHVzIDdbI2i\nFgcn17U3GwKBgDd1njMY7ENIuWHJt16k7m7wRwfwkH4DxQ89ieNn0+cgE/p3fC6R\nptCYWg7WMXThmhNwDi3lMrvnWTdZ0uL6XyEkHwKtmdfkIV3UZZPglv5uf6JEgSkg\nv3YCOXk3+y5HyWTjUIejtc334kVY1XFPThrFKTeJSSnRsP2l7IgkYBqhAoGAYGsr\nM3z1FrDF2nWw5odIfKJ30UAw2LRyB0eGH0uqhLgyzvwKcK2E98sLqYUi9llN6zOK\n1IEA8xM5hxl97AFxY4sdJEMbbi55wim7uZ5Q51nbvbbNUsmM/Lm6C/JWI8pzpVeU\nIR7EjYp50AE1WOsD6CyFQ0W35pWkn0jWvL4L938CgYEAlax4dLE5+YCG5DeLT1/N\nin6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn+uNatKvlVyfPm6rdxeHCmER1FpR7Q\nA/aNVjPeViKT/R4nK9ytsa+s/1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ\nbv1KwcKoQbNVXwauH79JKc0=\n-----END
-      PRIVATE KEY-----\n"}'
+      PRIVATE KEY-----\n","period":"12","format_version":"2","name":"new-test-gcs","version":"6","created_at":"2020-06-03T13:25:53Z","deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","timestamp_format":"%Y","message_type":"classic","placement":"waf_debug","updated_at":"2020-06-03T13:25:53Z","gzip_level":"9","public_key":null,"user":"user"}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Jun 2019 22:12:33 GMT
+      - Wed, 03 Jun 2020 13:25:54 GMT
       Fastly-Ratelimit-Remaining:
-      - "985"
+      - "964"
       Fastly-Ratelimit-Reset:
-      - "1559862000"
+      - "1591192800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -53,8 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3624-SJC
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-dca17741-DCA
       X-Timer:
-      - S1559859153.660464,VS0,VE542
+      - S1591190754.674641,VS0,VE405
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/fixtures/gcses/version.yaml
+++ b/fastly/fixtures/gcses/version.yaml
@@ -1,6 +1,5 @@
 ---
 version: 1
-rwmutex: {}
 interactions:
 - request:
     body: Service=7i6HN3TK9wS159v2gPAZ8A
@@ -10,27 +9,26 @@ interactions:
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
-      Fastly-Key:
-      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
       User-Agent:
-      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":67}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":6}'
     headers:
       Accept-Ranges:
+      - bytes
       - bytes
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Date:
-      - Thu, 06 Jun 2019 22:12:31 GMT
+      - Wed, 03 Jun 2020 13:25:53 GMT
       Fastly-Ratelimit-Remaining:
-      - "987"
+      - "966"
       Fastly-Ratelimit-Reset:
-      - "1559862000"
+      - "1591192800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,8 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-sjc3624-SJC
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-dca17741-DCA
       X-Timer:
-      - S1559859151.876981,VS0,VE475
+      - S1591190753.878677,VS0,VE138
     status: 200 OK
     code: 200
+    duration: ""

--- a/fastly/gcs.go
+++ b/fastly/gcs.go
@@ -175,6 +175,7 @@ type UpdateGCSInput struct {
 	FormatVersion     uint   `form:"format_version,omitempty"`
 	GzipLevel         uint8  `form:"gzip_level,omitempty"`
 	Format            string `form:"format,omitempty"`
+	MessageType       string `form:"message_type,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
 	Placement         string `form:"placement,omitempty"`

--- a/fastly/gcs_test.go
+++ b/fastly/gcs_test.go
@@ -157,10 +157,11 @@ func TestClient_GCSs(t *testing.T) {
 	var ugcs *GCS
 	record(t, "gcses/update", func(c *Client) {
 		ugcs, err = c.UpdateGCS(&UpdateGCSInput{
-			Service: testServiceID,
-			Version: tv.Number,
-			Name:    "test-gcs",
-			NewName: "new-test-gcs",
+			Service:     testServiceID,
+			Version:     tv.Number,
+			Name:        "test-gcs",
+			NewName:     "new-test-gcs",
+			MessageType: "classic",
 		})
 	})
 	if err != nil {
@@ -168,6 +169,9 @@ func TestClient_GCSs(t *testing.T) {
 	}
 	if ugcs.Name != "new-test-gcs" {
 		t.Errorf("bad name: %q", ugcs.Name)
+	}
+	if ugcs.MessageType != "classic" {
+		t.Errorf("bad message_type: %q", ugcs.MessageType)
 	}
 
 	// Delete


### PR DESCRIPTION
## Proposed Change(s)

* Add missing `MessageType` field to Updates.
* Update integration test mock recordings for GCS.

## Relevant Link(s) / Documentation:

* [GCS API Docs](https://developer.fastly.com/reference/api/logging/gcs/)

## Validation

```bash
$ rm -rf fastly/fixtures/gcses
$ export FASTLY_TEST_SERVICE_ID=<foo>
$ export FASTLY_API_KEY=<foo>
$ make test-full TESTARGS="-run=GCS -count=1"
$ make test TESTARGS="-run=GCS -count=1"
$ make fix-fixtures
$ unset FASTLY_TEST_SERVICE_ID FASTLY_API_KEY
$ make test
```