### PR TITLE
v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v4.0.0](https://github.com/fastly/go-fastly/releases/tag/v4.0.0) (2021-09-21)
+
+[Full Changelog](https://github.com/fastly/go-fastly/compare/v3.12.0...v4.0.0)
+
+**Bug fixes:**
+
+- Fix issues with serialising x-www-form-urlencoded data [#304](https://github.com/fastly/go-fastly/pull/304)
+
 ## [v3.12.0](https://github.com/fastly/go-fastly/releases/tag/v3.12.0) (2021-09-15)
 
 [Full Changelog](https://github.com/fastly/go-fastly/compare/v3.11.0...v3.12.0)

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -47,7 +47,7 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 var ProjectURL = "github.com/fastly/go-fastly"
 
 // ProjectVersion is the version of this library.
-var ProjectVersion = "3.12.0"
+var ProjectVersion = "4.0.0"
 
 // UserAgent is the user agent for this particular client.
 var UserAgent = fmt.Sprintf("FastlyGo/%s (+%s; %s)",


### PR DESCRIPTION
This is a major release because we've updated the consumer interface in the last PR.

e.g. `SSLCiphers` went from `[]string` to `string` type which would be a breaking change. 

> NOTE: Although this is a breaking change, it's unlikely anyone was using the `SSLCiphers` field because the original `[]string` type didn't work with our API endpoint.