### PR TITLE
omitempty should be set for ContentTypes and Extensions

### DIFF
--- a/fastly/gzip.go
+++ b/fastly/gzip.go
@@ -73,8 +73,8 @@ type CreateGzipInput struct {
 	ServiceVersion int
 
 	Name           string `form:"name,omitempty"`
-	ContentTypes   string `form:"content_types"`
-	Extensions     string `form:"extensions"`
+	ContentTypes   string `form:"content_types,omitempty"`
+	Extensions     string `form:"extensions,omitempty"`
 	CacheCondition string `form:"cache_condition,omitempty"`
 }
 


### PR DESCRIPTION
These are optional parameters.

Fixes https://github.com/fastly/terraform-provider-fastly/issues/66