### PR TITLE
Fix issues with serialising x-www-form-urlencoded data

### DIFF
--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -38,7 +38,7 @@ type Backend struct {
 	SSLSNIHostname      string     `mapstructure:"ssl_sni_hostname"`
 	MinTLSVersion       string     `mapstructure:"min_tls_version"`
 	MaxTLSVersion       string     `mapstructure:"max_tls_version"`
-	SSLCiphers          []string   `mapstructure:"ssl_ciphers"`
+	SSLCiphers          string     `mapstructure:"ssl_ciphers"`
 	CreatedAt           *time.Time `mapstructure:"created_at"`
 	UpdatedAt           *time.Time `mapstructure:"updated_at"`
 	DeletedAt           *time.Time `mapstructure:"deleted_at"`
@@ -124,7 +124,7 @@ type CreateBackendInput struct {
 	SSLSNIHostname  string      `form:"ssl_sni_hostname,omitempty"`
 	MinTLSVersion   string      `form:"min_tls_version,omitempty"`
 	MaxTLSVersion   string      `form:"max_tls_version,omitempty"`
-	SSLCiphers      []string    `form:"ssl_ciphers,omitempty"`
+	SSLCiphers      string      `form:"ssl_ciphers,omitempty"`
 }
 
 // CreateBackend creates a new Fastly backend.
@@ -225,7 +225,7 @@ type UpdateBackendInput struct {
 	SSLSNIHostname      *string      `form:"ssl_sni_hostname,omitempty"`
 	MinTLSVersion       *string      `form:"min_tls_version,omitempty"`
 	MaxTLSVersion       *string      `form:"max_tls_version,omitempty"`
-	SSLCiphers          []string     `form:"ssl_ciphers,omitempty"`
+	SSLCiphers          string       `form:"ssl_ciphers,omitempty"`
 }
 
 // UpdateBackend updates a specific backend.

--- a/fastly/backend_test.go
+++ b/fastly/backend_test.go
@@ -24,6 +24,7 @@ func TestClient_Backends(t *testing.T) {
 			Port:           1234,
 			ConnectTimeout: 1500,
 			OverrideHost:   "origin.example.com",
+			SSLCiphers:     "DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384",
 		})
 	})
 	if err != nil {
@@ -115,6 +116,7 @@ func TestClient_Backends(t *testing.T) {
 			Name:           "test-backend",
 			NewName:        String("new-test-backend"),
 			OverrideHost:   String("www.example.com"),
+			SSLCiphers:     "RC4:!COMPLEMENTOFDEFAULT",
 		})
 	})
 	if err != nil {

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -54,8 +54,14 @@ var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",
 	ProjectVersion, ProjectURL, runtime.Version())
 
 // formEncodingArrayPattern is used to match the encoded multi-valued field
-// format of |<T> where T is an incrementing index such as:
-// services|0=A&services|1=B
+// format of |<T> where T is an incrementing index
+//
+// Example:
+// foo|0=A&foo|1=B
+//
+// NOTE:
+// I'm only checking double digits and nothing larger as I don't expect anyone
+// to provide over 99 separate values.
 var formEncodingArrayPattern = regexp.MustCompile(`%7C\d{1,2}`)
 
 // Client is the main entrypoint to the Fastly golang API library.

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -300,6 +300,16 @@ func (c *Client) RequestForm(verb, p string, i interface{}, ro *RequestOptions) 
 	if err := form.NewEncoder(buf).KeepZeros(true).DelimitWith('|').Encode(i); err != nil {
 		return nil, err
 	}
+
+	// NOTE: This is a temporary work-around to the issue of the Fastly API not
+	// recognising the format used by the github.com/ajg/form package.
+	//
+	// TODO: Consider using some form of custom marshal
+	// (https://github.com/ajg/form#custom-marshaling) or alternatively switch
+	// out the package for something else that has better support for the more
+	// traditional serialisation format: foo[]=A&foo[]=B
+	//
+	// EXAMPLE: https://play.golang.org/p/Kmf3l54MB73
 	body := formEncodingArrayPattern.ReplaceAllString(buf.String(), "%5B%5D") // %5B%5D == []
 
 	ro.Body = strings.NewReader(body)

--- a/fastly/fixtures/backends/cleanup.yaml
+++ b/fastly/fixtures/backends/cleanup.yaml
@@ -6,26 +6,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/test-backend
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/32/backend/test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e test-backend, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 20 }''"}'
+      version =\u003e 32 }''"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:53 GMT
+      - Mon, 20 Sep 2021 12:34:31 GMT
       Fastly-Ratelimit-Remaining:
