### PR TITLE
Add Region field to all Scalyr CRUD actions

### DIFF
--- a/fastly/fixtures/scalyrs/cleanup.yaml
+++ b/fastly/fixtures/scalyrs/cleanup.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/132/logging/scalyr/test-scalyr
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/10/logging/scalyr/test-scalyr
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e test-scalyr, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 132 }''"}'
+      version =\u003e 10 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -22,11 +22,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 12:00:01 GMT
+      - Wed, 03 Jun 2020 14:26:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "997"
+      - "990"
       Fastly-Ratelimit-Reset:
-      - "1588942800"
+      - "1591196400"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17440-PAO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-dca17749-DCA
       X-Timer:
-      - S1588939201.493936,VS0,VE191
+      - S1591194369.266169,VS0,VE103
     status: 404 Not Found
     code: 404
     duration: ""
@@ -52,13 +52,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/132/logging/scalyr/new-test-scalyr
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/10/logging/scalyr/new-test-scalyr
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e new-test-scalyr, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 132 }''"}'
+      version =\u003e 10 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -68,11 +68,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 12:00:01 GMT
+      - Wed, 03 Jun 2020 14:26:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "996"
+      - "989"
       Fastly-Ratelimit-Reset:
-      - "1588942800"
+      - "1591196400"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -87,9 +87,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17440-PAO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-dca17749-DCA
       X-Timer:
-      - S1588939202.703577,VS0,VE193
+      - S1591194369.399321,VS0,VE115
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/scalyrs/create.yaml
+++ b/fastly/fixtures/scalyrs/create.yaml
@@ -2,12 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=132&format=%25h+%25l+%25u+%25t+%22%25r%22+%25%3Es+%25b&format_version=2&name=test-scalyr&placement=waf_debug&token=super-secure-token
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=10&format=%25h+%25l+%25u+%25t+%22%25r%22+%25%3Es+%25b&format_version=2&name=test-scalyr&placement=waf_debug&region=US&token=super-secure-token
     form:
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "132"
+      - "10"
       format:
       - '%h %l %u %t "%r" %>s %b'
       format_version:
@@ -16,17 +16,19 @@ interactions:
       - test-scalyr
       placement:
       - waf_debug
+      region:
+      - US
       token:
       - super-secure-token
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/132/logging/scalyr
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/10/logging/scalyr
     method: POST
   response:
-    body: '{"format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","name":"test-scalyr","placement":"waf_debug","token":"super-secure-token","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"132","created_at":"2020-05-08T11:59:59Z","response_condition":"","deleted_at":null,"updated_at":"2020-05-08T11:59:59Z"}'
+    body: '{"format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","name":"test-scalyr","placement":"waf_debug","region":"US","token":"super-secure-token","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"10","updated_at":"2020-06-03T14:26:08Z","response_condition":"","deleted_at":null,"created_at":"2020-06-03T14:26:08Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -36,11 +38,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 12:00:00 GMT
+      - Wed, 03 Jun 2020 14:26:08 GMT
       Fastly-Ratelimit-Remaining:
-      - "859"
+      - "993"
       Fastly-Ratelimit-Reset:
-      - "1588939200"
+      - "1591196400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -55,9 +57,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17440-PAO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-dca17749-DCA
       X-Timer:
-      - S1588939199.458383,VS0,VE625
+      - S1591194368.947134,VS0,VE409
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/delete.yaml
+++ b/fastly/fixtures/scalyrs/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/132/logging/scalyr/new-test-scalyr
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/10/logging/scalyr/new-test-scalyr
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -20,11 +20,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 12:00:01 GMT
+      - Wed, 03 Jun 2020 14:26:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "998"
+      - "991"
       Fastly-Ratelimit-Reset:
-      - "1588942800"
+      - "1591196400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17440-PAO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-dca17749-DCA
       X-Timer:
-      - S1588939201.206751,VS0,VE272
+      - S1591194369.064099,VS0,VE172
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/get.yaml
+++ b/fastly/fixtures/scalyrs/get.yaml
@@ -6,12 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/132/logging/scalyr/test-scalyr
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/10/logging/scalyr/test-scalyr
     method: GET
   response:
-    body: '{"placement":"waf_debug","name":"test-scalyr","format":"%h %l %u %t \"%r\"
-      %\u003es %b","deleted_at":null,"created_at":"2020-05-08T11:59:59Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","version":"132","response_condition":"","updated_at":"2020-05-08T11:59:59Z","token":"super-secure-token"}'
+    body: '{"response_condition":"","format":"%h %l %u %t \"%r\" %\u003es %b","service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","created_at":"2020-06-03T14:26:08Z","deleted_at":null,"region":"US","token":"super-secure-token","version":"10","name":"test-scalyr","updated_at":"2020-06-03T14:26:08Z","placement":"waf_debug"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -25,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 12:00:00 GMT
+      - Wed, 03 Jun 2020 14:26:08 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -40,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17440-PAO
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-dca17749-DCA
       X-Timer:
-      - S1588939200.304759,VS0,VE182
+      - S1591194369.504288,VS0,VE93
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/list.yaml
+++ b/fastly/fixtures/scalyrs/list.yaml
@@ -6,12 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/132/logging/scalyr
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/10/logging/scalyr
     method: GET
   response:
-    body: '[{"placement":"waf_debug","name":"test-scalyr","format":"%h %l %u %t \"%r\"
-      %\u003es %b","deleted_at":null,"updated_at":"2020-05-08T11:59:59Z","token":"super-secure-token","version":"132","format_version":"2","service_id":"7i6HN3TK9wS159v2gPAZ8A","response_condition":"","created_at":"2020-05-08T11:59:59Z"}]'
+    body: '[{"token":"super-secure-token","format":"%h %l %u %t \"%r\" %\u003es %b","service_id":"7i6HN3TK9wS159v2gPAZ8A","placement":"waf_debug","created_at":"2020-06-03T14:26:08Z","name":"test-scalyr","updated_at":"2020-06-03T14:26:08Z","region":"US","deleted_at":null,"format_version":"2","version":"10","response_condition":""}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -25,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 12:00:00 GMT
+      - Wed, 03 Jun 2020 14:26:08 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -40,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17440-PAO
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-dca17749-DCA
       X-Timer:
-      - S1588939200.100557,VS0,VE189
+      - S1591194368.387144,VS0,VE91
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/update.yaml
+++ b/fastly/fixtures/scalyrs/update.yaml
@@ -2,28 +2,29 @@
 version: 1
 interactions:
 - request:
-    body: Name=test-scalyr&Service=7i6HN3TK9wS159v2gPAZ8A&Version=132&name=new-test-scalyr&token=new-token
+    body: Name=test-scalyr&Service=7i6HN3TK9wS159v2gPAZ8A&Version=10&name=new-test-scalyr&region=EU&token=new-token
     form:
       Name:
       - test-scalyr
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "132"
+      - "10"
       name:
       - new-test-scalyr
+      region:
+      - EU
       token:
       - new-token
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/132/logging/scalyr/test-scalyr
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/10/logging/scalyr/test-scalyr
     method: PUT
   response:
-    body: '{"response_condition":"","token":"new-token","service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2020-05-08T11:59:59Z","version":"132","name":"new-test-scalyr","placement":"waf_debug","updated_at":"2020-05-08T11:59:59Z","deleted_at":null,"format_version":"2","format":"%h
-      %l %u %t \"%r\" %\u003es %b"}'
+    body: '{"format":"%h %l %u %t \"%r\" %\u003es %b","token":"new-token","response_condition":"","created_at":"2020-06-03T14:26:08Z","version":"10","name":"new-test-scalyr","format_version":"2","deleted_at":null,"updated_at":"2020-06-03T14:26:08Z","placement":"waf_debug","service_id":"7i6HN3TK9wS159v2gPAZ8A","region":"EU"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -33,11 +34,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 12:00:01 GMT
+      - Wed, 03 Jun 2020 14:26:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "999"
+      - "992"
       Fastly-Ratelimit-Reset:
-      - "1588942800"
+      - "1591196400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -52,9 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17440-PAO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-dca17749-DCA
       X-Timer:
-      - S1588939201.504254,VS0,VE687
+      - S1591194369.626285,VS0,VE410
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/version.yaml
+++ b/fastly/fixtures/scalyrs/version.yaml
@@ -10,11 +10,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":132}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":10}'
     headers:
       Accept-Ranges:
       - bytes
@@ -24,11 +24,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 11:59:59 GMT
+      - Wed, 03 Jun 2020 14:26:07 GMT
       Fastly-Ratelimit-Remaining:
