### PR TITLE
v1.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v1.15.0](https://github.com/fastly/go-fastly/releases/tag/v1.15.0) (2020-06-04)
+
+[Full Changelog](https://github.com/fastly/go-fastly/compare/v1.14.0...v1.15.0)
+
+**Enhancements:**
+
+- Add PublicKey field to S3 all CRUD actions [\#198](https://github.com/fastly/go-fastly/pull/198)
+- Add User field to Cloudfiles Updates [\#197](https://github.com/fastly/go-fastly/pull/197)
+- Remove extraneous Token field from all Kafka CRUD [\#196](https://github.com/fastly/go-fastly/pull/196)
+- Add Region field to all Scalyr CRUD actions [\#195](https://github.com/fastly/go-fastly/pull/195)
+- Add MessageType field to all SFTP CRUD actions [\#194](https://github.com/fastly/go-fastly/pull/194)
+- Add MessageType field to GCS Updates [\#193](https://github.com/fastly/go-fastly/pull/193)
+
 # Historical Manual Changelog
 
 All notable changes to this project will be documented in this file.

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -44,7 +44,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "1.14.0"
+var ProjectVersion = "1.15.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",


### PR DESCRIPTION
## Proposed Change(s)

Prepare for v1.15.0 release:
  * Update changelog
  * Update client version

~Blocked by https://github.com/fastly/go-fastly/pull/199~

## Note(s)
* Steps followed:
  * `bash -c 'CHANGELOG_GITHUB_TOKEN=$(cat ~/.github/credentials) SEMVER_TAG="v1.15.0" make changelog'`
  * `bash -c 'CHANGELOG_GITHUB_TOKEN=$(cat ~/.github/credentials) SEMVER_TAG="v1.15.0" make release-changelog'`
   
`make release-changelog` generates the following

```
# Changelog

## [Unreleased](https://github.com/fastly/go-fastly/releases/tag/HEAD)

[Full Changelog](https://github.com/fastly/go-fastly/compare/v1.14.0...HEAD)

**Enhancements:**

- Add PublicKey field to S3 all CRUD actions [\#198](https://github.com/fastly/go-fastly/pull/198)
- Add User field to Cloudfiles Updates [\#197](https://github.com/fastly/go-fastly/pull/197)
- Remove extraneous Token field from all Kafka CRUD [\#196](https://github.com/fastly/go-fastly/pull/196)
- Add Region field to all Scalyr CRUD actions [\#195](https://github.com/fastly/go-fastly/pull/195)
- Add MessageType field to all SFTP CRUD actions [\#194](https://github.com/fastly/go-fastly/pull/194)
- Add MessageType field to GCS Updates [\#193](https://github.com/fastly/go-fastly/pull/193)



\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

```