### PR TITLE
Dictionary ItemValue isn't optional

### DIFF
--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -159,10 +159,11 @@ type UpdateDictionaryItemInput struct {
 	// DictionaryID is the ID of the dictionary to retrieve items for (required).
 	DictionaryID string
 
-	// ItemKey is the name of the dictionary item to fetch.
+	// ItemKey is the name of the dictionary item to fetch (required).
 	ItemKey string
 
-	ItemValue *string `form:"item_value,omitempty"`
+	// ItemValue is the new value of the dictionary item (required).
+	ItemValue string `form:"item_value"`
 }
 
 // UpdateDictionaryItem updates a specific dictionary item.

--- a/fastly/dictionary_item_test.go
+++ b/fastly/dictionary_item_test.go
@@ -91,7 +91,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 			ServiceID:    testService.ID,
 			DictionaryID: testDictionary.ID,
 			ItemKey:      "test-dictionary-item",
-			ItemValue:    String("new-value"),
+			ItemValue:    "new-value",
 		})
 	})
 	if err != nil {


### PR DESCRIPTION
When updating a dictionary item, the 'value' to be assigned to the given key can't be optional (the backend API will actually return an error if you try).