### PR TITLE
Allow message_type support for FTP endpoint

### DIFF
--- a/fastly/ftp.go
+++ b/fastly/ftp.go
@@ -25,6 +25,7 @@ type FTP struct {
 	FormatVersion     uint       `mapstructure:"format_version"`
 	ResponseCondition string     `mapstructure:"response_condition"`
 	TimestampFormat   string     `mapstructure:"timestamp_format"`
+	MessageType       string     `mapstructure:"message_type"`
 	Placement         string     `mapstructure:"placement"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
@@ -93,6 +94,7 @@ type CreateFTPInput struct {
 	GzipLevel         uint8  `form:"gzip_level,omitempty"`
 	Format            string `form:"format,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
+	MessageType       string `form:"message_type,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
 	Placement         string `form:"placement,omitempty"`
 }
@@ -180,6 +182,7 @@ type UpdateFTPInput struct {
 	GzipLevel         uint8  `form:"gzip_level,omitempty"`
 	Format            string `form:"format,omitempty"`
 	ResponseCondition string `form:"response_condition,omitempty"`
+	MessageType       string `form:"message_type,omitempty"`
 	TimestampFormat   string `form:"timestamp_format,omitempty"`
 	Placement         string `form:"placement,omitempty"`
 }

--- a/fastly/ftp_test.go
+++ b/fastly/ftp_test.go
@@ -29,6 +29,7 @@ func TestClient_FTPs(t *testing.T) {
 			Format:          "format",
 			TimestampFormat: "%Y",
 			Placement:       "waf_debug",
+			MessageType:     "classic",
 		})
 	})
 	if err != nil {
@@ -90,6 +91,9 @@ func TestClient_FTPs(t *testing.T) {
 	}
 	if ftp.Placement != "waf_debug" {
 		t.Errorf("bad placement: %q", ftp.Placement)
+	}
+	if ftp.MessageType != "classic" {
+		t.Errorf("bad message type: %q", ftp.MessageType)
 	}
 
 	// List
@@ -157,6 +161,9 @@ func TestClient_FTPs(t *testing.T) {
 	}
 	if ftp.Placement != nftp.Placement {
 		t.Errorf("bad placement: %q", ftp.Placement)
+	}
+	if ftp.MessageType != nftp.MessageType {
+		t.Errorf("bad message type: %q", ftp.MessageType)
 	}
 
 	// Update


### PR DESCRIPTION
This adds `message_type` support to the Go client. This is also missing from terraform so need this first before making the terraform changes.