-      - "917"
+      - "4973"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632142800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4148-MAN
       X-Timer:
-      - S1610619953.007977,VS0,VE193
+      - S1632141271.970511,VS0,VE175
     status: 404 Not Found
     code: 404
     duration: ""
@@ -50,26 +50,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/new-test-backend
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/32/backend/new-test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e new-test-backend, service =\u003e
-      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 20 }''"}'
+      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 32 }''"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:53 GMT
+      - Mon, 20 Sep 2021 12:34:31 GMT
       Fastly-Ratelimit-Remaining:
-      - "916"
+      - "4972"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632142800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -83,9 +83,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4148-MAN
       X-Timer:
-      - S1610619953.247038,VS0,VE184
+      - S1632141271.166720,VS0,VE157
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/backends/create.yaml
+++ b/fastly/fixtures/backends/create.yaml
@@ -2,12 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=20&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&port=1234
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=32&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&port=1234&ssl_check_cert=0&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384
     form:
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "20"
+      - "32"
       address:
       - integ-test.go-fastly.com
       connect_timeout:
@@ -18,28 +18,32 @@ interactions:
       - origin.example.com
       port:
       - "1234"
+      ssl_check_cert:
+      - "0"
+      ssl_ciphers:
+      - DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/32/backend
     method: POST
   response:
-    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","port":1234,"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":20,"max_tls_version":null,"hostname":"integ-test.go-fastly.com","client_cert":null,"ssl_ca_cert":null,"error_threshold":0,"ssl_client_cert":null,"deleted_at":null,"shield":null,"max_conn":200,"ssl_cert_hostname":null,"use_ssl":false,"first_byte_timeout":15000,"ipv6":null,"ssl_ciphers":null,"comment":"","ssl_sni_hostname":null,"ssl_client_key":null,"request_condition":"","ssl_check_cert":true,"weight":100,"healthcheck":null,"auto_loadbalance":false,"updated_at":"2021-01-14T10:25:50Z","created_at":"2021-01-14T10:25:50Z","ipv4":null,"min_tls_version":null,"between_bytes_timeout":10000,"ssl_hostname":null}'
+    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","port":1234,"ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":32,"request_condition":"","use_ssl":false,"ssl_cert_hostname":null,"hostname":"integ-test.go-fastly.com","auto_loadbalance":false,"weight":100,"created_at":"2021-09-20T12:34:29Z","ipv4":null,"shield":null,"comment":"","min_tls_version":null,"ssl_sni_hostname":null,"first_byte_timeout":15000,"client_cert":null,"max_conn":200,"max_tls_version":null,"ssl_client_key":null,"ssl_ca_cert":null,"ipv6":null,"updated_at":"2021-09-20T12:34:29Z","between_bytes_timeout":10000,"healthcheck":null,"ssl_client_cert":null,"error_threshold":0,"ssl_hostname":null,"deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:50 GMT
+      - Mon, 20 Sep 2021 12:34:29 GMT
       Fastly-Ratelimit-Remaining:
-      - "923"
+      - "4976"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632142800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -53,9 +57,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4148-MAN
       X-Timer:
-      - S1610619950.359768,VS0,VE545
+      - S1632141270.622348,VS0,VE222
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/delete.yaml
+++ b/fastly/fixtures/backends/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/new-test-backend
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/32/backend/new-test-backend
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:52 GMT
+      - Mon, 20 Sep 2021 12:34:30 GMT
       Fastly-Ratelimit-Remaining:
-      - "918"
+      - "4974"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632142800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4148-MAN
       X-Timer:
-      - S1610619953.711130,VS0,VE253
+      - S1632141271.688140,VS0,VE254
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/get.yaml
+++ b/fastly/fixtures/backends/get.yaml
@@ -6,20 +6,20 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/test-backend
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/32/backend/test-backend
     method: GET
   response:
