### PR TITLE
Avoid generic ID field when more explicit naming would be clearer

### DIFF
--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -53,6 +53,10 @@ var ErrMissingURL = errors.New("missing required field 'URL'")
 // "ID" key, but one was not set.
 var ErrMissingID = errors.New("missing required field 'ID'")
 
+// ErrMissingTokenID is an error that is returned when an input struct requires a
+// "TokenID" key, but one was not set.
+var ErrMissingTokenID = errors.New("missing required field 'TokenID'")
+
 // ErrMissingDictionary is an error that is returned when an input struct
 // requires a "Dictionary" key, but one was not set.
 var ErrMissingDictionary = errors.New("missing required field 'Dictionary'")

--- a/fastly/token.go
+++ b/fastly/token.go
@@ -136,16 +136,16 @@ func (c *Client) CreateToken(i *CreateTokenInput) (*Token, error) {
 
 // DeleteTokenInput is used as input to the DeleteToken function.
 type DeleteTokenInput struct {
-	ID string
+	TokenID string
 }
 
 // DeleteToken revokes a specific token by its ID.
 func (c *Client) DeleteToken(i *DeleteTokenInput) error {
-	if i.ID == "" {
-		return ErrMissingID
+	if i.TokenID == "" {
+		return ErrMissingTokenID
 	}
 
-	path := fmt.Sprintf("/tokens/%s", i.ID)
+	path := fmt.Sprintf("/tokens/%s", i.TokenID)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/token.go
+++ b/fastly/token.go
@@ -64,17 +64,17 @@ func (c *Client) ListTokens() ([]*Token, error) {
 
 // ListCustomerTokensInput is used as input to the ListCustomerTokens function.
 type ListCustomerTokensInput struct {
-	ID string
+	CustomerID string
 }
 
 // ListCustomerTokens returns the full list of tokens belonging to a specific
 // customer.
 func (c *Client) ListCustomerTokens(i *ListCustomerTokensInput) ([]*Token, error) {
-	if i.ID == "" {
-		return nil, ErrMissingID
+	if i.CustomerID == "" {
+		return nil, ErrMissingCustomerID
 	}
 
-	path := fmt.Sprintf("/customer/%s/tokens", i.ID)
+	path := fmt.Sprintf("/customer/%s/tokens", i.CustomerID)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/token_test.go
+++ b/fastly/token_test.go
@@ -82,7 +82,7 @@ func TestClient_DeleteToken(t *testing.T) {
 	t.Parallel()
 
 	input := &DeleteTokenInput{
-		ID: "XXXXXXXXXXXXXXXXXXXXXX",
+		TokenID: "xxxxxxxxxxxxxxxxxxxxx",
 	}
 
 	var err error

--- a/fastly/token_test.go
+++ b/fastly/token_test.go
@@ -25,7 +25,7 @@ func TestClient_ListCustomerTokens(t *testing.T) {
 	var err error
 	record(t, "tokens/list_customer", func(c *Client) {
 		tokens, err = c.ListCustomerTokens(&ListCustomerTokensInput{
-			CustomerID: "xxxxxxxxxxxxxxxxxxxx",
+			CustomerID: "XXXXXXXXXXXXXXXXXXXXXX",
 		})
 	})
 	if err != nil {
@@ -82,7 +82,7 @@ func TestClient_DeleteToken(t *testing.T) {
 	t.Parallel()
 
 	input := &DeleteTokenInput{
-		TokenID: "xxxxxxxxxxxxxxxxxxxxx",
+		TokenID: "XXXXXXXXXXXXXXXXXXXXXX",
 	}
 
 	var err error

--- a/fastly/token_test.go
+++ b/fastly/token_test.go
@@ -25,7 +25,7 @@ func TestClient_ListCustomerTokens(t *testing.T) {
 	var err error
 	record(t, "tokens/list_customer", func(c *Client) {
 		tokens, err = c.ListCustomerTokens(&ListCustomerTokensInput{
-			ID: "XXXXXXXXXXXXXXXXXXXXXX",
+			CustomerID: "xxxxxxxxxxxxxxxxxxxx",
 		})
 	})
 	if err != nil {


### PR DESCRIPTION
There are multiple types of IDs used across our code base and the parent package/function/type doesn't always make it obvious what type of ID is required so we rename a few instances where it would be clearer to have a more explicit name.