### PR TITLE
Initialise Headers map to avoid runtime panic when purging.

### DIFF
--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -29,6 +29,7 @@ func (c *Client) Purge(i *PurgeInput) (*Purge, error) {
 	ro := new(RequestOptions)
 	ro.Parallel = true
 	if i.Soft {
+		ro.Headers = make(map[string]string)
 		ro.Headers["Fastly-Soft-Purge"] = "1"
 	}
 

--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -26,11 +26,13 @@ func (c *Client) Purge(i *PurgeInput) (*Purge, error) {
 		return nil, ErrMissingURL
 	}
 
-	ro := new(RequestOptions)
-	ro.Parallel = true
+	ro := &RequestOptions{
+		Parallel: true,
+	}
 	if i.Soft {
-		ro.Headers = make(map[string]string)
-		ro.Headers["Fastly-Soft-Purge"] = "1"
+		ro.Headers = map[string]string{
+			"Fastly-Soft-Purge": "1",
+		}
 	}
 
 	resp, err := c.Post("purge/"+i.URL, ro)

--- a/fastly/purge_test.go
+++ b/fastly/purge_test.go
@@ -1,8 +1,30 @@
 package fastly
 
-import "testing"
+import (
+	"testing"
+)
 
+// TestClient_Purge validates no runtime panics are raised by the Purge method.
+//
+// Specifically, we're ensuring that the setting of the `Soft` key to `true`
+// (which will require assigning a header to the RequestOptions struct) doesn't
+// cause `panic: assignment to entry in nil map`.
 func TestClient_Purge(t *testing.T) {
+	t.Parallel()
+
+	client := DefaultClient()
+	url := "http://gofastly.fastly-testing.com/foo/bar"
+
+	_, err := client.Purge(&PurgeInput{
+		URL:  url,
+		Soft: true,
+	})
+	if err == nil {
+		t.Fatalf("we've accidentally purged a real URL: %s", url)
+	}
+}
+
+func TestClient_PurgeKey(t *testing.T) {
 	t.Parallel()
 
 	var err error

--- a/fastly/purge_test.go
+++ b/fastly/purge_test.go
@@ -7,8 +7,8 @@ import (
 // TestClient_Purge validates no runtime panics are raised by the Purge method.
 //
 // Specifically, we're ensuring that the setting of the `Soft` key to `true`
-// (which will require assigning a header to the RequestOptions struct) doesn't
-// cause `panic: assignment to entry in nil map`.
+// (which will require assigning a header to the RequestOptions.Headers field)
+// doesn't cause `panic: assignment to entry in nil map`.
 func TestClient_Purge(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Problem**: https://github.com/fastly/go-fastly/issues/266

The call to `new(RequestOptions)` initialises the struct with zero values. So the `RequestOptions.Headers` map is `nil` by default . Hence trying to assign a value to `nil` results in `panic: assignment to entry in nil map`:

Example code that validated this:

```go
p, err := client.Purge(&fastly.PurgeInput{
	URL:  "http://testing-gofastly-purge.integralist-test.com.global.prod.fastly.net/anything/foo",
	Soft: true,
})
```