### PR TITLE
Ensure consistent naming for ServiceID (fixes missed references)

### DIFF
--- a/fastly/realtime_stats.go
+++ b/fastly/realtime_stats.go
@@ -23,7 +23,7 @@ type RealtimeData struct {
 
 // GetRealtimeStatsInput is an input parameter to GetRealtimeStats function
 type GetRealtimeStatsInput struct {
-	Service   string
+	ServiceID string
 	Timestamp uint64
 	Limit     uint32
 }
@@ -47,11 +47,11 @@ func (c *RTSClient) GetRealtimeStats(i *GetRealtimeStatsInput) (*RealtimeStatsRe
 
 // GetRealtimeStatsJSON fetches stats and decodes the response directly to the JSON struct dst.
 func (c *RTSClient) GetRealtimeStatsJSON(i *GetRealtimeStatsInput, dst interface{}) error {
-	if i.Service == "" {
+	if i.ServiceID == "" {
 		return ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/v1/channel/%s/ts/%d", i.Service, i.Timestamp)
+	path := fmt.Sprintf("/v1/channel/%s/ts/%d", i.ServiceID, i.Timestamp)
 
 	if i.Limit != 0 {
 		path = fmt.Sprintf("%s/limit/%d", path, i.Limit)

--- a/fastly/realtime_stats_test.go
+++ b/fastly/realtime_stats_test.go
@@ -7,7 +7,7 @@ import (
 func TestClient_GetRealtimeStats_validation(t *testing.T) {
 	var err error
 	_, err = testStatsClient.GetRealtimeStats(&GetRealtimeStatsInput{
-		Service: "",
+		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
@@ -22,7 +22,7 @@ func TestStatsClient_GetRealtimeStats(t *testing.T) {
 	// Get
 	recordRealtimeStats(t, "realtime_stats/get", func(c *RTSClient) {
 		_, err = c.GetRealtimeStats(&GetRealtimeStatsInput{
-			Service:   testServiceID,
+			ServiceID: testServiceID,
 			Timestamp: 0,
 			Limit:     3,
 		})
@@ -42,7 +42,7 @@ func TestStatsClient_GetRealtimeStatsJSON(t *testing.T) {
 	var err error
 	recordRealtimeStats(t, "realtime_stats/get", func(c *RTSClient) {
 		err = c.GetRealtimeStatsJSON(&GetRealtimeStatsInput{
-			Service:   testServiceID,
+			ServiceID: testServiceID,
 			Timestamp: 0,
 			Limit:     3,
 		}, &ret)

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -145,7 +145,7 @@ func (c *Client) GetServiceDetails(i *GetServiceInput) (*ServiceDetail, error) {
 
 // UpdateServiceInput is used as input to the UpdateService function.
 type UpdateServiceInput struct {
-	ID string
+	ServiceID string
 
 	Name    *string `form:"name,omitempty"`
 	Comment *string `form:"comment,omitempty"`
@@ -153,8 +153,8 @@ type UpdateServiceInput struct {
 
 // UpdateService updates the service with the given input.
 func (c *Client) UpdateService(i *UpdateServiceInput) (*Service, error) {
-	if i.ID == "" {
-		return nil, ErrMissingID
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
 	}
 
 	if i.Name == nil && i.Comment == nil {
@@ -165,7 +165,7 @@ func (c *Client) UpdateService(i *UpdateServiceInput) (*Service, error) {
 		return nil, ErrMissingNameValue
 	}
 
-	path := fmt.Sprintf("/service/%s", i.ID)
+	path := fmt.Sprintf("/service/%s", i.ServiceID)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/service_test.go
+++ b/fastly/service_test.go
@@ -124,8 +124,8 @@ func TestClient_Services(t *testing.T) {
 	var us *Service
 	record(t, "services/update", func(c *Client) {
 		us, err = c.UpdateService(&UpdateServiceInput{
-			ID:   s.ID,
-			Name: String("new-test-service"),
+			ServiceID: s.ID,
+			Name:      String("new-test-service"),
 		})
 	})
 	if err != nil {
@@ -171,20 +171,20 @@ func TestClient_GetService_validation(t *testing.T) {
 func TestClient_UpdateService_validation(t *testing.T) {
 	var err error
 	_, err = testClient.UpdateService(&UpdateServiceInput{})
-	if err != ErrMissingID {
+	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
 	_, err = testClient.UpdateService(&UpdateServiceInput{
-		ID: "foo",
+		ServiceID: "foo",
 	})
 	if err != ErrMissingOptionalNameComment {
 		t.Errorf("bad error: %s", err)
 	}
 
 	_, err = testClient.UpdateService(&UpdateServiceInput{
-		ID:   "foo",
-		Name: String(""),
+		ServiceID: "foo",
+		Name:      String(""),
 	})
 	if err != ErrMissingNameValue {
 		t.Errorf("bad error: %s", err)


### PR DESCRIPTION
In Go-Fastly 2.0.0 we aimed for consistency with various ID fields but we missed some references.