### PR TITLE
v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [v1.17.0](https://github.com/fastly/go-fastly/releases/tag/v1.17.0) (2020-07-16)
+## [v1.18.0](https://github.com/fastly/go-fastly/releases/tag/v1.18.0) (2020-10-28)
+
+[Full Changelog](https://github.com/fastly/go-fastly/compare/v1.17.0...v1.18.0)
+
+**Enhancements:**
+
+- Add SASL fields support for Kafka Logging Endpoint [\#226](https://github.com/fastly/go-fastly/pull/226)
+
+## [v1.17.0](https://github.com/fastly/go-fastly/releases/tag/v1.17.0) (2020-07-20)
 
 [Full Changelog](https://github.com/fastly/go-fastly/compare/v1.16.2...v1.17.0)
 

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -46,7 +46,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "1.17.0"
+var ProjectVersion = "1.18.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",


### PR DESCRIPTION
TL;DR
Updates CHANGELOG and client version for v1.18.0 release. Includes:

#226 support for kafka endpoint sasl options