### PR TITLE
Add User field to Cloudfiles Updates

### DIFF
--- a/fastly/cloudfiles.go
+++ b/fastly/cloudfiles.go
@@ -171,6 +171,7 @@ type UpdateCloudfilesInput struct {
 	Name string
 
 	NewName           *string `form:"name,omitempty"`
+	User              *string `form:"user,omitempty"`
 	AccessKey         *string `form:"access_key,omitempty"`
 	BucketName        *string `form:"bucket_name,omitempty"`
 	Path              *string `form:"path,omitempty"`

--- a/fastly/cloudfiles_test.go
+++ b/fastly/cloudfiles_test.go
@@ -175,6 +175,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 			Version:       tv.Number,
 			Name:          "test-cloudfiles",
 			NewName:       String("new-test-cloudfiles"),
+			User:          String("new-user"),
 			Period:        Uint(0),
 			GzipLevel:     Uint(0),
 			FormatVersion: Uint(2),
@@ -185,6 +186,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 	}
 	if ucloudfiles.Name != "new-test-cloudfiles" {
 		t.Errorf("bad name: %q", ucloudfiles.Name)
+	}
+	if ucloudfiles.User != "new-user" {
+		t.Errorf("bad user: %q", ucloudfiles.User)
 	}
 	if ucloudfiles.GzipLevel != 0 {
 		t.Errorf("bad gzip_level: %q", ucloudfiles.GzipLevel)

--- a/fastly/fixtures/cloudfiles/cleanup.yaml
+++ b/fastly/fixtures/cloudfiles/cleanup.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/101/logging/cloudfiles/test-cloudfiles
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/logging/cloudfiles/test-cloudfiles
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e test-cloudfiles, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 101 }''"}'
+      version =\u003e 14 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -22,11 +22,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 00:39:47 GMT
+      - Wed, 03 Jun 2020 15:00:22 GMT
       Fastly-Ratelimit-Remaining:
       - "995"
       Fastly-Ratelimit-Reset:
-      - "1588899600"
+      - "1591200000"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17438-PAO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-dca17728-DCA
       X-Timer:
-      - S1588898387.331904,VS0,VE191
+      - S1591196422.107294,VS0,VE96
     status: 404 Not Found
     code: 404
     duration: ""
@@ -52,13 +52,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/101/logging/cloudfiles/new-test-cloudfiles
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/logging/cloudfiles/new-test-cloudfiles
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e new-test-cloudfiles, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 101 }''"}'
+      version =\u003e 14 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -68,11 +68,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 00:39:47 GMT
+      - Wed, 03 Jun 2020 15:00:22 GMT
       Fastly-Ratelimit-Remaining:
       - "994"
       Fastly-Ratelimit-Reset:
-      - "1588899600"
+      - "1591200000"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -87,9 +87,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17438-PAO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-dca17728-DCA
       X-Timer:
-      - S1588898388.539481,VS0,VE181
+      - S1591196422.230100,VS0,VE111
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/cloudfiles/create.yaml
+++ b/fastly/fixtures/cloudfiles/create.yaml
@@ -2,12 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=101&access_key=secret-key&bucket_name=bucket-name&format=format&format_version=1&gzip_level=9&message_type=classic&name=test-cloudfiles&path=%2Fpath&period=12&placement=waf_debug&public_key=-----BEGIN+PGP+PUBLIC+KEY+BLOCK-----%0A%0AmQENBFyUD8sBCACyFnB39AuuTygseek%2BeA4fo0cgwva6%2FFSjnWq7riouQee8GgQ%2F%0AibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr%2BIZ4GVGJqs6ZJnvQcqe3xPoR4%0A8AnBfw90o32r%2FLuHf6QCJXi%2BAEu35koNlNAvLJ2B%2BKACaNB7N0EeWmqpV%2F1V2k9p%0AlDYk%2Bth7LcCuaFNGqKS%2FPrMnnMqR6VDLCjHhNx4KR79b0Twm%2F2qp6an3hyNRu8Gn%0Adwxpf1%2FBUu3JWf%2BLqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB%0A89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz%0AdCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6%0AvFFc9jxV%2FwUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc%0A9jxV%2F815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg%2BmjM3b8N7iXm9%0AOLX59fbDAWtBSldSZE22RXd3CvlFOG%2FEnKBXSjBtEqfyxYSnyOPkMPBYWGL%2FApkX%0ASvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR%2B3rv1u3aoy7%2Fs2EltAfDS3ZQIq%0A7%2FcWTLJml%2FlleeB%2FY6rPj8xqeCYhE5ahw9gsV%2FMdqatl24V9Tks30iijx0Hhw%2BGx%0AkATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe%2FKY9M2yVnMHUXmAZwbG%0AM1cMI%2FNH1DjevCKdGBLcRJlhuLPKF%2FanuQENBFyUD8sBCADIpd7r7GuPd6n%2FIkxe%0Au6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y%2Fart8ip0VJ3m07L%0A4RSfSpnzqgSwdjSq5hNour2Fo%2FBzYhK7yaz2AzVSbe33R0%2BRYhb4b%2F6N%2BbKbjwGF%0AftCsqVFMH%2BPyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K%0AUEGUcTzz%2B8QGAwAra%2B0ewPXo%2FAkO%2B8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu%0AYrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O%2B0F1G7ttZ2GRRgVBZPwi%0AkiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV%2FwUCXJQPywIb%0ADAAKCRC6vFFc9jxV%2F9YOCACe8qmOSnKQpQfW%2BPqYOqo3dt7JyweTs3FkD6NT8Zml%0AdYy%2FvkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L%0A3Tp90NN%2BQY5WDbsGmsyk6%2B6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c%0AFaNmEfKKy%2Fr1PO20NXEG6t9t05K%2FfrHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR%0A5%2BzkkSq%2FeG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR%0AwMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr%2BN%0A%3D28dr%0A-----END+PGP+PUBLIC+KEY+BLOCK-----%0A&region=DFW&timestamp_format=%25Y&user=user
+    body: Service=7i6HN3TK9wS159v2gPAZ8A&Version=14&access_key=secret-key&bucket_name=bucket-name&format=format&format_version=1&gzip_level=9&message_type=classic&name=test-cloudfiles&path=%2Fpath&period=12&placement=waf_debug&public_key=-----BEGIN+PGP+PUBLIC+KEY+BLOCK-----%0A%0AmQENBFyUD8sBCACyFnB39AuuTygseek%2BeA4fo0cgwva6%2FFSjnWq7riouQee8GgQ%2F%0AibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr%2BIZ4GVGJqs6ZJnvQcqe3xPoR4%0A8AnBfw90o32r%2FLuHf6QCJXi%2BAEu35koNlNAvLJ2B%2BKACaNB7N0EeWmqpV%2F1V2k9p%0AlDYk%2Bth7LcCuaFNGqKS%2FPrMnnMqR6VDLCjHhNx4KR79b0Twm%2F2qp6an3hyNRu8Gn%0Adwxpf1%2FBUu3JWf%2BLqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB%0A89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz%0AdCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6%0AvFFc9jxV%2FwUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc%0A9jxV%2F815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg%2BmjM3b8N7iXm9%0AOLX59fbDAWtBSldSZE22RXd3CvlFOG%2FEnKBXSjBtEqfyxYSnyOPkMPBYWGL%2FApkX%0ASvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR%2B3rv1u3aoy7%2Fs2EltAfDS3ZQIq%0A7%2FcWTLJml%2FlleeB%2FY6rPj8xqeCYhE5ahw9gsV%2FMdqatl24V9Tks30iijx0Hhw%2BGx%0AkATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe%2FKY9M2yVnMHUXmAZwbG%0AM1cMI%2FNH1DjevCKdGBLcRJlhuLPKF%2FanuQENBFyUD8sBCADIpd7r7GuPd6n%2FIkxe%0Au6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y%2Fart8ip0VJ3m07L%0A4RSfSpnzqgSwdjSq5hNour2Fo%2FBzYhK7yaz2AzVSbe33R0%2BRYhb4b%2F6N%2BbKbjwGF%0AftCsqVFMH%2BPyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K%0AUEGUcTzz%2B8QGAwAra%2B0ewPXo%2FAkO%2B8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu%0AYrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O%2B0F1G7ttZ2GRRgVBZPwi%0AkiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV%2FwUCXJQPywIb%0ADAAKCRC6vFFc9jxV%2F9YOCACe8qmOSnKQpQfW%2BPqYOqo3dt7JyweTs3FkD6NT8Zml%0AdYy%2FvkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L%0A3Tp90NN%2BQY5WDbsGmsyk6%2B6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c%0AFaNmEfKKy%2Fr1PO20NXEG6t9t05K%2FfrHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR%0A5%2BzkkSq%2FeG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR%0AwMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr%2BN%0A%3D28dr%0A-----END+PGP+PUBLIC+KEY+BLOCK-----%0A&region=DFW&timestamp_format=%25Y&user=user
     form:
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "101"
+      - "14"
       access_key:
       - secret-key
       bucket_name:
@@ -70,13 +70,13 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/101/logging/cloudfiles
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/logging/cloudfiles
     method: POST
   response:
     body: '{"access_key":"secret-key","bucket_name":"bucket-name","format":"format","format_version":"1","gzip_level":"9","message_type":"classic","name":"test-cloudfiles","path":"/path","period":"12","placement":"waf_debug","public_key":"-----BEGIN
       PGP PUBLIC KEY BLOCK-----\n\nmQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/\nibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4\n8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p\nlDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn\ndwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB\n89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz\ndCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6\nvFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc\n9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9\nOLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX\nSvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq\n7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx\nkATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG\nM1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe\nu6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L\n4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF\nftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K\nUEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu\nYrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi\nkiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb\nDAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml\ndYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L\n3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c\nFaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR\n5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR\nwMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N\n=28dr\n-----END
-      PGP PUBLIC KEY BLOCK-----\n","region":"DFW","timestamp_format":"%Y","user":"user","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"101","deleted_at":null,"response_condition":"","created_at":"2020-05-08T00:39:45Z","updated_at":"2020-05-08T00:39:45Z"}'
+      PGP PUBLIC KEY BLOCK-----\n","region":"DFW","timestamp_format":"%Y","user":"user","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"14","updated_at":"2020-06-03T15:00:20Z","response_condition":"","deleted_at":null,"created_at":"2020-06-03T15:00:20Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -86,11 +86,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 00:39:45 GMT
+      - Wed, 03 Jun 2020 15:00:21 GMT
       Fastly-Ratelimit-Remaining:
       - "998"
       Fastly-Ratelimit-Reset:
-      - "1588899600"
+      - "1591200000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -105,9 +105,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17438-PAO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-dca17728-DCA
       X-Timer:
-      - S1588898385.361802,VS0,VE508
+      - S1591196421.778199,VS0,VE333
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/cloudfiles/delete.yaml
+++ b/fastly/fixtures/cloudfiles/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/101/logging/cloudfiles/new-test-cloudfiles
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/logging/cloudfiles/new-test-cloudfiles
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -20,11 +20,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 00:39:47 GMT
+      - Wed, 03 Jun 2020 15:00:22 GMT
       Fastly-Ratelimit-Remaining:
       - "996"
       Fastly-Ratelimit-Reset:
-      - "1588899600"
+      - "1591200000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-pao17438-PAO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-dca17728-DCA
       X-Timer:
-      - S1588898387.948384,VS0,VE369
+      - S1591196422.926397,VS0,VE157
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/cloudfiles/get.yaml
+++ b/fastly/fixtures/cloudfiles/get.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/101/logging/cloudfiles/test-cloudfiles
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/logging/cloudfiles/test-cloudfiles
     method: GET
   response:
-    body: '{"region":"DFW","placement":"waf_debug","period":"12","gzip_level":"9","name":"test-cloudfiles","bucket_name":"bucket-name","public_key":"-----BEGIN
+    body: '{"timestamp_format":"%Y","service_id":"7i6HN3TK9wS159v2gPAZ8A","placement":"waf_debug","message_type":"classic","updated_at":"2020-06-03T15:00:20Z","region":"DFW","gzip_level":"9","public_key":"-----BEGIN
       PGP PUBLIC KEY BLOCK-----\n\nmQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/\nibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4\n8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p\nlDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn\ndwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB\n89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz\ndCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6\nvFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc\n9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9\nOLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX\nSvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq\n7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx\nkATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG\nM1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe\nu6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L\n4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF\nftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K\nUEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu\nYrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi\nkiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb\nDAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml\ndYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L\n3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c\nFaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR\n5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR\nwMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N\n=28dr\n-----END