-    body: '{"name":"test-backend","service_id":"7i6HN3TK9wS159v2gPAZ8A","address":"integ-test.go-fastly.com","ssl_sni_hostname":null,"between_bytes_timeout":10000,"ssl_client_key":null,"weight":100,"min_tls_version":null,"auto_loadbalance":false,"shield":null,"connect_timeout":1500,"comment":"","port":1234,"ipv4":null,"ssl_client_cert":null,"first_byte_timeout":15000,"ssl_ciphers":null,"deleted_at":null,"request_condition":"","max_conn":200,"ssl_cert_hostname":null,"hostname":"integ-test.go-fastly.com","ssl_check_cert":true,"ipv6":null,"use_ssl":false,"ssl_ca_cert":null,"version":20,"updated_at":"2021-01-14T10:25:50Z","override_host":"origin.example.com","created_at":"2021-01-14T10:25:50Z","error_threshold":0,"max_tls_version":null,"healthcheck":null,"ssl_hostname":null,"client_cert":null}'
+    body: '{"ipv4":null,"auto_loadbalance":false,"between_bytes_timeout":10000,"connect_timeout":1500,"name":"test-backend","ipv6":null,"address":"integ-test.go-fastly.com","request_condition":"","updated_at":"2021-09-20T12:34:29Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","comment":"","error_threshold":0,"version":32,"ssl_client_key":null,"weight":100,"max_conn":200,"ssl_client_cert":null,"ssl_check_cert":false,"port":1234,"ssl_cert_hostname":null,"ssl_ca_cert":null,"max_tls_version":null,"shield":null,"healthcheck":null,"ssl_sni_hostname":null,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","override_host":"origin.example.com","client_cert":null,"created_at":"2021-09-20T12:34:29Z","deleted_at":null,"use_ssl":false,"ssl_hostname":null,"hostname":"integ-test.go-fastly.com","min_tls_version":null,"first_byte_timeout":15000}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store, s-maxage=0
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:51 GMT
+      - Mon, 20 Sep 2021 12:34:30 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -27,15 +27,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish, 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS, MISS, MISS
       X-Cache-Hits:
-      - 0, 0
+      - 0, 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4148-MAN, cache-man4148-MAN
       X-Timer:
-      - S1610619951.458633,VS0,VE468
+      - S1632141270.062465,VS0,VE346
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/list.yaml
+++ b/fastly/fixtures/backends/list.yaml
@@ -6,20 +6,20 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/32/backend
     method: GET
   response:
-    body: '[{"use_ssl":false,"weight":100,"ssl_ciphers":null,"port":1234,"connect_timeout":1500,"ssl_ca_cert":null,"created_at":"2021-01-14T10:25:50Z","ipv6":null,"ssl_client_cert":null,"comment":"","address":"integ-test.go-fastly.com","client_cert":null,"deleted_at":null,"max_conn":200,"override_host":"origin.example.com","ssl_check_cert":true,"auto_loadbalance":false,"ssl_hostname":null,"error_threshold":0,"hostname":"integ-test.go-fastly.com","name":"test-backend","updated_at":"2021-01-14T10:25:50Z","between_bytes_timeout":10000,"first_byte_timeout":15000,"request_condition":"","healthcheck":null,"ssl_client_key":null,"max_tls_version":null,"ssl_cert_hostname":null,"ssl_sni_hostname":null,"version":20,"shield":null,"min_tls_version":null,"ipv4":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A"}]'
+    body: '[{"use_ssl":false,"port":1234,"first_byte_timeout":15000,"error_threshold":0,"ssl_cert_hostname":null,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","request_condition":"","comment":"","client_cert":null,"ssl_client_cert":null,"healthcheck":null,"override_host":"origin.example.com","ssl_check_cert":false,"ipv4":null,"address":"integ-test.go-fastly.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_ca_cert":null,"ipv6":null,"created_at":"2021-09-20T12:34:29Z","ssl_sni_hostname":null,"auto_loadbalance":false,"min_tls_version":null,"hostname":"integ-test.go-fastly.com","between_bytes_timeout":10000,"name":"test-backend","connect_timeout":1500,"version":32,"ssl_client_key":null,"updated_at":"2021-09-20T12:34:29Z","ssl_hostname":null,"deleted_at":null,"weight":100,"max_tls_version":null,"shield":null,"max_conn":200}]'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:51 GMT
+      - Mon, 20 Sep 2021 12:34:30 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4148-MAN
       X-Timer:
-      - S1610619951.946600,VS0,VE467
+      - S1632141270.868788,VS0,VE168
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update.yaml
+++ b/fastly/fixtures/backends/update.yaml
@@ -2,40 +2,42 @@
 version: 1
 interactions:
 - request:
