### PR TITLE
v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.17.0](https://github.com/fastly/go-fastly/releases/tag/v1.17.0) (2020-07-16)
+
+[Full Changelog](https://github.com/fastly/go-fastly/compare/v1.16.2...v1.17.0)
+
+**Enhancements:**
+
+- Added support to list all datacenters [\#210](https://github.com/fastly/go-fastly/pull/210)
+
 ## [v1.16.2](https://github.com/fastly/go-fastly/releases/tag/v1.16.2) (2020-07-13)
 
 [Full Changelog](https://github.com/fastly/go-fastly/compare/v1.16.1...v1.16.2)

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -46,7 +46,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "1.16.2"
+var ProjectVersion = "1.17.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",


### PR DESCRIPTION
### TL;DR
Updates CHANGELOG and client version for v1.17.0 release. Includes:

- #210 Add support to list all datacenters