-      - "860"
+      - "994"
       Fastly-Ratelimit-Reset:
-      - "1588939200"
+      - "1591196400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17440-PAO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-dca17749-DCA
       X-Timer:
-      - S1588939199.091107,VS0,VE352
+      - S1591194368.766089,VS0,VE153
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/scalyr.go
+++ b/fastly/scalyr.go
@@ -16,6 +16,7 @@ type Scalyr struct {
 	Format            string     `mapstructure:"format"`
 	FormatVersion     uint       `mapstructure:"format_version"`
 	Token             string     `mapstructure:"token"`
+	Region            string     `mapstructure:"region"`
 	ResponseCondition string     `mapstructure:"response_condition"`
 	Placement         string     `mapstructure:"placement"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
@@ -77,6 +78,7 @@ type CreateScalyrInput struct {
 	Format            *string `form:"format,omitempty"`
 	FormatVersion     *uint   `form:"format_version,omitempty"`
 	Token             *string `form:"token,omitempty"`
+	Region            *string `form:"region,omitempty"`
 	ResponseCondition *string `form:"response_condition,omitempty"`
 	Placement         *string `form:"placement,omitempty"`
 }
@@ -156,6 +158,7 @@ type UpdateScalyrInput struct {
 	Format            *string `form:"format,omitempty"`
 	FormatVersion     *uint   `form:"format_version,omitempty"`
 	Token             *string `form:"token,omitempty"`
+	Region            *string `form:"region,omitempty"`
 	ResponseCondition *string `form:"response_condition,omitempty"`
 	Placement         *string `form:"placement,omitempty"`
 }

--- a/fastly/scalyr_test.go
+++ b/fastly/scalyr_test.go
@@ -23,6 +23,7 @@ func TestClient_Scalyrs(t *testing.T) {
 			Format:        String("%h %l %u %t \"%r\" %>s %b"),
 			FormatVersion: Uint(2),
 			Placement:     String("waf_debug"),
+			Region:        String("US"),
 			Token:         String("super-secure-token"),
 		})
 	})
@@ -58,6 +59,9 @@ func TestClient_Scalyrs(t *testing.T) {
 	}
 	if s.Placement != "waf_debug" {
 		t.Errorf("bad placement: %q", s.Placement)
+	}
+	if s.Region != "US" {
+		t.Errorf("bad region: %q", s.Region)
 	}
 	if s.Token != "super-secure-token" {
 		t.Errorf("bad token: %q", s.Token)
@@ -102,6 +106,9 @@ func TestClient_Scalyrs(t *testing.T) {
 	if s.Placement != ns.Placement {
 		t.Errorf("bad placement: %q", s.Placement)
 	}
+	if s.Region != "US" {
+		t.Errorf("bad region: %q", s.Region)
+	}
 	if s.Token != ns.Token {
 		t.Errorf("bad token: %q", s.Token)
 	}
@@ -114,6 +121,7 @@ func TestClient_Scalyrs(t *testing.T) {
 			Version: tv.Number,
 			Name:    "test-scalyr",
 			NewName: String("new-test-scalyr"),
+			Region:  String("EU"),
 			Token:   String("new-token"),
 		})
 	})
@@ -122,6 +130,9 @@ func TestClient_Scalyrs(t *testing.T) {
 	}
 	if us.Name != "new-test-scalyr" {
 		t.Errorf("bad name: %q", us.Name)
+	}
+	if us.Region != "EU" {
+		t.Errorf("bad region: %q", us.Region)
 	}
 	if us.Token != "new-token" {
 		t.Errorf("bad token: %q", us.Token)


### PR DESCRIPTION
## Proposed Change(s)

* Add missing `Region` field to Creates, Updates and all CRUD responses.
* Update integration test mock recordings for Scalyr.

## Relevant Link(s) / Documentation

* [Scalyr API Docs](https://developer.fastly.com/reference/api/logging/scalyr/)

## Validation

```bash
$ export FASTLY_TEST_SERVICE_ID=<foo>; \
export FASTLY_API_KEY="$(stoml ~/.config/fastly/config.toml token)"; \
rm -rf fastly/fixtures/scalyrs && \
make test TESTARGS="-run=Scalyr -count=1" && \
make fix-fixtures && \
unset FASTLY_TEST_SERVICE_ID FASTLY_API_KEY && \
make test
```