### PR TITLE
Remove `omitempty` from `SSLCheckCert` field

### DIFF
--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -111,16 +111,20 @@ type CreateBackendInput struct {
 	HealthCheck         string      `form:"healthcheck,omitempty"`
 	Shield              string      `form:"shield,omitempty"`
 	UseSSL              Compatibool `form:"use_ssl,omitempty"`
-	SSLCheckCert        Compatibool `form:"ssl_check_cert,omitempty"`
-	SSLCACert           string      `form:"ssl_ca_cert,omitempty"`
-	SSLClientCert       string      `form:"ssl_client_cert,omitempty"`
-	SSLClientKey        string      `form:"ssl_client_key,omitempty"`
-	SSLHostname         string      `form:"ssl_hostname,omitempty"`
-	SSLCertHostname     string      `form:"ssl_cert_hostname,omitempty"`
-	SSLSNIHostname      string      `form:"ssl_sni_hostname,omitempty"`
-	MinTLSVersion       string      `form:"min_tls_version,omitempty"`
-	MaxTLSVersion       string      `form:"max_tls_version,omitempty"`
-	SSLCiphers          []string    `form:"ssl_ciphers,omitempty"`
+	// NOTE: Fastly API sets "ssl_check_cert" to true as its default value
+	// if this parameter is not present in the request.
+	// Removing omitempty from this particular field so that we can still
+	// create a new backend with "ssl_check_cert: false" set.
+	SSLCheckCert    Compatibool `form:"ssl_check_cert"`
+	SSLCACert       string      `form:"ssl_ca_cert,omitempty"`
+	SSLClientCert   string      `form:"ssl_client_cert,omitempty"`
+	SSLClientKey    string      `form:"ssl_client_key,omitempty"`
+	SSLHostname     string      `form:"ssl_hostname,omitempty"`
+	SSLCertHostname string      `form:"ssl_cert_hostname,omitempty"`
+	SSLSNIHostname  string      `form:"ssl_sni_hostname,omitempty"`
+	MinTLSVersion   string      `form:"min_tls_version,omitempty"`
+	MaxTLSVersion   string      `form:"max_tls_version,omitempty"`
+	SSLCiphers      []string    `form:"ssl_ciphers,omitempty"`
 }
 
 // CreateBackend creates a new Fastly backend.

--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -45,6 +45,12 @@ const (
 // SnippetType is the type of VCL Snippet
 type SnippetType string
 
+// Helper function to get a pointer to string
+func SnippetTypeToString(b string) *SnippetType {
+	p := SnippetType(b)
+	return &p
+}
+
 // Snippet is the Fastly Snippet object
 type Snippet struct {
 	ServiceID      string `mapstructure:"service_id"`


### PR DESCRIPTION
A customer noticed this when using our [Terraform provider](https://github.com/fastly/terraform-provider-fastly) (and it actually caused an incident for them). This is a sad case but we need to be careful when setting `omitempty` tag especially if our API sets `true` as the default value.

We could use a pointer instead, but in this particular case, I figured removing the `omitempty` tag is a safer change for backward compatibility.

Once this PR is merged and a new go-fastly version is released, I will make a separate PR on the Terraform provider repo to bump the current require version to the latest version, which also requires some minor changes related to the recent breaking changes in go-fastly.