### PR TITLE
Update godoc link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Go Fastly
 =========
 [![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godocs]
 
-[godocs]: https://pkg.go.dev/github.com/fastly/go-fastly?tab=overview
+[godocs]: https://pkg.go.dev/github.com/fastly/go-fastly/fastly?tab=doc
 
 Go Fastly is a Golang API client for interacting with most facets of the
 [Fastly API](https://docs.fastly.com/api).


### PR DESCRIPTION
### TL;DR
Due to the package structure its hard to find the actual page which has the docs on pkg.go.dev, this updates the link to go straight to the type doc page.