-      PGP PUBLIC KEY BLOCK-----\n","access_key":"secret-key","user":"user","message_type":"classic","created_at":"2020-05-08T00:39:45Z","timestamp_format":"%Y","updated_at":"2020-05-08T00:39:45Z","format_version":"1","version":"101","service_id":"7i6HN3TK9wS159v2gPAZ8A","response_condition":"","path":"/path","format":"format","deleted_at":null}'
+      PGP PUBLIC KEY BLOCK-----\n","user":"user","bucket_name":"bucket-name","format":"format","response_condition":"","path":"/path","access_key":"secret-key","format_version":"1","period":"12","name":"test-cloudfiles","version":"14","created_at":"2020-06-03T15:00:20Z","deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 00:39:46 GMT
+      - Wed, 03 Jun 2020 15:00:21 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17438-PAO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-dca17728-DCA
       X-Timer:
-      - S1588898386.087700,VS0,VE175
+      - S1591196421.272963,VS0,VE135
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/cloudfiles/list.yaml
+++ b/fastly/fixtures/cloudfiles/list.yaml
@@ -6,12 +6,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/101/logging/cloudfiles
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/logging/cloudfiles
     method: GET
   response:
-    body: '[{"public_key":"-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/\nibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4\n8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p\nlDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn\ndwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB\n89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz\ndCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6\nvFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc\n9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9\nOLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX\nSvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq\n7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx\nkATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG\nM1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe\nu6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L\n4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF\nftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K\nUEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu\nYrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi\nkiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb\nDAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml\ndYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L\n3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c\nFaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR\n5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR\nwMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N\n=28dr\n-----END
-      PGP PUBLIC KEY BLOCK-----\n","gzip_level":"9","format_version":"1","region":"DFW","placement":"waf_debug","created_at":"2020-05-08T00:39:45Z","format":"format","deleted_at":null,"response_condition":"","version":"101","access_key":"secret-key","message_type":"classic","period":"12","updated_at":"2020-05-08T00:39:45Z","path":"/path","user":"user","name":"test-cloudfiles","timestamp_format":"%Y","bucket_name":"bucket-name","service_id":"7i6HN3TK9wS159v2gPAZ8A"}]'
+    body: '[{"user":"user","public_key":"-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/\nibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4\n8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p\nlDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn\ndwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB\n89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz\ndCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6\nvFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc\n9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9\nOLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX\nSvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq\n7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx\nkATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG\nM1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe\nu6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L\n4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF\nftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K\nUEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu\nYrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi\nkiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb\nDAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml\ndYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L\n3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c\nFaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR\n5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR\nwMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N\n=28dr\n-----END
+      PGP PUBLIC KEY BLOCK-----\n","region":"DFW","gzip_level":"9","placement":"waf_debug","message_type":"classic","updated_at":"2020-06-03T15:00:20Z","timestamp_format":"%Y","service_id":"7i6HN3TK9wS159v2gPAZ8A","deleted_at":null,"name":"test-cloudfiles","version":"14","created_at":"2020-06-03T15:00:20Z","format_version":"1","period":"12","path":"/path","access_key":"secret-key","response_condition":"","bucket_name":"bucket-name","format":"format"}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 00:39:46 GMT
+      - Wed, 03 Jun 2020 15:00:21 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17438-PAO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-dca17728-DCA
       X-Timer:
-      - S1588898386.886541,VS0,VE185
+      - S1591196421.145545,VS0,VE99
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/cloudfiles/update.yaml
+++ b/fastly/fixtures/cloudfiles/update.yaml
@@ -2,14 +2,14 @@
 version: 1
 interactions:
 - request:
-    body: Name=test-cloudfiles&Service=7i6HN3TK9wS159v2gPAZ8A&Version=101&format_version=2&gzip_level=0&name=new-test-cloudfiles&period=0
+    body: Name=test-cloudfiles&Service=7i6HN3TK9wS159v2gPAZ8A&Version=14&format_version=2&gzip_level=0&name=new-test-cloudfiles&period=0&user=new-user
     form:
       Name:
       - test-cloudfiles
       Service:
       - 7i6HN3TK9wS159v2gPAZ8A
       Version:
