### PR TITLE
Setting go.mod module to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fastly/go-fastly
+module github.com/fastly/go-fastly/v2
 
 require (
 	github.com/ajg/form v0.0.0-20160802194845-cc2954064ec9


### PR DESCRIPTION
Changing module name in `go.mod` to be able to use the go-fastly `dev-v2` branch code with go modules.