### PR TITLE
ignore prerelease tags from being released

### DIFF
--- a/scripts/release-changelog.sh
+++ b/scripts/release-changelog.sh
@@ -25,5 +25,6 @@ github_changelog_generator -u fastly -p go-fastly \
   --bugs-label "**Bug fixes:**" \
   --release-url "https://github.com/fastly/go-fastly/releases/tag/%s" \
   --exclude-labels documentation \
+  --exclude-tags-regex "v.*-.*" \
   --output RELEASE_CHANGELOG.md \
   --since-tag $prev_tag


### PR DESCRIPTION
## Proposed Change(s)

* Ignores pre-release tags from being release in release changelogs

## Note(s)

Matches what is used by `make changelog`

https://github.com/fastly/go-fastly/blame/936776b61a119658c8216a931e91d5678245d2fc/scripts/changelog.sh#L28