-      - "101"
+      - "14"
       format_version:
       - "2"
       gzip_level:
@@ -18,17 +18,19 @@ interactions:
       - new-test-cloudfiles
       period:
       - "0"
+      user:
+      - new-user
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/101/logging/cloudfiles/test-cloudfiles
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/logging/cloudfiles/test-cloudfiles
     method: PUT
   response:
-    body: '{"access_key":"secret-key","version":"101","format":"format","placement":"waf_debug","path":"/path","created_at":"2020-05-08T00:39:45Z","public_key":"-----BEGIN
+    body: '{"path":"/path","access_key":"secret-key","response_condition":"","format":"format","bucket_name":"bucket-name","deleted_at":null,"version":"14","name":"new-test-cloudfiles","created_at":"2020-06-03T15:00:20Z","format_version":"2","period":"0","message_type":"classic","placement":"waf_debug","updated_at":"2020-06-03T15:00:20Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","timestamp_format":"%Y","user":"new-user","public_key":"-----BEGIN
       PGP PUBLIC KEY BLOCK-----\n\nmQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/\nibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4\n8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p\nlDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn\ndwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB\n89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz\ndCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6\nvFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc\n9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9\nOLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX\nSvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq\n7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx\nkATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG\nM1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe\nu6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L\n4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF\nftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K\nUEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu\nYrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi\nkiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb\nDAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml\ndYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L\n3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c\nFaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR\n5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR\nwMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N\n=28dr\n-----END
-      PGP PUBLIC KEY BLOCK-----\n","user":"user","message_type":"classic","period":"0","service_id":"7i6HN3TK9wS159v2gPAZ8A","timestamp_format":"%Y","bucket_name":"bucket-name","gzip_level":"0","region":"DFW","name":"new-test-cloudfiles","deleted_at":null,"format_version":"2","updated_at":"2020-05-08T00:39:45Z","response_condition":""}'
+      PGP PUBLIC KEY BLOCK-----\n","gzip_level":"0","region":"DFW"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -38,11 +40,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 00:39:46 GMT
+      - Wed, 03 Jun 2020 15:00:21 GMT
       Fastly-Ratelimit-Remaining:
       - "997"
       Fastly-Ratelimit-Reset:
-      - "1588899600"
+      - "1591200000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,9 +59,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-pao17438-PAO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-dca17728-DCA
       X-Timer:
-      - S1588898386.282707,VS0,VE650
+      - S1591196421.440436,VS0,VE457
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/cloudfiles/version.yaml
+++ b/fastly/fixtures/cloudfiles/version.yaml
@@ -10,11 +10,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/1.10.0 (+github.com/fastly/go-fastly; go1.14.2)
+      - FastlyGo/1.14.0 (+github.com/fastly/go-fastly; go1.14.2)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":101}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":14}'
     headers:
       Accept-Ranges:
       - bytes
@@ -24,11 +24,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 08 May 2020 00:39:45 GMT
+      - Wed, 03 Jun 2020 15:00:20 GMT
       Fastly-Ratelimit-Remaining:
       - "999"
       Fastly-Ratelimit-Reset:
-      - "1588899600"
+      - "1591200000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-pao17438-PAO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-dca17728-DCA
       X-Timer:
-      - S1588898385.938200,VS0,VE402
+      - S1591196421.558304,VS0,VE190
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
## Proposed Change(s)

* Add missing `User` field to Updates.
* Update integration test mock recordings for Cloudfiles.

## Relevant Link(s) / Documentation

* [API Docs](https://developer.fastly.com/reference/api/logging/cloudfiles/)

## Validation

```bash
$ export FASTLY_TEST_SERVICE_ID=<foo>; \
export FASTLY_API_KEY="$(stoml ~/.config/fastly/config.toml token)"; \
rm -rf fastly/fixtures/cloudfile* && \
make test TESTARGS="-run=Cloudfiles -count=1" && \
make fix-fixtures && \
unset FASTLY_TEST_SERVICE_ID FASTLY_API_KEY && \
make test
```