### PR TITLE
NewName should be optional

### DIFF
--- a/fastly/domain.go
+++ b/fastly/domain.go
@@ -151,7 +151,7 @@ type UpdateDomainInput struct {
 	Name string
 
 	// NewName is the updated name of the domain
-	NewName string `form:"name"`
+	NewName *string `form:"name,omitempty"`
 
 	// Comment is a personal, freeform descriptive note.
 	Comment *string `form:"comment,omitempty"`
@@ -170,6 +170,10 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 
 	if i.Name == "" {
 		return nil, ErrMissingName
+	}
+
+	if i.NewName == nil && i.Comment == nil {
+		return nil, ErrMissingOptionalNameComment
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))

--- a/fastly/domain_test.go
+++ b/fastly/domain_test.go
@@ -92,7 +92,7 @@ func TestClient_Domains(t *testing.T) {
 			ServiceID:      testServiceID,
 			ServiceVersion: tv.Number,
 			Name:           "integ-test.go-fastly.com",
-			NewName:        "new-integ-test.go-fastly.com",
+			NewName:        String("new-integ-test.go-fastly.com"),
 		})
 	})
 	if err != nil {
@@ -201,6 +201,15 @@ func TestClient_UpdateDomain_validation(t *testing.T) {
 		Name:           "",
 	})
 	if err != ErrMissingName {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.UpdateDomain(&UpdateDomainInput{
+		ServiceID:      "foo",
+		ServiceVersion: 1,
+		Name:           "bar",
+	})
+	if err != ErrMissingOptionalNameComment {
 		t.Errorf("bad error: %s", err)
 	}
 }


### PR DESCRIPTION
The `NewName` field should be optional because the API allows updating of the domain object using just the `Comment` field.