-    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=20&name=new-test-backend&override_host=www.example.com
+    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=32&name=new-test-backend&override_host=www.example.com&ssl_ciphers=RC4%3A%21COMPLEMENTOFDEFAULT
     form:
       Name:
       - test-backend
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "20"
+      - "32"
       name:
       - new-test-backend
       override_host:
       - www.example.com
+      ssl_ciphers:
+      - RC4:!COMPLEMENTOFDEFAULT
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/20/backend/test-backend
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/32/backend/test-backend
     method: PUT
   response:
-    body: '{"ssl_sni_hostname":null,"hostname":"integ-test.go-fastly.com","ipv6":null,"ssl_ca_cert":null,"error_threshold":0,"ipv4":null,"ssl_ciphers":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_hostname":null,"ssl_check_cert":true,"ssl_client_key":null,"deleted_at":null,"ssl_client_cert":null,"request_condition":"","max_tls_version":null,"override_host":"www.example.com","shield":null,"ssl_cert_hostname":null,"auto_loadbalance":false,"address":"integ-test.go-fastly.com","use_ssl":false,"first_byte_timeout":15000,"comment":"","name":"new-test-backend","created_at":"2021-01-14T10:25:50Z","weight":100,"max_conn":200,"connect_timeout":1500,"min_tls_version":null,"updated_at":"2021-01-14T10:25:50Z","version":20,"between_bytes_timeout":10000,"client_cert":null,"port":1234,"healthcheck":null}'
+    body: '{"override_host":"www.example.com","ssl_sni_hostname":null,"comment":"","ssl_check_cert":false,"shield":null,"min_tls_version":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","hostname":"integ-test.go-fastly.com","auto_loadbalance":false,"ssl_cert_hostname":null,"created_at":"2021-09-20T12:34:29Z","weight":100,"ipv4":null,"request_condition":"","name":"new-test-backend","version":32,"use_ssl":false,"error_threshold":0,"ssl_hostname":null,"deleted_at":null,"port":1234,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","ssl_client_cert":null,"ssl_ca_cert":null,"ssl_client_key":null,"address":"integ-test.go-fastly.com","ipv6":null,"connect_timeout":1500,"healthcheck":null,"updated_at":"2021-09-20T12:34:29Z","between_bytes_timeout":10000,"client_cert":null,"first_byte_timeout":15000,"max_tls_version":null,"max_conn":200}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:52 GMT
+      - Mon, 20 Sep 2021 12:34:30 GMT
       Fastly-Ratelimit-Remaining:
-      - "919"
+      - "4975"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632142800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +51,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4148-MAN
       X-Timer:
-      - S1610619952.963543,VS0,VE623
+      - S1632141270.435215,VS0,VE229
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/version.yaml
+++ b/fastly/fixtures/backends/version.yaml
@@ -10,24 +10,24 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":20}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":32}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:25:50 GMT
+      - Mon, 20 Sep 2021 12:34:29 GMT
       Fastly-Ratelimit-Remaining:
-      - "925"
+      - "4977"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632142800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4144-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4148-MAN
       X-Timer:
-      - S1610619950.755481,VS0,VE538
+      - S1632141269.818375,VS0,VE709
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/tokens/create_and_bulk_delete.yaml
+++ b/fastly/fixtures/tokens/create_and_bulk_delete.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: name=my-test-token-1&password=foobar&scope=global&username=testing%40fastly.com
+    body: name=my-test-token-1&password=foobar&scope=global&services%5B%5D=5wHdzYhbILBcvU2aAjH8so&services%5B%5D=6besTz8jIUQudhhr4vLEzt&username=testing%40fastly.com
     form:
       name:
       - my-test-token-1
@@ -10,17 +10,20 @@ interactions:
       - foobar
       scope:
       - global
+      services[]:
+      - 5wHdzYhbILBcvU2aAjH8so
+      - 6besTz8jIUQudhhr4vLEzt
       username:
       - testing@fastly.com
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/3.11.0 (+github.com/fastly/go-fastly; go1.17)
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/sudo
     method: POST
   response:
-    body: '{"expiry_time":"2021-09-15T16:15:56+00:00"}'
+    body: '{"expiry_time":"2021-09-20T11:29:38+00:00"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -29,11 +32,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Sep 2021 16:10:56 GMT
+      - Mon, 20 Sep 2021 11:24:38 GMT
       Fastly-Ratelimit-Remaining:
-      - "4999"
+      - "4992"
       Fastly-Ratelimit-Reset:
