### PR TITLE
Set maximum dictionary/ACL sizes to 1,000

### DIFF
--- a/fastly/fastly.go
+++ b/fastly/fastly.go
@@ -18,10 +18,10 @@ const (
 	BatchModifyMaximumOperations = 1000
 
 	// Represents the maximum number of items that can be placed within an Edge Dictionary.
-	MaximumDictionarySize = 10000
+	MaximumDictionarySize = 1000
 
 	// Represents the maximum number of entries that can be placed within an ACL.
-	MaximumACLSize = 10000
+	MaximumACLSize = 1000
 )
 
 type statusResp struct {


### PR DESCRIPTION
This reduces the exported constants specifying the maximum sizes of ACLs and service dictionaries from 10,000 to 1,000, to match the documentation: 

> ACL containers are limited to 1000 ACL entries.

https://docs.fastly.com/en/guides/about-acls

> Dictionary containers are limited to 1000 items.

https://docs.fastly.com/en/guides/about-edge-dictionaries

This was originally introduced in https://github.com/fastly/go-fastly/pull/129 for use in Terraform, which is where I discovered this discrepancy. The behavior I observed was that changes appeared to succeed but the resulting ACL truncated excess entries.