### PR TITLE
Update docs.fastly.com links

### DIFF
--- a/fastly/realtime_stats.go
+++ b/fastly/realtime_stats.go
@@ -31,7 +31,7 @@ type GetRealtimeStatsInput struct {
 // GetRealtimeStats returns realtime stats for a service based on the GetRealtimeStatsInput
 // parameter. The realtime stats work in a rolling fashion where first request will return
 // a timestamp which should be passed to the next call and so on.
-// More details at https://docs.fastly.com/api/analytics
+// More details at https://developer.fastly.com/reference/api/metrics-stats/realtime/
 func (c *RTSClient) GetRealtimeStats(i *GetRealtimeStatsInput) (*RealtimeStatsResponse, error) {
 	var resp interface{}
 	if err := c.GetRealtimeStatsJSON(i, &resp); err != nil {

--- a/fastly/stats.go
+++ b/fastly/stats.go
@@ -84,7 +84,7 @@ type Stats struct {
 // GetStatsInput is an input to the GetStats function.
 // Stats can be filtered by a Service ID, an individual stats field,
 // time range (From and To), sampling rate (By) and/or Fastly region (Region)
-// Allowed values for the fields are described at https://docs.fastly.com/api/stats
+// Allowed values for the fields are described at https://developer.fastly.com/reference/api/metrics-stats/
 type GetStatsInput struct {
 	Service string
 	Field   string
@@ -170,7 +170,7 @@ type UsageResponse struct {
 }
 
 // GetUsageInput is used as an input to the GetUsage function
-// Value for the input are described at https://docs.fastly.com/api/stats
+// Value for the input are described at https://developer.fastly.com/reference/api/metrics-stats/
 type GetUsageInput struct {
 	From   string
 	To     string

--- a/fastly/tls.go
+++ b/fastly/tls.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetPrivateKeyInput is an input to the GetPrivateKey function.
-// Allowed values for the fields are described at https://docs.fastly.com/api/platform-tls.
+// Allowed values for the fields are described at https://developer.fastly.com/reference/api/tls/platform/.
 type GetPrivateKeyInput struct {
 	ID string
 }


### PR DESCRIPTION
Over time the content on https://docs.fastly.com/ has been reorganised and some content has moved to https://developer.fastly.com/. This commit updates the links to point to their new locations.