### PR TITLE
Add basic managed logging endpoint support to go-fastly

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ make test \
   FASTLY_TEST_SERVICE_ID="SERVICEID" \
   FASTLY_API_KEY="TESTAPIKEY" \
   TESTARGS="-run=Logentries"
-make fix-fixtures
+make fix-fixtures FASTLY_TEST_SERVICE_ID="SERVICEID"
 
 # Re-run test suite with newly recorded fixtures
 unset FASTLY_TEST_SERVICE_ID FASTLY_API_KEY

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -41,6 +41,10 @@ var ErrMissingName = errors.New("missing required field 'Name'")
 // "Key" key, but one was not set.
 var ErrMissingKey = errors.New("missing required field 'Key'")
 
+// ErrMissingKind is an error that is returned when an input struct requires a
+// "Kind" key, but one was not set.
+var ErrMissingKind = errors.New("missing required field 'Kind'")
+
 // ErrMissingURL is an error that is returned when an input struct requires a
 // "URL" key, but one was not set.
 var ErrMissingURL = errors.New("missing required field 'URL'")
@@ -181,12 +185,19 @@ var ErrMissingTLSConfiguration = errors.New("missing required field 'Configurati
 // a "Domain" field assigned a "TLSDomain" struct, but one was not set.
 var ErrMissingTLSDomain = errors.New("missing required field 'Domain'")
 
-// ErrStatusNotOk is an error that indicates that indicates that the response body returned
+// ErrStatusNotOk is an error that indicates that the response body returned
 // by the Fastly API was not `{"status": "ok"}`
 var ErrStatusNotOk = errors.New("unexpected 'status' field in API response body")
 
 // ErrNotOK is a generic error indicating that something is not okay.
 var ErrNotOK = errors.New("not ok")
+
+// ErrNotImplemented is a generic error indicating that something is not yet implemented.
+var ErrNotImplemented = errors.New("not implemented")
+
+// ErrManagedLoggingEnabled is an error that indicates that managed logging was
+// already enabled for a service.
+var ErrManagedLoggingEnabled = errors.New("managed logging already enabled")
 
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)

--- a/fastly/fixtures/managed_logging/create.yaml
+++ b/fastly/fixtures/managed_logging/create.yaml
@@ -2,15 +2,9 @@
 version: 1
 interactions:
 - request:
-    body: Kind=1&ServiceID=7i6HN3TK9wS159v2gPAZ8A
-    form:
-      Kind:
-      - "1"
-      ServiceID:
-      - 7i6HN3TK9wS159v2gPAZ8A
+    body: ""
+    form: {}
     headers:
-      Content-Type:
-      - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.5)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/log_stream/managed/instance_output
@@ -25,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jan 2021 19:28:04 GMT
+      - Mon, 11 Jan 2021 14:05:07 GMT
       Fastly-Ratelimit-Remaining:
-      - "19997"
+      - "19998"
       Fastly-Ratelimit-Reset:
-      - "1610049600"
+      - "1610377200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-den8229-DEN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-den8275-DEN
       X-Timer:
-      - S1610047683.768767,VS0,VE1256
+      - S1610373907.878240,VS0,VE941
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/managed_logging/create.yaml
+++ b/fastly/fixtures/managed_logging/create.yaml
@@ -1,0 +1,51 @@
+---
+version: 1
+interactions:
+- request:
+    body: Kind=1&ServiceID=7i6HN3TK9wS159v2gPAZ8A
+    form:
+      Kind:
+      - "1"
+      ServiceID:
+      - 7i6HN3TK9wS159v2gPAZ8A
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/log_stream/managed/instance_output
+    method: POST
+  response:
+    body: '{"status":"ok"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Jan 2021 19:28:04 GMT
+      Fastly-Ratelimit-Remaining:
+      - "19997"
+      Fastly-Ratelimit-Reset:
+      - "1610049600"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-den8229-DEN
+      X-Timer:
+      - S1610047683.768767,VS0,VE1256
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/managed_logging/delete.yaml
+++ b/fastly/fixtures/managed_logging/delete.yaml
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jan 2021 19:28:05 GMT
+      - Mon, 11 Jan 2021 14:05:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "19995"
+      - "19996"
       Fastly-Ratelimit-Reset:
-      - "1610049600"
+      - "1610377200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-den8229-DEN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-den8275-DEN
       X-Timer:
-      - S1610047685.823978,VS0,VE866
+      - S1610373908.316897,VS0,VE892
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/managed_logging/delete.yaml
+++ b/fastly/fixtures/managed_logging/delete.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/log_stream/managed/instance_output
+    method: DELETE
+  response:
+    body: '{"status":"ok"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Jan 2021 19:28:05 GMT
+      Fastly-Ratelimit-Remaining:
+      - "19995"
+      Fastly-Ratelimit-Reset:
+      - "1610049600"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-den8229-DEN
+      X-Timer:
+      - S1610047685.823978,VS0,VE866
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/managed_logging/recreate.yaml
+++ b/fastly/fixtures/managed_logging/recreate.yaml
@@ -1,0 +1,51 @@
+---
+version: 1
+interactions:
+- request:
+    body: Kind=1&ServiceID=7i6HN3TK9wS159v2gPAZ8A
+    form:
+      Kind:
+      - "1"
+      ServiceID:
+      - 7i6HN3TK9wS159v2gPAZ8A
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/log_stream/managed/instance_output
+    method: POST
+  response:
+    body: '{"msg":"Event Buffer has already been enabled for this service"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 07 Jan 2021 19:28:04 GMT
+      Fastly-Ratelimit-Remaining:
+      - "19996"
+      Fastly-Ratelimit-Reset:
+      - "1610049600"
+      Status:
+      - 409 Conflict
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-den8229-DEN
+      X-Timer:
+      - S1610047684.059177,VS0,VE736
+    status: 409 Conflict
+    code: 409
+    duration: ""

--- a/fastly/fixtures/managed_logging/recreate.yaml
+++ b/fastly/fixtures/managed_logging/recreate.yaml
@@ -2,15 +2,9 @@
 version: 1
 interactions:
 - request:
-    body: Kind=1&ServiceID=7i6HN3TK9wS159v2gPAZ8A
-    form:
-      Kind:
-      - "1"
-      ServiceID:
-      - 7i6HN3TK9wS159v2gPAZ8A
+    body: ""
+    form: {}
     headers:
-      Content-Type:
-      - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.5)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/log_stream/managed/instance_output
@@ -25,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 07 Jan 2021 19:28:04 GMT
+      - Mon, 11 Jan 2021 14:05:08 GMT
       Fastly-Ratelimit-Remaining:
-      - "19996"
+      - "19997"
       Fastly-Ratelimit-Reset:
-      - "1610049600"
+      - "1610377200"
       Status:
       - 409 Conflict
       Strict-Transport-Security:
@@ -43,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-den8229-DEN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-den8275-DEN
       X-Timer:
-      - S1610047684.059177,VS0,VE736
+      - S1610373908.834016,VS0,VE457
     status: 409 Conflict
     code: 409
     duration: ""

--- a/fastly/managed_logging.go
+++ b/fastly/managed_logging.go
@@ -29,7 +29,7 @@ const (
 	ManagedLoggingInstanceOutput
 )
 
