### PR TITLE
Added support for /datacenters API call

### DIFF
--- a/fastly/datacenters.go
+++ b/fastly/datacenters.go
@@ -1,12 +1,20 @@
 package fastly
 
+// Coordinates represent the location of a datacenter.
+type Coordinates struct {
+	Latitude   float64 `mapstructure:"latitude"`
+	Longtitude float64 `mapstructure:"longitude"`
+	X          float64 `mapstructure:"x"`
+	Y          float64 `mapstructure:"y"`
+}
+
 // Datacenter is a list of Datacenters returned by the Fastly API.
 type Datacenter struct {
-	Code        string            `mapstructure:"code"`
-	Coordinates map[string]string `mapstructure:"coordinates"`
-	Group       string            `mapstructure:"group"`
-	Name        string            `mapstructure:"name"`
-	Shield      string            `mapstructure:"shield"`
+	Code        string      `mapstructure:"code"`
+	Coordinates Coordinates `mapstructure:"coordinates"`
+	Group       string      `mapstructure:"group"`
+	Name        string      `mapstructure:"name"`
+	Shield      string      `mapstructure:"shield"`
 }
 
 // AllDatacenters returns the lists of datacenters for Fastly's network.

--- a/fastly/datacenters.go
+++ b/fastly/datacenters.go
@@ -1,0 +1,24 @@
+package fastly
+
+// Datacenter is a list of Datacenters returned by the Fastly API.
+type Datacenter struct {
+	Code        string            `mapstructure:"code"`
+	Coordinates map[string]string `mapstructure:"coordinates"`
+	Group       string            `mapstructure:"group"`
+	Name        string            `mapstructure:"name"`
+	Shield      string            `mapstructure:"shield"`
+}
+
+// AllDatacenters returns the lists of datacenters for Fastly's network.
+func (c *Client) AllDatacenters() (datacenters []Datacenter, err error) {
+	resp, err := c.Get("/datacenters", nil)
+	if err != nil {
+		return nil, err
+	}
+	var m []Datacenter
+	if err := decodeBodyMap(resp.Body, &m); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}

--- a/fastly/datacenters_test.go
+++ b/fastly/datacenters_test.go
@@ -1,0 +1,19 @@
+package fastly
+
+import "testing"
+
+func TestDatacenters(t *testing.T) {
+	t.Parallel()
+
+	var err error
+	var datacenters []Datacenter
+	record(t, "datacenters/list", func(c *Client) {
+		datacenters, err = c.AllDatacenters()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(datacenters) == 0 {
+		t.Fatal("missing datacenters")
+	}
+}

--- a/fastly/fixtures/datacenters/list.yaml
+++ b/fastly/fixtures/datacenters/list.yaml
@@ -1,0 +1,46 @@
+---
+version: 1
+rwmutex: {}
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Fastly-Key:
+      - xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      User-Agent:
+      - FastlyGo/0.4.3.dev (+github.com/fastly/go-fastly; go1.12)
+    url: https://api.fastly.com/datacenters
+    method: GET
+  response:
+    body: '[{"code":"AMS","name":"Amsterdam","group":"Europe","coordinates":{"x":0,"y":0,"latitude":52.308613,"longitude":4.763889},"shield":"amsterdam-nl"},{"code":"IAD","name":"Ashburn","group":"United States","coordinates":{"x":0,"y":0,"latitude":38.944533,"longitude":-77.455811}}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Age:
+      - "0"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2020 20:16:27 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-mdw17325-MDW
+      X-Timer:
+      - S1594319825.301688,VS0,VE114
+    status: 200 OK
+    code: 200


### PR DESCRIPTION
Adds support for the following [utility API](https://developer.fastly.com/reference/api/utils/datacenter/).

The API `/datacenters` lists Fastly datacenters and their locations.