### PR TITLE
Check pointer struct type isn't `nil` before referencing its fields

### DIFF
--- a/fastly/managed_logging.go
+++ b/fastly/managed_logging.go
@@ -51,7 +51,7 @@ func (c *Client) CreateManagedLogging(i *CreateManagedLoggingInput) (*ManagedLog
 	// with a 409. Handle this case specially so users can decide if this is
 	// truly an error.
 	if err != nil {
-		if resp.StatusCode == http.StatusConflict {
+		if resp != nil && resp.StatusCode == http.StatusConflict {
 			return nil, ErrManagedLoggingEnabled
 		}
 		return nil, err


### PR DESCRIPTION
A [CLI](https://github.com/fastly/cli) user reported that their internet connection died during running `fastly logs tail` and this resulted in a panic. 

The associated stack trace (below) indicated the issue was within the go-fastly API client.

```
$ fastly logs tail

panic: runtime error: invalid memory address or nil pointer dereference

github.com/fastly/go-fastly/v3/fastly.(*Client).CreateManagedLogging(0xc000681380, 0xc0002f2658, 0xc000851ed0, 0x1006df0, 0x60)
	/Users/.../go/pkg/mod/github.com/fastly/go-fastly/v3@v3.9.0/fastly/managed_logging.go:54 +0x113
github.com/fastly/cli/pkg/logs.(*TailCommand).enableManagedLogging(0xc0002f2580, 0x197b040, 0xc00028e7f8, 0x2, 0x2)
	/Users/.../go/src/github.com/fastly/cli/pkg/logs/tail.go:312 +0x51
github.com/fastly/cli/pkg/logs.(*TailCommand).Exec(0xc0002f2580, 0x197b6e0, 0xc000010010, 0x197b040, 0xc00028e7f8, 0x1982070, 0xc0002f2580)
	/Users/.../go/src/github.com/fastly/cli/pkg/logs/tail.go:139 +0x27a
github.com/fastly/cli/pkg/app.Run(0x18bf118, 0xc0000201c0, 0x2, 0x2, 0x1, 0xc0002a2f20, 0x16, 0xc0002c6a00, 0x34, 0xc000282f38, ...)
	/Users/.../go/src/github.com/fastly/cli/pkg/app/run.go:805 +0x7084
main.main()
	/Users/.../go/src/github.com/fastly/cli/cmd/fastly/main.go:149 +0x898
```

Upon investigation I noticed the code was referencing a field on a pointer struct type that (due to an earlier error) was likely being returned as `nil`, and thus referencing the field would explain the `nil pointer dereference` error.