-// CreateManagedLogging enabled managed logging for a service.
+// CreateManagedLogging enables managed logging for a service.
 func (c *Client) CreateManagedLogging(i *CreateManagedLoggingInput) (*ManagedLogging, error) {
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
@@ -46,7 +46,7 @@ func (c *Client) CreateManagedLogging(i *CreateManagedLoggingInput) (*ManagedLog
 		return nil, ErrNotImplemented
 	}
 
-	resp, err := c.PostForm(path, i, nil)
+	resp, err := c.Post(path, nil)
 	// If the service already has managed logging enabled, it will respond
 	// with a 409. Handle this case specially so users can decide if this is
 	// truly an error.

--- a/fastly/managed_logging.go
+++ b/fastly/managed_logging.go
@@ -1,0 +1,97 @@
+package fastly
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type (
+	// ManagedLogging represents a managed logging endpoint for a service.
+	ManagedLogging struct {
+		ServiceID string `mapstructure:"service_id"`
+	}
+
+	// ManagedLoggingKind type represents multiple kinds of log streams the
+	// managed logging feature will support.
+	ManagedLoggingKind uint
+
+	// CreateManagedLoggingInput is used as input to the CreateManagedLogging function.
+	CreateManagedLoggingInput struct {
+		// ServiceID is the ID of the service (required).
+		ServiceID string
+		// Kind is the kind of managed logging we are creating (required).
+		Kind ManagedLoggingKind
+	}
+)
+
+const (
+	ManagedLoggingUnset ManagedLoggingKind = iota
+	ManagedLoggingInstanceOutput
+)
+
+// CreateManagedLogging enabled managed logging for a service.
+func (c *Client) CreateManagedLogging(i *CreateManagedLoggingInput) (*ManagedLogging, error) {
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+
+	var path string
+
+	switch i.Kind {
+	case ManagedLoggingUnset:
+		return nil, ErrMissingKind
+	case ManagedLoggingInstanceOutput:
+		path = fmt.Sprintf("/service/%s/log_stream/managed/instance_output", i.ServiceID)
+	default:
+		return nil, ErrNotImplemented
+	}
+
+	resp, err := c.PostForm(path, i, nil)
+	// If the service already has managed logging enabled, it will respond
+	// with a 409. Handle this case specially so users can decide if this is
+	// truly an error.
+	if err != nil {
+		if resp.StatusCode == http.StatusConflict {
+			return nil, ErrManagedLoggingEnabled
+		}
+		return nil, err
+	}
+
+	var m *ManagedLogging
+	if err := decodeBodyMap(resp.Body, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// DeleteManagedLoggingInput is used as input to the DeleteManagedLogging function.
+type DeleteManagedLoggingInput struct {
+	// ServiceID is the ID of the service (required).
+	ServiceID string
+	// Kind is the kind of managed logging we are removing (required).
+	Kind ManagedLoggingKind
+}
+
+// DeleteManagedLogging disables managed logging for a service
+func (c *Client) DeleteManagedLogging(i *DeleteManagedLoggingInput) error {
+	if i.ServiceID == "" {
+		return ErrMissingServiceID
+	}
+
+	var path string
+
+	switch i.Kind {
+	case ManagedLoggingUnset:
+		return ErrMissingKind
+	case ManagedLoggingInstanceOutput:
+		path = fmt.Sprintf("/service/%s/log_stream/managed/instance_output", i.ServiceID)
+	default:
+		return ErrNotImplemented
+	}
+
+	_, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/fastly/managed_logging_test.go
+++ b/fastly/managed_logging_test.go
@@ -1,0 +1,93 @@
+package fastly
+
+import "testing"
+
+func TestClient_ManagedLogging(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	// Create
+	record(t, "managed_logging/create", func(c *Client) {
+		_, err = c.CreateManagedLogging(&CreateManagedLoggingInput{
+			ServiceID: testServiceID,
+			Kind:      ManagedLoggingInstanceOutput,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test that enabling managed logging on a service with it already
+	// enabled results in a 409.
+	record(t, "managed_logging/recreate", func(c *Client) {
+		_, err = c.CreateManagedLogging(&CreateManagedLoggingInput{
+			ServiceID: testServiceID,
+			Kind:      ManagedLoggingInstanceOutput,
+		})
+	})
+	if err != ErrManagedLoggingEnabled {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// Delete
+	record(t, "managed_logging/delete", func(c *Client) {
+		err = c.DeleteManagedLogging(&DeleteManagedLoggingInput{
+			ServiceID: testServiceID,
+			Kind:      ManagedLoggingInstanceOutput,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClient_CreateManagedLogging_validation(t *testing.T) {
+	_, err := testClient.CreateManagedLogging(&CreateManagedLoggingInput{
+		ServiceID: "",
+		Kind:      ManagedLoggingInstanceOutput,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	_, err = testClient.CreateManagedLogging(&CreateManagedLoggingInput{
+		ServiceID: testServiceID,
+	})
+	if err != ErrMissingKind {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	_, err = testClient.CreateManagedLogging(&CreateManagedLoggingInput{
+		ServiceID: testServiceID,
+		Kind:      999,
+	})
+	if err != ErrNotImplemented {
+		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestClient_DeleteManagedLogging_validation(t *testing.T) {
+	err := testClient.DeleteManagedLogging(&DeleteManagedLoggingInput{
+		ServiceID: "",
+		Kind:      ManagedLoggingInstanceOutput,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	err = testClient.DeleteManagedLogging(&DeleteManagedLoggingInput{
+		ServiceID: testServiceID,
+	})
+	if err != ErrMissingKind {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	err = testClient.DeleteManagedLogging(&DeleteManagedLoggingInput{
+		ServiceID: testServiceID,
+		Kind:      999,
+	})
+	if err != ErrNotImplemented {
+		t.Errorf("unexpected error: %s", err)
+	}
+}


### PR DESCRIPTION
Support enabling and disabling managed logging for a service.