### PR TITLE
ACL entry Subnet should be integer type (missed references)

### DIFF
--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -107,7 +107,7 @@ type CreateACLEntryInput struct {
 	IP        string `form:"ip"`
 
 	// Optional fields
-	Subnet  string `form:"subnet,omitempty"`
+	Subnet  int    `form:"subnet,omitempty"`
 	Negated bool   `form:"negated,omitempty"`
 	Comment string `form:"comment,omitempty"`
 }
@@ -191,7 +191,7 @@ type UpdateACLEntryInput struct {
 
 	// Optional fields
 	IP      *string `form:"ip,omitempty"`
-	Subnet  *string `form:"subnet,omitempty"`
+	Subnet  *int    `form:"subnet,omitempty"`
 	Negated *bool   `form:"negated,omitempty"`
 	Comment *string `form:"comment,omitempty"`
 }

--- a/fastly/acl_entry_test.go
+++ b/fastly/acl_entry_test.go
@@ -25,7 +25,7 @@ func TestClient_ACLEntries(t *testing.T) {
 			ServiceID: testService.ID,
 			ACLID:     testACL.ID,
 			IP:        "10.0.0.3",
-			Subnet:    "8",
+			Subnet:    8,
 			Negated:   false,
 			Comment:   "test entry",
 		})


### PR DESCRIPTION
As per https://github.com/fastly/go-fastly/pull/288 but for the other CRUD methods (i.e. create and single entry update)