-      - "1631725200"
+      - "1632139200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,14 +50,14 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4150-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4144-MAN
       X-Timer:
-      - S1631722256.303142,VS0,VE306
+      - S1632137078.768877,VS0,VE400
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: name=my-test-token-1&password=foobar&scope=global&username=testing%40fastly.com
+    body: name=my-test-token-1&password=foobar&scope=global&services%5B%5D=5wHdzYhbILBcvU2aAjH8so&services%5B%5D=6besTz8jIUQudhhr4vLEzt&username=testing%40fastly.com
     form:
       name:
       - my-test-token-1
@@ -62,17 +65,20 @@ interactions:
       - foobar
       scope:
       - global
+      services[]:
+      - 5wHdzYhbILBcvU2aAjH8so
+      - 6besTz8jIUQudhhr4vLEzt
       username:
       - testing@fastly.com
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/3.11.0 (+github.com/fastly/go-fastly; go1.17)
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/tokens
     method: POST
   response:
-    body: '{"id":"67WnFZog4TztGgdNfc9mxX","name":"my-test-token-1","user_id":"52LiGaZmbWl4D5xv4tcxON","customer_id":"51MumwLiSJyFTWhtbByYgR","service_id":null,"expires_at":null,"created_at":"2021-09-15T16:10:56Z","updated_at":"2021-09-15T16:10:56Z","scope":"global","services":[],"access_token":"XXXXXXXXXXXXXXXXXXXXXX"}'
+    body: '{"id":"27DePetT24oLN9xdXRMkdo","name":"my-test-token-1","user_id":"52LiGaZmbWl4D5xv4tcxON","customer_id":"51MumwLiSJyFTWhtbByYgR","service_id":"6besTz8jIUQudhhr4vLEzt","expires_at":null,"created_at":"2021-09-20T11:24:38Z","updated_at":"2021-09-20T11:24:38Z","scope":"global","services":["5wHdzYhbILBcvU2aAjH8so","6besTz8jIUQudhhr4vLEzt"],"access_token":"XXXXXXXXXXXXXXXXXXXXXX"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -81,11 +87,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Sep 2021 16:10:56 GMT
+      - Mon, 20 Sep 2021 11:24:38 GMT
       Fastly-Ratelimit-Remaining:
-      - "4998"
+      - "4991"
       Fastly-Ratelimit-Reset:
-      - "1631725200"
+      - "1632139200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -99,14 +105,14 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4150-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4144-MAN
       X-Timer:
-      - S1631722257.636563,VS0,VE348
+      - S1632137078.206178,VS0,VE386
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: name=my-test-token-2&password=foobar&scope=global&username=testing%40fastly.com
+    body: name=my-test-token-2&password=foobar&scope=global&services%5B%5D=5wHdzYhbILBcvU2aAjH8so&services%5B%5D=6besTz8jIUQudhhr4vLEzt&username=testing%40fastly.com
     form:
       name:
       - my-test-token-2
@@ -114,17 +120,20 @@ interactions:
       - foobar
       scope:
       - global
+      services[]:
+      - 5wHdzYhbILBcvU2aAjH8so
+      - 6besTz8jIUQudhhr4vLEzt
       username:
       - testing@fastly.com
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/3.11.0 (+github.com/fastly/go-fastly; go1.17)
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/sudo
     method: POST
   response:
-    body: '{"expiry_time":"2021-09-15T16:15:57+00:00"}'
+    body: '{"expiry_time":"2021-09-20T11:29:38+00:00"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -133,11 +142,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Sep 2021 16:10:57 GMT
+      - Mon, 20 Sep 2021 11:24:38 GMT
       Fastly-Ratelimit-Remaining:
-      - "4997"
+      - "4990"
       Fastly-Ratelimit-Reset:
-      - "1631725200"
+      - "1632139200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -151,14 +160,14 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4150-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4144-MAN
       X-Timer:
-      - S1631722257.011411,VS0,VE232
+      - S1632137079.627201,VS0,VE371
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: name=my-test-token-2&password=foobar&scope=global&username=testing%40fastly.com
+    body: name=my-test-token-2&password=foobar&scope=global&services%5B%5D=5wHdzYhbILBcvU2aAjH8so&services%5B%5D=6besTz8jIUQudhhr4vLEzt&username=testing%40fastly.com
     form:
       name:
       - my-test-token-2
@@ -166,17 +175,20 @@ interactions:
       - foobar
       scope:
       - global
