### PR TITLE
Use port 443 if UseSSL is set.

### DIFF
--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -133,6 +133,10 @@ func (c *Client) CreateBackend(i *CreateBackendInput) (*Backend, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
+	if i.UseSSL && i.Port == 0 {
+		i.Port = 443
+	}
+
 	path := fmt.Sprintf("/service/%s/version/%d/backend", i.ServiceID, i.ServiceVersion)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {

--- a/fastly/backend_test.go
+++ b/fastly/backend_test.go
@@ -21,9 +21,9 @@ func TestClient_Backends(t *testing.T) {
 			ServiceVersion: tv.Number,
 			Name:           "test-backend",
 			Address:        "integ-test.go-fastly.com",
-			Port:           1234,
 			ConnectTimeout: 1500,
 			OverrideHost:   "origin.example.com",
+			UseSSL:         true,
 		})
 	})
 	if err != nil {
@@ -53,7 +53,7 @@ func TestClient_Backends(t *testing.T) {
 	if b.Address != "integ-test.go-fastly.com" {
 		t.Errorf("bad address: %q", b.Address)
 	}
-	if b.Port != 1234 {
+	if b.Port != 443 {
 		t.Errorf("bad port: %d", b.Port)
 	}
 	if b.ConnectTimeout != 1500 {

--- a/fastly/fixtures/backends/cleanup.yaml
+++ b/fastly/fixtures/backends/cleanup.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/test-backend
+      - FastlyGo/3.4.0 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/backend/test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e test-backend, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 20 }''"}'
+      version =\u003e 2 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:53 GMT
+      - Wed, 24 Mar 2021 12:56:51 GMT
       Fastly-Ratelimit-Remaining:
-      - "917"
+      - "4995"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1616590800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4138-MAN
       X-Timer:
-      - S1610619953.007977,VS0,VE193
+      - S1616590612.709425,VS0,VE192
     status: 404 Not Found
     code: 404
     duration: ""
@@ -50,13 +50,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/new-test-backend
+      - FastlyGo/3.4.0 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/backend/new-test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e new-test-backend, service =\u003e
-      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 20 }''"}'
+      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 2 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -65,11 +65,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:53 GMT
+      - Wed, 24 Mar 2021 12:56:52 GMT
       Fastly-Ratelimit-Remaining:
-      - "916"
+      - "4994"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1616590800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -83,9 +83,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4138-MAN
       X-Timer:
-      - S1610619953.247038,VS0,VE184
+      - S1616590612.929691,VS0,VE192
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/backends/create.yaml
+++ b/fastly/fixtures/backends/create.yaml
@@ -2,12 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=20&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&port=1234
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=2&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&port=443&use_ssl=1
     form:
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "20"
+      - "2"
       address:
       - integ-test.go-fastly.com
       connect_timeout:
@@ -17,16 +17,18 @@ interactions:
       override_host:
       - origin.example.com
       port:
-      - "1234"
+      - "443"
+      use_ssl:
+      - "1"
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend
+      - FastlyGo/3.4.0 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/backend
     method: POST
   response:
-    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","port":1234,"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":20,"max_tls_version":null,"hostname":"integ-test.go-fastly.com","client_cert":null,"ssl_ca_cert":null,"error_threshold":0,"ssl_client_cert":null,"deleted_at":null,"shield":null,"max_conn":200,"ssl_cert_hostname":null,"use_ssl":false,"first_byte_timeout":15000,"ipv6":null,"ssl_ciphers":null,"comment":"","ssl_sni_hostname":null,"ssl_client_key":null,"request_condition":"","ssl_check_cert":true,"weight":100,"healthcheck":null,"auto_loadbalance":false,"updated_at":"2021-01-14T10:25:50Z","created_at":"2021-01-14T10:25:50Z","ipv4":null,"min_tls_version":null,"between_bytes_timeout":10000,"ssl_hostname":null}'
+    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","port":443,"use_ssl":true,"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":2,"between_bytes_timeout":10000,"ssl_sni_hostname":null,"hostname":"integ-test.go-fastly.com","ssl_check_cert":true,"ssl_ciphers":null,"request_condition":"","ssl_client_key":null,"deleted_at":null,"ssl_ca_cert":null,"ssl_cert_hostname":null,"created_at":"2021-03-24T12:56:50Z","ssl_client_cert":null,"weight":100,"ipv4":null,"first_byte_timeout":15000,"max_tls_version":null,"comment":"","ssl_hostname":null,"healthcheck":null,"auto_loadbalance":false,"client_cert":null,"error_threshold":0,"updated_at":"2021-03-24T12:56:50Z","min_tls_version":null,"max_conn":200,"shield":null,"ipv6":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,11 +37,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:50 GMT
+      - Wed, 24 Mar 2021 12:56:50 GMT
       Fastly-Ratelimit-Remaining:
-      - "923"
+      - "4998"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1616590800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -53,9 +55,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4138-MAN
       X-Timer:
-      - S1610619950.359768,VS0,VE545
+      - S1616590610.655774,VS0,VE495
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/delete.yaml
+++ b/fastly/fixtures/backends/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/new-test-backend
+      - FastlyGo/3.4.0 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/backend/new-test-backend
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:52 GMT
+      - Wed, 24 Mar 2021 12:56:51 GMT
       Fastly-Ratelimit-Remaining:
-      - "918"
+      - "4996"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1616590800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4138-MAN
       X-Timer:
-      - S1610619953.711130,VS0,VE253
+      - S1616590611.432342,VS0,VE245
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/get.yaml
+++ b/fastly/fixtures/backends/get.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/test-backend
+      - FastlyGo/3.4.0 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/backend/test-backend
     method: GET
   response:
-    body: '{"name":"test-backend","service_id":"7i6HN3TK9wS159v2gPAZ8A","address":"integ-test.go-fastly.com","ssl_sni_hostname":null,"between_bytes_timeout":10000,"ssl_client_key":null,"weight":100,"min_tls_version":null,"auto_loadbalance":false,"shield":null,"connect_timeout":1500,"comment":"","port":1234,"ipv4":null,"ssl_client_cert":null,"first_byte_timeout":15000,"ssl_ciphers":null,"deleted_at":null,"request_condition":"","max_conn":200,"ssl_cert_hostname":null,"hostname":"integ-test.go-fastly.com","ssl_check_cert":true,"ipv6":null,"use_ssl":false,"ssl_ca_cert":null,"version":20,"updated_at":"2021-01-14T10:25:50Z","override_host":"origin.example.com","created_at":"2021-01-14T10:25:50Z","error_threshold":0,"max_tls_version":null,"healthcheck":null,"ssl_hostname":null,"client_cert":null}'
+    body: '{"ssl_client_key":null,"override_host":"origin.example.com","created_at":"2021-03-24T12:56:50Z","deleted_at":null,"ssl_cert_hostname":null,"use_ssl":true,"service_id":"7i6HN3TK9wS159v2gPAZ8A","request_condition":"","connect_timeout":1500,"ssl_ciphers":null,"error_threshold":0,"ssl_hostname":null,"between_bytes_timeout":10000,"weight":100,"address":"integ-test.go-fastly.com","ssl_check_cert":true,"max_tls_version":null,"ssl_client_cert":null,"name":"test-backend","auto_loadbalance":false,"first_byte_timeout":15000,"hostname":"integ-test.go-fastly.com","ssl_ca_cert":null,"ipv4":null,"ssl_sni_hostname":null,"version":2,"min_tls_version":null,"updated_at":"2021-03-24T12:56:50Z","comment":"","port":443,"client_cert":null,"healthcheck":null,"ipv6":null,"shield":null,"max_conn":200}'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:51 GMT
+      - Wed, 24 Mar 2021 12:56:51 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4138-MAN
       X-Timer:
-      - S1610619951.458633,VS0,VE468
+      - S1616590611.671194,VS0,VE423
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/list.yaml
+++ b/fastly/fixtures/backends/list.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend
+      - FastlyGo/3.4.0 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/backend
     method: GET
   response:
-    body: '[{"use_ssl":false,"weight":100,"ssl_ciphers":null,"port":1234,"connect_timeout":1500,"ssl_ca_cert":null,"created_at":"2021-01-14T10:25:50Z","ipv6":null,"ssl_client_cert":null,"comment":"","address":"integ-test.go-fastly.com","client_cert":null,"deleted_at":null,"max_conn":200,"override_host":"origin.example.com","ssl_check_cert":true,"auto_loadbalance":false,"ssl_hostname":null,"error_threshold":0,"hostname":"integ-test.go-fastly.com","name":"test-backend","updated_at":"2021-01-14T10:25:50Z","between_bytes_timeout":10000,"first_byte_timeout":15000,"request_condition":"","healthcheck":null,"ssl_client_key":null,"max_tls_version":null,"ssl_cert_hostname":null,"ssl_sni_hostname":null,"version":20,"shield":null,"min_tls_version":null,"ipv4":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A"}]'
+    body: '[{"port":443,"between_bytes_timeout":10000,"max_tls_version":null,"max_conn":200,"healthcheck":null,"use_ssl":true,"ipv4":null,"updated_at":"2021-03-24T12:56:50Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_client_key":null,"ipv6":null,"override_host":"origin.example.com","auto_loadbalance":false,"error_threshold":0,"shield":null,"name":"test-backend","weight":100,"min_tls_version":null,"ssl_ciphers":null,"address":"integ-test.go-fastly.com","deleted_at":null,"version":2,"ssl_hostname":null,"ssl_ca_cert":null,"client_cert":null,"ssl_sni_hostname":null,"connect_timeout":1500,"ssl_cert_hostname":null,"created_at":"2021-03-24T12:56:50Z","comment":"","hostname":"integ-test.go-fastly.com","request_condition":"","first_byte_timeout":15000,"ssl_client_cert":null,"ssl_check_cert":true}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:51 GMT
+      - Wed, 24 Mar 2021 12:56:50 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4138-MAN
       X-Timer:
-      - S1610619951.946600,VS0,VE467
+      - S1616590610.176883,VS0,VE469
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update.yaml
+++ b/fastly/fixtures/backends/update.yaml
@@ -2,14 +2,14 @@
 version: 1
 interactions:
 - request:
-    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=20&name=new-test-backend&override_host=www.example.com
+    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=2&name=new-test-backend&override_host=www.example.com
     form:
       Name:
       - test-backend
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "20"
+      - "2"
       name:
       - new-test-backend
       override_host:
@@ -18,11 +18,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/test-backend
+      - FastlyGo/3.4.0 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/backend/test-backend
     method: PUT
   response:
-    body: '{"ssl_sni_hostname":null,"hostname":"integ-test.go-fastly.com","ipv6":null,"ssl_ca_cert":null,"error_threshold":0,"ipv4":null,"ssl_ciphers":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_hostname":null,"ssl_check_cert":true,"ssl_client_key":null,"deleted_at":null,"ssl_client_cert":null,"request_condition":"","max_tls_version":null,"override_host":"www.example.com","shield":null,"ssl_cert_hostname":null,"auto_loadbalance":false,"address":"integ-test.go-fastly.com","use_ssl":false,"first_byte_timeout":15000,"comment":"","name":"new-test-backend","created_at":"2021-01-14T10:25:50Z","weight":100,"max_conn":200,"connect_timeout":1500,"min_tls_version":null,"updated_at":"2021-01-14T10:25:50Z","version":20,"between_bytes_timeout":10000,"client_cert":null,"port":1234,"healthcheck":null}'
+    body: '{"ssl_cert_hostname":null,"override_host":"www.example.com","created_at":"2021-03-24T12:56:50Z","ssl_ca_cert":null,"address":"integ-test.go-fastly.com","ssl_client_key":null,"deleted_at":null,"request_condition":"","ssl_check_cert":true,"ssl_ciphers":null,"hostname":"integ-test.go-fastly.com","between_bytes_timeout":10000,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_sni_hostname":null,"port":443,"min_tls_version":null,"ipv6":null,"shield":null,"max_conn":200,"client_cert":null,"error_threshold":0,"updated_at":"2021-03-24T12:56:50Z","auto_loadbalance":false,"use_ssl":true,"name":"new-test-backend","healthcheck":null,"connect_timeout":1500,"ipv4":null,"max_tls_version":null,"first_byte_timeout":15000,"comment":"","ssl_hostname":null,"weight":100,"version":2,"ssl_client_cert":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -31,11 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:52 GMT
+      - Wed, 24 Mar 2021 12:56:51 GMT
       Fastly-Ratelimit-Remaining:
-      - "919"
+      - "4997"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1616590800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +49,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4138-MAN
       X-Timer:
-      - S1610619952.963543,VS0,VE623
+      - S1616590611.120725,VS0,VE250
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/version.yaml
+++ b/fastly/fixtures/backends/version.yaml
@@ -10,11 +10,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
+      - FastlyGo/3.4.0 (+github.com/fastly/go-fastly; go1.16)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":20}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":2}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +23,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:50 GMT
+      - Wed, 24 Mar 2021 12:56:49 GMT
       Fastly-Ratelimit-Remaining:
-      - "925"
+      - "4999"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1616590800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4138-MAN
       X-Timer:
-      - S1610619950.755481,VS0,VE538
+      - S1616590609.395066,VS0,VE234
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
**Problem**: in the CLI the `--use-ssl` flag should cause the backend to be created on port 443 (currently no port is set in the call to the go-fastly API client and so the API itself is setting the default of port 80).