+      services[]:
+      - 5wHdzYhbILBcvU2aAjH8so
+      - 6besTz8jIUQudhhr4vLEzt
       username:
       - testing@fastly.com
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/3.11.0 (+github.com/fastly/go-fastly; go1.17)
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/tokens
     method: POST
   response:
-    body: '{"id":"XzkxSPqcUJmf522PeZ1tb","name":"my-test-token-2","user_id":"52LiGaZmbWl4D5xv4tcxON","customer_id":"51MumwLiSJyFTWhtbByYgR","service_id":null,"expires_at":null,"created_at":"2021-09-15T16:10:57Z","updated_at":"2021-09-15T16:10:57Z","scope":"global","services":[],"access_token":"XXXXXXXXXXXXXXXXXXXXXX"}'
+    body: '{"id":"5nifBbOSCa4gxQ0846z1RL","name":"my-test-token-2","user_id":"52LiGaZmbWl4D5xv4tcxON","customer_id":"51MumwLiSJyFTWhtbByYgR","service_id":"6besTz8jIUQudhhr4vLEzt","expires_at":null,"created_at":"2021-09-20T11:24:39Z","updated_at":"2021-09-20T11:24:39Z","scope":"global","services":["5wHdzYhbILBcvU2aAjH8so","6besTz8jIUQudhhr4vLEzt"],"access_token":"XXXXXXXXXXXXXXXXXXXXXX"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -185,11 +197,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Sep 2021 16:10:57 GMT
+      - Mon, 20 Sep 2021 11:24:39 GMT
       Fastly-Ratelimit-Remaining:
-      - "4996"
+      - "4989"
       Fastly-Ratelimit-Reset:
-      - "1631725200"
+      - "1632139200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -203,15 +215,15 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4150-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4144-MAN
       X-Timer:
-      - S1631722257.275500,VS0,VE167
+      - S1632137079.019631,VS0,VE221
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"data":[{"type":"token","id":"67WnFZog4TztGgdNfc9mxX"},{"type":"token","id":"XzkxSPqcUJmf522PeZ1tb"}]}
+      {"data":[{"type":"token","id":"27DePetT24oLN9xdXRMkdo"},{"type":"token","id":"5nifBbOSCa4gxQ0846z1RL"}]}
     form: {}
     headers:
       Accept:
@@ -219,7 +231,7 @@ interactions:
       Content-Type:
       - application/vnd.api+json; ext=bulk
       User-Agent:
-      - FastlyGo/3.11.0 (+github.com/fastly/go-fastly; go1.17)
+      - FastlyGo/3.12.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/tokens
     method: DELETE
   response:
@@ -230,11 +242,11 @@ interactions:
       Cache-Control:
       - no-store
       Date:
-      - Wed, 15 Sep 2021 16:10:57 GMT
+      - Mon, 20 Sep 2021 11:24:39 GMT
       Fastly-Ratelimit-Remaining:
-      - "4995"
+      - "4988"
       Fastly-Ratelimit-Reset:
-      - "1631725200"
+      - "1632139200"
       Status:
       - 204 No Content
       Strict-Transport-Security:
@@ -246,9 +258,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4150-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4144-MAN
       X-Timer:
-      - S1631722257.462874,VS0,VE199
+      - S1632137079.267003,VS0,VE276
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/token_test.go
+++ b/fastly/token_test.go
@@ -117,6 +117,7 @@ func TestClient_CreateAndBulkDeleteTokens(t *testing.T) {
 			Scope:    "global",
 			Username: "testing@fastly.com",
 			Password: "foobar",
+			Services: []string{"5wHdzYhbILBcvU2aAjH8so", "6besTz8jIUQudhhr4vLEzt"},
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -127,6 +128,7 @@ func TestClient_CreateAndBulkDeleteTokens(t *testing.T) {
 			Scope:    "global",
 			Username: "testing@fastly.com",
 			Password: "foobar",
+			Services: []string{"5wHdzYhbILBcvU2aAjH8so", "6besTz8jIUQudhhr4vLEzt"},
 		})
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
- Creating tokens using the `foo|0=A&foo|1=B` format doesn't work with our API endpoint, so switch to `foo[]=A&foo[]=B`.
- Creating/updating backends were incorrectly asking for a slice of strings, rather than a string that was colon delimited.

> **NOTE**: Refer to the updated fixture files to see the difference in API response.