### PR TITLE
Switch from `bool` to `Compatibool` for ACL entries

### DIFF
--- a/fastly/acl_entries_batch_test.go
+++ b/fastly/acl_entries_batch_test.go
@@ -27,14 +27,14 @@ func TestClient_BatchModifyAclEntries_Create(t *testing.T) {
 				Operation: CreateBatchOperation,
 				IP:        String("127.0.0.1"),
 				Subnet:    Int(24),
-				Negated:   Bool(false),
+				Negated:   CBool(false),
 				Comment:   String("ACL Entry 1"),
 			},
 			{
 				Operation: CreateBatchOperation,
 				IP:        String("192.168.0.1"),
 				Subnet:    Int(24),
-				Negated:   Bool(false),
+				Negated:   CBool(true),
 				Comment:   String("ACL Entry 2"),
 			},
 		},
@@ -43,7 +43,6 @@ func TestClient_BatchModifyAclEntries_Create(t *testing.T) {
 	// When: I execute the batch create operations against the Fastly API,
 	var err error
 	record(t, fixtureBase+"create_acl_entries", func(c *Client) {
-
 		err = c.BatchModifyACLEntries(batchCreateOperations)
 	})
 	if err != nil {
@@ -89,9 +88,9 @@ func TestClient_BatchModifyAclEntries_Create(t *testing.T) {
 		}
 
 		actualNegated := entry.Negated
-		expectedNegated := batchCreateOperations.Entries[i].Negated
+		expectedNegated := bool(*batchCreateOperations.Entries[i].Negated)
 
-		if actualNegated != *expectedNegated {
+		if actualNegated != expectedNegated {
 			t.Errorf("Negated did not match, expected %v, got %v", expectedNegated, actualNegated)
 		}
 
@@ -127,14 +126,14 @@ func TestClient_BatchModifyAclEntries_Delete(t *testing.T) {
 				Operation: CreateBatchOperation,
 				IP:        String("127.0.0.1"),
 				Subnet:    Int(24),
-				Negated:   Bool(false),
+				Negated:   CBool(false),
 				Comment:   String("ACL Entry 1"),
 			},
 			{
 				Operation: CreateBatchOperation,
 				IP:        String("192.168.0.1"),
 				Subnet:    Int(24),
-				Negated:   Bool(false),
+				Negated:   CBool(true),
 				Comment:   String("ACL Entry 2"),
 			},
 		},
@@ -229,14 +228,14 @@ func TestClient_BatchModifyAclEntries_Update(t *testing.T) {
 				Operation: CreateBatchOperation,
 				IP:        String("127.0.0.1"),
 				Subnet:    Int(24),
-				Negated:   Bool(false),
+				Negated:   CBool(false),
 				Comment:   String("ACL Entry 1"),
 			},
 			{
 				Operation: CreateBatchOperation,
 				IP:        String("192.168.0.1"),
 				Subnet:    Int(24),
-				Negated:   Bool(false),
+				Negated:   CBool(true),
 				Comment:   String("ACL Entry 2"),
 			},
 		},
@@ -276,7 +275,7 @@ func TestClient_BatchModifyAclEntries_Update(t *testing.T) {
 				ID:        String(createdACLEntries[0].ID),
 				IP:        String("127.0.0.2"),
 				Subnet:    Int(16),
-				Negated:   Bool(true),
+				Negated:   CBool(true),
 				Comment:   String("Updated ACL Entry 1"),
 			},
 		},
@@ -334,9 +333,9 @@ func TestClient_BatchModifyAclEntries_Update(t *testing.T) {
 	}
 
 	actualNegated := actualACLEntries[0].Negated
-	expectedNegated := batchUpdateOperations.Entries[0].Negated
+	expectedNegated := bool(*batchUpdateOperations.Entries[0].Negated)
 
-	if actualNegated != *expectedNegated {
+	if actualNegated != expectedNegated {
 		t.Errorf("First Subnet did not match, expected %v, got %v", expectedNegated, actualNegated)
 	}
 

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -107,9 +107,9 @@ type CreateACLEntryInput struct {
 	IP        string `form:"ip"`
 
 	// Optional fields
-	Subnet  int    `form:"subnet,omitempty"`
-	Negated bool   `form:"negated,omitempty"`
-	Comment string `form:"comment,omitempty"`
+	Subnet  int         `form:"subnet,omitempty"`
+	Negated Compatibool `form:"negated,omitempty"`
+	Comment string      `form:"comment,omitempty"`
 }
 
 // CreateACLEntry creates and returns a new ACL entry.
@@ -190,10 +190,10 @@ type UpdateACLEntryInput struct {
 	ID        string
 
 	// Optional fields
-	IP      *string `form:"ip,omitempty"`
-	Subnet  *int    `form:"subnet,omitempty"`
-	Negated *bool   `form:"negated,omitempty"`
-	Comment *string `form:"comment,omitempty"`
+	IP      *string      `form:"ip,omitempty"`
+	Subnet  *int         `form:"subnet,omitempty"`
+	Negated *Compatibool `form:"negated,omitempty"`
+	Comment *string      `form:"comment,omitempty"`
 }
 
 // UpdateACLEntry updates an ACL entry
@@ -237,7 +237,7 @@ type BatchACLEntry struct {
 	ID        *string        `json:"id,omitempty"`
 	IP        *string        `json:"ip,omitempty"`
 	Subnet    *int           `json:"subnet,omitempty"`
-	Negated   *bool          `json:"negated,omitempty"`
+	Negated   *Compatibool   `json:"negated,omitempty"`
 	Comment   *string        `json:"comment,omitempty"`
 }
 

--- a/fastly/acl_entry_test.go
+++ b/fastly/acl_entry_test.go
@@ -26,7 +26,7 @@ func TestClient_ACLEntries(t *testing.T) {
 			ACLID:     testACL.ID,
 			IP:        "10.0.0.3",
 			Subnet:    8,
-			Negated:   false,
+			Negated:   Compatibool(false),
 			Comment:   "test entry",
 		})
 	})
@@ -100,7 +100,7 @@ func TestClient_ACLEntries(t *testing.T) {
 			ACLID:     testACL.ID,
 			ID:        e.ID,
 			IP:        String("10.0.0.4"),
-			Negated:   Bool(true),
+			Negated:   CBool(true),
 		})
 	})
 	if err != nil {

--- a/fastly/fixtures/acl_entries/acl.yaml
+++ b/fastly/fixtures/acl_entries/acl.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=5BEXGVZPrhtk8TJfJJiz5u&ServiceVersion=2&name=test_acl_ACLEntries
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=2&name=test_acl_ACLEntries
     form:
       ServiceID:
-      - 5BEXGVZPrhtk8TJfJJiz5u
+      - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
       - "2"
       name:
@@ -14,24 +14,24 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5BEXGVZPrhtk8TJfJJiz5u/version/2/acl
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/acl
     method: POST
   response:
-    body: '{"service_id":"5BEXGVZPrhtk8TJfJJiz5u","version":"2","name":"test_acl_ACLEntries","created_at":"2021-01-14T10:23:48Z","id":"3XA9Zoz75yiYlgnjzDAFmI","updated_at":"2021-01-14T10:23:48Z","deleted_at":null}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"2","name":"test_acl_ACLEntries","updated_at":"2021-09-22T10:29:24Z","deleted_at":null,"id":"1PCB9fTlFSnrOrUCKa0WzO","created_at":"2021-09-22T10:29:24Z"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:48 GMT
+      - Wed, 22 Sep 2021 10:29:24 GMT
       Fastly-Ratelimit-Remaining:
-      - "977"
+      - "4994"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632308400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619828.969284,VS0,VE303
+      - S1632306565.759753,VS0,VE215
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries/create.yaml
+++ b/fastly/fixtures/acl_entries/create.yaml
@@ -2,12 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: ACLID=3XA9Zoz75yiYlgnjzDAFmI&ServiceID=5BEXGVZPrhtk8TJfJJiz5u&comment=test+entry&ip=10.0.0.3&subnet=8
+    body: ACLID=1PCB9fTlFSnrOrUCKa0WzO&ServiceID=7i6HN3TK9wS159v2gPAZ8A&comment=test+entry&ip=10.0.0.3&subnet=8
     form:
       ACLID:
-      - 3XA9Zoz75yiYlgnjzDAFmI
+      - 1PCB9fTlFSnrOrUCKa0WzO
       ServiceID:
-      - 5BEXGVZPrhtk8TJfJJiz5u
+      - 7i6HN3TK9wS159v2gPAZ8A
       comment:
       - test entry
       ip:
@@ -18,25 +18,25 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5BEXGVZPrhtk8TJfJJiz5u/acl/3XA9Zoz75yiYlgnjzDAFmI/entry
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/acl/1PCB9fTlFSnrOrUCKa0WzO/entry
     method: POST
   response:
-    body: '{"service_id":"5BEXGVZPrhtk8TJfJJiz5u","acl_id":"3XA9Zoz75yiYlgnjzDAFmI","ip":"10.0.0.3","subnet":8,"comment":"test
-      entry","id":"5Eyk2g71nkTniNmscr6bJs","updated_at":"2021-01-14T10:23:48Z","created_at":"2021-01-14T10:23:48Z","negated":0,"deleted_at":null}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","acl_id":"1PCB9fTlFSnrOrUCKa0WzO","ip":"10.0.0.3","subnet":8,"comment":"test
+      entry","negated":0,"updated_at":"2021-09-22T10:29:25Z","created_at":"2021-09-22T10:29:25Z","id":"69nI3MhHVzdtXD5XW9B6ZN"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:48 GMT
+      - Wed, 22 Sep 2021 10:29:25 GMT
       Fastly-Ratelimit-Remaining:
-      - "976"
+      - "4993"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632308400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -50,9 +50,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619828.394394,VS0,VE252
+      - S1632306565.999302,VS0,VE170
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries/create_service.yaml
+++ b/fastly/fixtures/acl_entries/create_service.yaml
@@ -14,24 +14,24 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/service
     method: POST
   response:
-    body: '{"customer_id":"51MumwLiSJyFTWhtbByYgR","comment":"go-fastly client test","name":"test_service_ACLEntries","type":"vcl","id":"5BEXGVZPrhtk8TJfJJiz5u","paused":false,"versions":[{"deployed":false,"staging":false,"locked":false,"service_id":"5BEXGVZPrhtk8TJfJJiz5u","created_at":"2021-01-14T10:23:47Z","testing":false,"updated_at":"2021-01-14T10:23:47Z","active":false,"comment":"","number":1,"deleted_at":null}],"updated_at":"2021-01-14T10:23:47Z","created_at":"2021-01-14T10:23:47Z","deleted_at":null,"publish_key":""}'
+    body: '{"customer_id":"51MumwLiSJyFTWhtbByYgR","comment":"go-fastly client test","name":"test_service_ACLEntries","type":"vcl","id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2021-09-22T10:29:24Z","versions":[{"service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2021-09-22T10:29:24Z","staging":false,"comment":"","deployed":false,"locked":false,"deleted_at":null,"testing":false,"number":1,"active":false,"created_at":"2021-09-22T10:29:24Z"}],"paused":false,"publish_key":"","created_at":"2021-09-22T10:29:24Z","deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:47 GMT
+      - Wed, 22 Sep 2021 10:29:24 GMT
       Fastly-Ratelimit-Remaining:
-      - "979"
+      - "4996"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632308400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619827.274502,VS0,VE238
+      - S1632306564.308192,VS0,VE206
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries/delete.yaml
+++ b/fastly/fixtures/acl_entries/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5BEXGVZPrhtk8TJfJJiz5u/acl/3XA9Zoz75yiYlgnjzDAFmI/entry/5Eyk2g71nkTniNmscr6bJs
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/acl/1PCB9fTlFSnrOrUCKa0WzO/entry/69nI3MhHVzdtXD5XW9B6ZN
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:50 GMT
+      - Wed, 22 Sep 2021 10:29:26 GMT
       Fastly-Ratelimit-Remaining:
-      - "974"
+      - "4991"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632308400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619830.037578,VS0,VE264
+      - S1632306566.833539,VS0,VE209
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries/delete_acl.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5BEXGVZPrhtk8TJfJJiz5u/version/2/acl/test_acl_ACLEntries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/acl/test_acl_ACLEntries
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:50 GMT
+      - Wed, 22 Sep 2021 10:29:26 GMT
       Fastly-Ratelimit-Remaining:
-      - "973"
+      - "4990"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632308400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619830.345719,VS0,VE313
+      - S1632306566.062229,VS0,VE229
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries/delete_service.yaml
+++ b/fastly/fixtures/acl_entries/delete_service.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5BEXGVZPrhtk8TJfJJiz5u
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:50 GMT
+      - Wed, 22 Sep 2021 10:29:26 GMT
       Fastly-Ratelimit-Remaining:
-      - "972"
+      - "4989"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632308400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619831.683988,VS0,VE254
+      - S1632306566.314758,VS0,VE215
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries/get.yaml
+++ b/fastly/fixtures/acl_entries/get.yaml
@@ -6,21 +6,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5BEXGVZPrhtk8TJfJJiz5u/acl/3XA9Zoz75yiYlgnjzDAFmI/entry/5Eyk2g71nkTniNmscr6bJs
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/acl/1PCB9fTlFSnrOrUCKa0WzO/entry/69nI3MhHVzdtXD5XW9B6ZN
     method: GET
   response:
-    body: '{"id":"5Eyk2g71nkTniNmscr6bJs","ip":"10.0.0.3","updated_at":"2021-01-14T10:23:48Z","service_id":"5BEXGVZPrhtk8TJfJJiz5u","deleted_at":null,"comment":"test
-      entry","negated":"0","created_at":"2021-01-14T10:23:48Z","subnet":8,"acl_id":"3XA9Zoz75yiYlgnjzDAFmI"}'
+    body: '{"updated_at":"2021-09-22T10:29:25Z","id":"69nI3MhHVzdtXD5XW9B6ZN","acl_id":"1PCB9fTlFSnrOrUCKa0WzO","subnet":8,"ip":"10.0.0.3","negated":"0","service_id":"7i6HN3TK9wS159v2gPAZ8A","created_at":"2021-09-22T10:29:25Z","comment":"test
+      entry"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:49 GMT
+      - Wed, 22 Sep 2021 10:29:25 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -34,9 +34,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619829.216304,VS0,VE439
+      - S1632306565.474371,VS0,VE120
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries/list.yaml
+++ b/fastly/fixtures/acl_entries/list.yaml
@@ -6,21 +6,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5BEXGVZPrhtk8TJfJJiz5u/acl/3XA9Zoz75yiYlgnjzDAFmI/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/acl/1PCB9fTlFSnrOrUCKa0WzO/entries
     method: GET
   response:
-    body: '[{"created_at":"2021-01-14T10:23:48Z","acl_id":"3XA9Zoz75yiYlgnjzDAFmI","comment":"test
-      entry","deleted_at":null,"ip":"10.0.0.3","updated_at":"2021-01-14T10:23:48Z","negated":"0","id":"5Eyk2g71nkTniNmscr6bJs","service_id":"5BEXGVZPrhtk8TJfJJiz5u","subnet":8}]'
+    body: '[{"created_at":"2021-09-22T10:29:25Z","id":"69nI3MhHVzdtXD5XW9B6ZN","subnet":8,"ip":"10.0.0.3","negated":"0","updated_at":"2021-09-22T10:29:25Z","comment":"test
+      entry","acl_id":"1PCB9fTlFSnrOrUCKa0WzO","service_id":"7i6HN3TK9wS159v2gPAZ8A"}]'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:49 GMT
+      - Wed, 22 Sep 2021 10:29:25 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -34,9 +34,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619829.690429,VS0,VE466
+      - S1632306565.196419,VS0,VE247
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries/update.yaml
+++ b/fastly/fixtures/acl_entries/update.yaml
@@ -2,41 +2,40 @@
 version: 1
 interactions:
 - request:
-    body: ACLID=3XA9Zoz75yiYlgnjzDAFmI&ID=5Eyk2g71nkTniNmscr6bJs&ServiceID=5BEXGVZPrhtk8TJfJJiz5u&ip=10.0.0.4&negated=true
+    body: ACLID=1PCB9fTlFSnrOrUCKa0WzO&ID=69nI3MhHVzdtXD5XW9B6ZN&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ip=10.0.0.4&negated=1
     form:
       ACLID:
-      - 3XA9Zoz75yiYlgnjzDAFmI
+      - 1PCB9fTlFSnrOrUCKa0WzO
       ID:
-      - 5Eyk2g71nkTniNmscr6bJs
+      - 69nI3MhHVzdtXD5XW9B6ZN
       ServiceID:
-      - 5BEXGVZPrhtk8TJfJJiz5u
+      - 7i6HN3TK9wS159v2gPAZ8A
       ip:
       - 10.0.0.4
       negated:
-      - "true"
+      - "1"
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5BEXGVZPrhtk8TJfJJiz5u/acl/3XA9Zoz75yiYlgnjzDAFmI/entry/5Eyk2g71nkTniNmscr6bJs
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/acl/1PCB9fTlFSnrOrUCKa0WzO/entry/69nI3MhHVzdtXD5XW9B6ZN
     method: PATCH
   response:
-    body: '{"subnet":8,"acl_id":"3XA9Zoz75yiYlgnjzDAFmI","created_at":"2021-01-14T10:23:48Z","negated":"true","service_id":"5BEXGVZPrhtk8TJfJJiz5u","ip":"10.0.0.4","id":"5Eyk2g71nkTniNmscr6bJs","deleted_at":null,"comment":"test
-      entry","updated_at":"2021-01-14T10:23:48Z"}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","comment":"test entry","acl_id":"1PCB9fTlFSnrOrUCKa0WzO","negated":1,"ip":"10.0.0.4","updated_at":"2021-09-22T10:29:25Z","created_at":"2021-09-22T10:29:25Z","subnet":8,"id":"69nI3MhHVzdtXD5XW9B6ZN"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:49 GMT
+      - Wed, 22 Sep 2021 10:29:25 GMT
       Fastly-Ratelimit-Remaining:
-      - "975"
+      - "4992"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632308400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -50,9 +49,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619830.700188,VS0,VE277
+      - S1632306566.618880,VS0,VE191
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries/version.yaml
+++ b/fastly/fixtures/acl_entries/version.yaml
@@ -2,32 +2,32 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=5BEXGVZPrhtk8TJfJJiz5u
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A
     form:
       ServiceID:
-      - 5BEXGVZPrhtk8TJfJJiz5u
+      - 7i6HN3TK9wS159v2gPAZ8A
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5BEXGVZPrhtk8TJfJJiz5u/version
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"5BEXGVZPrhtk8TJfJJiz5u","number":2}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":2}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:47 GMT
+      - Wed, 22 Sep 2021 10:29:24 GMT
       Fastly-Ratelimit-Remaining:
-      - "978"
+      - "4995"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632308400"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4130-MAN
       X-Timer:
-      - S1610619828.559353,VS0,VE286
+      - S1632306565.538865,VS0,VE196
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/create/create_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_acl.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=5JukT0tQGanjTr3Wu9ACAO&ServiceVersion=2&name=test_acl_BatchModifyAclEntries_Create
+    body: ServiceID=1NFSgcMirbG1hN2nRK00Gg&ServiceVersion=2&name=test_acl_BatchModifyAclEntries_Create
     form:
       ServiceID:
-      - 5JukT0tQGanjTr3Wu9ACAO
+      - 1NFSgcMirbG1hN2nRK00Gg
       ServiceVersion:
       - "2"
       name:
@@ -14,24 +14,24 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5JukT0tQGanjTr3Wu9ACAO/version/2/acl
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/1NFSgcMirbG1hN2nRK00Gg/version/2/acl
     method: POST
   response:
-    body: '{"service_id":"5JukT0tQGanjTr3Wu9ACAO","version":"2","name":"test_acl_BatchModifyAclEntries_Create","updated_at":"2021-01-14T10:23:39Z","id":"21Jt9DJ4QbAg46MyEUxQXi","deleted_at":null,"created_at":"2021-01-14T10:23:39Z"}'
+    body: '{"service_id":"1NFSgcMirbG1hN2nRK00Gg","version":"2","name":"test_acl_BatchModifyAclEntries_Create","id":"43sh3SIrf0NIyf6jkSNkz6","created_at":"2021-09-22T11:01:29Z","updated_at":"2021-09-22T11:01:29Z","deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:39 GMT
+      - Wed, 22 Sep 2021 11:01:30 GMT
       Fastly-Ratelimit-Remaining:
-      - "997"
+      - "4997"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4137-MAN
       X-Timer:
-      - S1610619819.975620,VS0,VE313
+      - S1632308490.841909,VS0,VE201
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/create/create_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_acl_entries.yaml
@@ -2,8 +2,8 @@
 version: 1
 interactions:
 - request:
-    body: '{"entries":[{"op":"create","ip":"127.0.0.1","subnet":"24","negated":false,"comment":"ACL
-      Entry 1"},{"op":"create","ip":"192.168.0.1","subnet":"24","negated":false,"comment":"ACL
+    body: '{"entries":[{"op":"create","ip":"127.0.0.1","subnet":24,"negated":"0","comment":"ACL
+      Entry 1"},{"op":"create","ip":"192.168.0.1","subnet":24,"negated":"1","comment":"ACL
       Entry 2"}]}'
     form: {}
     headers:
@@ -12,8 +12,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5JukT0tQGanjTr3Wu9ACAO/acl/21Jt9DJ4QbAg46MyEUxQXi/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/1NFSgcMirbG1hN2nRK00Gg/acl/43sh3SIrf0NIyf6jkSNkz6/entries
     method: PATCH
   response:
     body: '{"status":"ok"}'
@@ -21,15 +21,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:39 GMT
+      - Wed, 22 Sep 2021 11:01:30 GMT
       Fastly-Ratelimit-Remaining:
-      - "996"
+      - "4996"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4137-MAN
       X-Timer:
-      - S1610619819.365414,VS0,VE531
+      - S1632308490.069566,VS0,VE384
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/create/create_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_service.yaml
@@ -14,24 +14,24 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/service
     method: POST
   response:
-    body: '{"customer_id":"51MumwLiSJyFTWhtbByYgR","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Create","type":"vcl","publish_key":"","updated_at":"2021-01-14T10:23:38Z","created_at":"2021-01-14T10:23:38Z","deleted_at":null,"versions":[{"staging":false,"locked":false,"active":false,"number":1,"deployed":false,"deleted_at":null,"created_at":"2021-01-14T10:23:38Z","service_id":"5JukT0tQGanjTr3Wu9ACAO","comment":"","testing":false,"updated_at":"2021-01-14T10:23:38Z"}],"id":"5JukT0tQGanjTr3Wu9ACAO","paused":false}'
+    body: '{"customer_id":"51MumwLiSJyFTWhtbByYgR","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Create","type":"vcl","id":"1NFSgcMirbG1hN2nRK00Gg","paused":false,"updated_at":"2021-09-22T11:01:29Z","created_at":"2021-09-22T11:01:29Z","versions":[{"locked":false,"deleted_at":null,"comment":"","number":1,"deployed":false,"created_at":"2021-09-22T11:01:29Z","staging":false,"service_id":"1NFSgcMirbG1hN2nRK00Gg","active":false,"updated_at":"2021-09-22T11:01:29Z","testing":false}],"publish_key":"","deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:38 GMT
+      - Wed, 22 Sep 2021 11:01:29 GMT
       Fastly-Ratelimit-Remaining:
-      - "999"
+      - "4999"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4137-MAN
       X-Timer:
-      - S1610619818.278756,VS0,VE245
+      - S1632308489.883637,VS0,VE401
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/create/create_version.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/create_version.yaml
@@ -2,32 +2,32 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=5JukT0tQGanjTr3Wu9ACAO
+    body: ServiceID=1NFSgcMirbG1hN2nRK00Gg
     form:
       ServiceID:
-      - 5JukT0tQGanjTr3Wu9ACAO
+      - 1NFSgcMirbG1hN2nRK00Gg
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5JukT0tQGanjTr3Wu9ACAO/version
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/1NFSgcMirbG1hN2nRK00Gg/version
     method: POST
   response:
-    body: '{"service_id":"5JukT0tQGanjTr3Wu9ACAO","number":2}'
+    body: '{"service_id":"1NFSgcMirbG1hN2nRK00Gg","number":2}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:38 GMT
+      - Wed, 22 Sep 2021 11:01:29 GMT
       Fastly-Ratelimit-Remaining:
-      - "998"
+      - "4998"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4137-MAN
       X-Timer:
-      - S1610619819.569565,VS0,VE306
+      - S1632308489.309608,VS0,VE506
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/create/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/delete_acl.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5JukT0tQGanjTr3Wu9ACAO/version/2/acl/test_acl_BatchModifyAclEntries_Create
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/1NFSgcMirbG1hN2nRK00Gg/version/2/acl/test_acl_BatchModifyAclEntries_Create
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:40 GMT
+      - Wed, 22 Sep 2021 11:01:31 GMT
       Fastly-Ratelimit-Remaining:
-      - "995"
+      - "4995"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4137-MAN
       X-Timer:
-      - S1610619820.180864,VS0,VE296
+      - S1632308491.906160,VS0,VE224
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/create/delete_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/delete_service.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5JukT0tQGanjTr3Wu9ACAO
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/1NFSgcMirbG1hN2nRK00Gg
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:40 GMT
+      - Wed, 22 Sep 2021 11:01:31 GMT
       Fastly-Ratelimit-Remaining:
-      - "994"
+      - "4994"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4137-MAN
       X-Timer:
-      - S1610619821.522572,VS0,VE220
+      - S1632308491.157720,VS0,VE338
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/create/list_after_create.yaml
+++ b/fastly/fixtures/acl_entries_batch/create/list_after_create.yaml
@@ -6,22 +6,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/5JukT0tQGanjTr3Wu9ACAO/acl/21Jt9DJ4QbAg46MyEUxQXi/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/1NFSgcMirbG1hN2nRK00Gg/acl/43sh3SIrf0NIyf6jkSNkz6/entries
     method: GET
   response:
-    body: '[{"id":"1YXr767DZB9JfTZEkdKOj0","subnet":24,"service_id":"5JukT0tQGanjTr3Wu9ACAO","negated":"0","deleted_at":null,"comment":"ACL
-      Entry 1","acl_id":"21Jt9DJ4QbAg46MyEUxQXi","updated_at":"2021-01-14T10:23:39Z","ip":"127.0.0.1","created_at":"2021-01-14T10:23:39Z"},{"negated":"0","id":"1e1RhpCmntwdD68Is7zsC6","service_id":"5JukT0tQGanjTr3Wu9ACAO","subnet":24,"created_at":"2021-01-14T10:23:39Z","acl_id":"21Jt9DJ4QbAg46MyEUxQXi","deleted_at":null,"comment":"ACL
-      Entry 2","ip":"192.168.0.1","updated_at":"2021-01-14T10:23:39Z"}]'
+    body: '[{"subnet":24,"id":"7MczYgeGt6qZOKi7WjQL9S","created_at":"2021-09-22T11:01:30Z","ip":"127.0.0.1","negated":"0","updated_at":"2021-09-22T11:01:30Z","comment":"ACL
+      Entry 1","acl_id":"43sh3SIrf0NIyf6jkSNkz6","service_id":"1NFSgcMirbG1hN2nRK00Gg"},{"service_id":"1NFSgcMirbG1hN2nRK00Gg","comment":"ACL
+      Entry 2","acl_id":"43sh3SIrf0NIyf6jkSNkz6","ip":"192.168.0.1","negated":"1","updated_at":"2021-09-22T11:01:30Z","created_at":"2021-09-22T11:01:30Z","subnet":24,"id":"0qwhkqXJLaJR3mLT4UoqGw"}]'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:40 GMT
+      - Wed, 22 Sep 2021 11:01:30 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4137-MAN
       X-Timer:
-      - S1610619820.944258,VS0,VE191
+      - S1632308490.480700,VS0,VE400
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/delete/create_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_acl.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=0LwY12HMwvVr5TmfdLhiKB&ServiceVersion=2&name=test_acl_BatchModifyAclEntries_Delete
+    body: ServiceID=3HSOFAYE9MIClrNMnneZ88&ServiceVersion=2&name=test_acl_BatchModifyAclEntries_Delete
     form:
       ServiceID:
-      - 0LwY12HMwvVr5TmfdLhiKB
+      - 3HSOFAYE9MIClrNMnneZ88
       ServiceVersion:
       - "2"
       name:
@@ -14,24 +14,24 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0LwY12HMwvVr5TmfdLhiKB/version/2/acl
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/3HSOFAYE9MIClrNMnneZ88/version/2/acl
     method: POST
   response:
-    body: '{"service_id":"0LwY12HMwvVr5TmfdLhiKB","version":"2","name":"test_acl_BatchModifyAclEntries_Delete","created_at":"2021-01-14T10:23:41Z","id":"4HXRtBKpLbDcsvWAepvIeQ","deleted_at":null,"updated_at":"2021-01-14T10:23:41Z"}'
+    body: '{"service_id":"3HSOFAYE9MIClrNMnneZ88","version":"2","name":"test_acl_BatchModifyAclEntries_Delete","deleted_at":null,"updated_at":"2021-09-22T11:02:47Z","created_at":"2021-09-22T11:02:47Z","id":"2tmd64cHXy8wccFSnB5tP0"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:41 GMT
+      - Wed, 22 Sep 2021 11:02:47 GMT
       Fastly-Ratelimit-Remaining:
-      - "991"
+      - "4991"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4139-MAN
       X-Timer:
-      - S1610619821.454438,VS0,VE277
+      - S1632308567.811725,VS0,VE436
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/delete/create_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_acl_entries.yaml
@@ -2,8 +2,8 @@
 version: 1
 interactions:
 - request:
-    body: '{"entries":[{"op":"create","ip":"127.0.0.1","subnet":"24","negated":false,"comment":"ACL
-      Entry 1"},{"op":"create","ip":"192.168.0.1","subnet":"24","negated":false,"comment":"ACL
+    body: '{"entries":[{"op":"create","ip":"127.0.0.1","subnet":24,"negated":"0","comment":"ACL
+      Entry 1"},{"op":"create","ip":"192.168.0.1","subnet":24,"negated":"1","comment":"ACL
       Entry 2"}]}'
     form: {}
     headers:
@@ -12,8 +12,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0LwY12HMwvVr5TmfdLhiKB/acl/4HXRtBKpLbDcsvWAepvIeQ/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/3HSOFAYE9MIClrNMnneZ88/acl/2tmd64cHXy8wccFSnB5tP0/entries
     method: PATCH
   response:
     body: '{"status":"ok"}'
@@ -21,15 +21,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:42 GMT
+      - Wed, 22 Sep 2021 11:02:47 GMT
       Fastly-Ratelimit-Remaining:
-      - "990"
+      - "4990"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4139-MAN
       X-Timer:
-      - S1610619822.774808,VS0,VE235
+      - S1632308567.279852,VS0,VE232
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/delete/create_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_service.yaml
@@ -14,24 +14,24 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/service
     method: POST
   response:
-    body: '{"customer_id":"51MumwLiSJyFTWhtbByYgR","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Delete","type":"vcl","versions":[{"deployed":false,"locked":false,"created_at":"2021-01-14T10:23:40Z","number":1,"deleted_at":null,"comment":"","staging":false,"service_id":"0LwY12HMwvVr5TmfdLhiKB","updated_at":"2021-01-14T10:23:40Z","active":false,"testing":false}],"updated_at":"2021-01-14T10:23:40Z","paused":false,"id":"0LwY12HMwvVr5TmfdLhiKB","publish_key":"","deleted_at":null,"created_at":"2021-01-14T10:23:40Z"}'
+    body: '{"customer_id":"51MumwLiSJyFTWhtbByYgR","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Delete","type":"vcl","publish_key":"","paused":false,"updated_at":"2021-09-22T11:02:46Z","versions":[{"deleted_at":null,"testing":false,"active":false,"number":1,"created_at":"2021-09-22T11:02:46Z","locked":false,"staging":false,"deployed":false,"comment":"","service_id":"3HSOFAYE9MIClrNMnneZ88","updated_at":"2021-09-22T11:02:46Z"}],"id":"3HSOFAYE9MIClrNMnneZ88","deleted_at":null,"created_at":"2021-09-22T11:02:46Z"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:41 GMT
+      - Wed, 22 Sep 2021 11:02:46 GMT
       Fastly-Ratelimit-Remaining:
-      - "993"
+      - "4993"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4139-MAN
       X-Timer:
-      - S1610619821.815226,VS0,VE222
+      - S1632308566.864602,VS0,VE433
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/delete/create_version.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/create_version.yaml
@@ -2,32 +2,32 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=0LwY12HMwvVr5TmfdLhiKB
+    body: ServiceID=3HSOFAYE9MIClrNMnneZ88
     form:
       ServiceID:
-      - 0LwY12HMwvVr5TmfdLhiKB
+      - 3HSOFAYE9MIClrNMnneZ88
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0LwY12HMwvVr5TmfdLhiKB/version
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/3HSOFAYE9MIClrNMnneZ88/version
     method: POST
   response:
-    body: '{"service_id":"0LwY12HMwvVr5TmfdLhiKB","number":2}'
+    body: '{"service_id":"3HSOFAYE9MIClrNMnneZ88","number":2}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:41 GMT
+      - Wed, 22 Sep 2021 11:02:46 GMT
       Fastly-Ratelimit-Remaining:
-      - "992"
+      - "4992"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4139-MAN
       X-Timer:
-      - S1610619821.125397,VS0,VE273
+      - S1632308566.327747,VS0,VE452
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/delete/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/delete_acl.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0LwY12HMwvVr5TmfdLhiKB/version/2/acl/test_acl_BatchModifyAclEntries_Delete
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/3HSOFAYE9MIClrNMnneZ88/version/2/acl/test_acl_BatchModifyAclEntries_Delete
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:43 GMT
+      - Wed, 22 Sep 2021 11:02:48 GMT
       Fastly-Ratelimit-Remaining:
-      - "988"
+      - "4988"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4139-MAN
       X-Timer:
-      - S1610619823.290756,VS0,VE287
+      - S1632308568.318513,VS0,VE190
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/delete/delete_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/delete_acl_entries.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"entries":[{"op":"delete","id":"62E4eZ3hGflhAoiBGOMEos"}]}'
+    body: '{"entries":[{"op":"delete","id":"5Fd2BgJh5t1KWMCCQh9bgq"}]}'
     form: {}
     headers:
       Accept:
@@ -10,8 +10,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0LwY12HMwvVr5TmfdLhiKB/acl/4HXRtBKpLbDcsvWAepvIeQ/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/3HSOFAYE9MIClrNMnneZ88/acl/2tmd64cHXy8wccFSnB5tP0/entries
     method: PATCH
   response:
     body: '{"status":"ok"}'
@@ -19,15 +19,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:42 GMT
+      - Wed, 22 Sep 2021 11:02:48 GMT
       Fastly-Ratelimit-Remaining:
-      - "989"
+      - "4989"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4139-MAN
       X-Timer:
-      - S1610619823.662541,VS0,VE261
+      - S1632308568.883749,VS0,VE234
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/delete/delete_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/delete_service.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0LwY12HMwvVr5TmfdLhiKB
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/3HSOFAYE9MIClrNMnneZ88
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:43 GMT
+      - Wed, 22 Sep 2021 11:02:48 GMT
       Fastly-Ratelimit-Remaining:
-      - "987"
+      - "4987"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4139-MAN
       X-Timer:
-      - S1610619824.623615,VS0,VE259
+      - S1632308569.531540,VS0,VE345
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/delete/list_after_delete.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/list_after_delete.yaml
@@ -6,21 +6,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0LwY12HMwvVr5TmfdLhiKB/acl/4HXRtBKpLbDcsvWAepvIeQ/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/3HSOFAYE9MIClrNMnneZ88/acl/2tmd64cHXy8wccFSnB5tP0/entries
     method: GET
   response:
-    body: '[{"updated_at":"2021-01-14T10:23:41Z","ip":"192.168.0.1","comment":"ACL
-      Entry 2","subnet":24,"service_id":"0LwY12HMwvVr5TmfdLhiKB","id":"3zM1cN7ritzGZ9wi97xN1P","created_at":"2021-01-14T10:23:41Z","negated":"0","acl_id":"4HXRtBKpLbDcsvWAepvIeQ","deleted_at":null}]'
+    body: '[{"negated":"1","ip":"192.168.0.1","id":"79oTJwlhREppUI6BahCekM","updated_at":"2021-09-22T11:02:47Z","subnet":24,"created_at":"2021-09-22T11:02:47Z","service_id":"3HSOFAYE9MIClrNMnneZ88","comment":"ACL
+      Entry 2","acl_id":"2tmd64cHXy8wccFSnB5tP0"}]'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:43 GMT
+      - Wed, 22 Sep 2021 11:02:48 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -34,9 +34,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4139-MAN
       X-Timer:
-      - S1610619823.070525,VS0,VE176
+      - S1632308568.146840,VS0,VE144
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/delete/list_before_delete.yaml
+++ b/fastly/fixtures/acl_entries_batch/delete/list_before_delete.yaml
@@ -6,22 +6,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0LwY12HMwvVr5TmfdLhiKB/acl/4HXRtBKpLbDcsvWAepvIeQ/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/3HSOFAYE9MIClrNMnneZ88/acl/2tmd64cHXy8wccFSnB5tP0/entries
     method: GET
   response:
-    body: '[{"created_at":"2021-01-14T10:23:41Z","updated_at":"2021-01-14T10:23:41Z","ip":"127.0.0.1","deleted_at":null,"comment":"ACL
-      Entry 1","acl_id":"4HXRtBKpLbDcsvWAepvIeQ","negated":"0","subnet":24,"service_id":"0LwY12HMwvVr5TmfdLhiKB","id":"62E4eZ3hGflhAoiBGOMEos"},{"service_id":"0LwY12HMwvVr5TmfdLhiKB","subnet":24,"id":"3zM1cN7ritzGZ9wi97xN1P","negated":"0","ip":"192.168.0.1","updated_at":"2021-01-14T10:23:41Z","acl_id":"4HXRtBKpLbDcsvWAepvIeQ","comment":"ACL
-      Entry 2","deleted_at":null,"created_at":"2021-01-14T10:23:41Z"}]'
+    body: '[{"subnet":24,"comment":"ACL Entry 1","created_at":"2021-09-22T11:02:47Z","ip":"127.0.0.1","id":"5Fd2BgJh5t1KWMCCQh9bgq","negated":"0","service_id":"3HSOFAYE9MIClrNMnneZ88","updated_at":"2021-09-22T11:02:47Z","acl_id":"2tmd64cHXy8wccFSnB5tP0"},{"acl_id":"2tmd64cHXy8wccFSnB5tP0","updated_at":"2021-09-22T11:02:47Z","service_id":"3HSOFAYE9MIClrNMnneZ88","ip":"192.168.0.1","negated":"1","id":"79oTJwlhREppUI6BahCekM","created_at":"2021-09-22T11:02:47Z","comment":"ACL
+      Entry 2","subnet":24}]'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:42 GMT
+      - Wed, 22 Sep 2021 11:02:47 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,9 +34,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4139-MAN
       X-Timer:
-      - S1610619822.054831,VS0,VE471
+      - S1632308568.543070,VS0,VE312
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/update/create_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_acl.yaml
@@ -2,10 +2,10 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=0Akek5AFpJCUDYry2Hkju2&ServiceVersion=2&name=test_acl_BatchModifyAclEntries_Update
+    body: ServiceID=5eExXVGVxVxKhaiNduThkR&ServiceVersion=2&name=test_acl_BatchModifyAclEntries_Update
     form:
       ServiceID:
-      - 0Akek5AFpJCUDYry2Hkju2
+      - 5eExXVGVxVxKhaiNduThkR
       ServiceVersion:
       - "2"
       name:
@@ -14,24 +14,24 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0Akek5AFpJCUDYry2Hkju2/version/2/acl
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/5eExXVGVxVxKhaiNduThkR/version/2/acl
     method: POST
   response:
-    body: '{"service_id":"0Akek5AFpJCUDYry2Hkju2","version":"2","name":"test_acl_BatchModifyAclEntries_Update","id":"5LpMLuDvLHtcpJ8hzbX0VG","deleted_at":null,"created_at":"2021-01-14T10:23:44Z","updated_at":"2021-01-14T10:23:44Z"}'
+    body: '{"service_id":"5eExXVGVxVxKhaiNduThkR","version":"2","name":"test_acl_BatchModifyAclEntries_Update","deleted_at":null,"updated_at":"2021-09-22T11:02:59Z","created_at":"2021-09-22T11:02:59Z","id":"17nbIIGX2ZTN8sfLyLtwgR"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:44 GMT
+      - Wed, 22 Sep 2021 11:02:59 GMT
       Fastly-Ratelimit-Remaining:
-      - "984"
+      - "4984"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4133-MAN
       X-Timer:
-      - S1610619825.715529,VS0,VE275
+      - S1632308579.224905,VS0,VE201
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/update/create_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_acl_entries.yaml
@@ -2,8 +2,8 @@
 version: 1
 interactions:
 - request:
-    body: '{"entries":[{"op":"create","ip":"127.0.0.1","subnet":"24","negated":false,"comment":"ACL
-      Entry 1"},{"op":"create","ip":"192.168.0.1","subnet":"24","negated":false,"comment":"ACL
+    body: '{"entries":[{"op":"create","ip":"127.0.0.1","subnet":24,"negated":"0","comment":"ACL
+      Entry 1"},{"op":"create","ip":"192.168.0.1","subnet":24,"negated":"1","comment":"ACL
       Entry 2"}]}'
     form: {}
     headers:
@@ -12,8 +12,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0Akek5AFpJCUDYry2Hkju2/acl/5LpMLuDvLHtcpJ8hzbX0VG/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/5eExXVGVxVxKhaiNduThkR/acl/17nbIIGX2ZTN8sfLyLtwgR/entries
     method: PATCH
   response:
     body: '{"status":"ok"}'
@@ -21,15 +21,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:45 GMT
+      - Wed, 22 Sep 2021 11:02:59 GMT
       Fastly-Ratelimit-Remaining:
-      - "983"
+      - "4983"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4133-MAN
       X-Timer:
-      - S1610619825.034235,VS0,VE248
+      - S1632308579.453642,VS0,VE342
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/update/create_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_service.yaml
@@ -14,24 +14,24 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
     url: https://api.fastly.com/service
     method: POST
   response:
-    body: '{"customer_id":"51MumwLiSJyFTWhtbByYgR","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Update","type":"vcl","publish_key":"","updated_at":"2021-01-14T10:23:44Z","id":"0Akek5AFpJCUDYry2Hkju2","versions":[{"updated_at":"2021-01-14T10:23:44Z","number":1,"locked":false,"service_id":"0Akek5AFpJCUDYry2Hkju2","created_at":"2021-01-14T10:23:44Z","testing":false,"deployed":false,"staging":false,"deleted_at":null,"comment":"","active":false}],"created_at":"2021-01-14T10:23:44Z","deleted_at":null,"paused":false}'
+    body: '{"customer_id":"51MumwLiSJyFTWhtbByYgR","comment":"go-fastly client test","name":"test_service_BatchModifyAclEntries_Update","type":"vcl","created_at":"2021-09-22T11:02:58Z","versions":[{"service_id":"5eExXVGVxVxKhaiNduThkR","deployed":false,"staging":false,"active":false,"deleted_at":null,"locked":false,"comment":"","created_at":"2021-09-22T11:02:58Z","updated_at":"2021-09-22T11:02:58Z","testing":false,"number":1}],"deleted_at":null,"paused":false,"publish_key":"","id":"5eExXVGVxVxKhaiNduThkR","updated_at":"2021-09-22T11:02:58Z"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:44 GMT
+      - Wed, 22 Sep 2021 11:02:58 GMT
       Fastly-Ratelimit-Remaining:
-      - "986"
+      - "4986"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4133-MAN
       X-Timer:
-      - S1610619824.993680,VS0,VE288
+      - S1632308578.139944,VS0,VE661
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/update/create_version.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/create_version.yaml
@@ -2,32 +2,32 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=0Akek5AFpJCUDYry2Hkju2
+    body: ServiceID=5eExXVGVxVxKhaiNduThkR
     form:
       ServiceID:
-      - 0Akek5AFpJCUDYry2Hkju2
+      - 5eExXVGVxVxKhaiNduThkR
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0Akek5AFpJCUDYry2Hkju2/version
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/5eExXVGVxVxKhaiNduThkR/version
     method: POST
   response:
-    body: '{"service_id":"0Akek5AFpJCUDYry2Hkju2","number":2}'
+    body: '{"service_id":"5eExXVGVxVxKhaiNduThkR","number":2}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:44 GMT
+      - Wed, 22 Sep 2021 11:02:59 GMT
       Fastly-Ratelimit-Remaining:
-      - "985"
+      - "4985"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4133-MAN
       X-Timer:
-      - S1610619824.353921,VS0,VE295
+      - S1632308579.827540,VS0,VE374
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/update/delete_acl.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/delete_acl.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0Akek5AFpJCUDYry2Hkju2/version/2/acl/test_acl_BatchModifyAclEntries_Update
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/5eExXVGVxVxKhaiNduThkR/version/2/acl/test_acl_BatchModifyAclEntries_Update
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:46 GMT
+      - Wed, 22 Sep 2021 11:03:00 GMT
       Fastly-Ratelimit-Remaining:
-      - "981"
+      - "4981"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4133-MAN
       X-Timer:
-      - S1610619827.544100,VS0,VE297
+      - S1632308580.428511,VS0,VE240
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/update/delete_service.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/delete_service.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0Akek5AFpJCUDYry2Hkju2
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/5eExXVGVxVxKhaiNduThkR
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:47 GMT
+      - Wed, 22 Sep 2021 11:03:00 GMT
       Fastly-Ratelimit-Remaining:
-      - "980"
+      - "4980"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4133-MAN
       X-Timer:
-      - S1610619827.884990,VS0,VE279
+      - S1632308581.748301,VS0,VE187
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/update/list_after_update.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/list_after_update.yaml
@@ -6,22 +6,22 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0Akek5AFpJCUDYry2Hkju2/acl/5LpMLuDvLHtcpJ8hzbX0VG/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/5eExXVGVxVxKhaiNduThkR/acl/17nbIIGX2ZTN8sfLyLtwgR/entries
     method: GET
   response:
-    body: '[{"acl_id":"5LpMLuDvLHtcpJ8hzbX0VG","deleted_at":null,"service_id":"0Akek5AFpJCUDYry2Hkju2","comment":"Updated
-      ACL Entry 1","created_at":"2021-01-14T10:23:45Z","negated":"1","subnet":16,"ip":"127.0.0.2","updated_at":"2021-01-14T10:23:46Z","id":"61QD49PqouKtm7DBKI4PCo"},{"ip":"192.168.0.1","updated_at":"2021-01-14T10:23:45Z","id":"5GuOrZyuqqeYps785EQyIu","acl_id":"5LpMLuDvLHtcpJ8hzbX0VG","deleted_at":null,"service_id":"0Akek5AFpJCUDYry2Hkju2","comment":"ACL
-      Entry 2","subnet":24,"created_at":"2021-01-14T10:23:45Z","negated":"0"}]'
+    body: '[{"subnet":16,"updated_at":"2021-09-22T11:03:00Z","created_at":"2021-09-22T11:02:59Z","negated":"1","comment":"Updated
+      ACL Entry 1","ip":"127.0.0.2","id":"6gcf6qN6a90w5WISByUzqp","service_id":"5eExXVGVxVxKhaiNduThkR","acl_id":"17nbIIGX2ZTN8sfLyLtwgR"},{"updated_at":"2021-09-22T11:02:59Z","subnet":24,"created_at":"2021-09-22T11:02:59Z","negated":"1","comment":"ACL
+      Entry 2","id":"68oskig9jsgpobiSaBYmv0","ip":"192.168.0.1","service_id":"5eExXVGVxVxKhaiNduThkR","acl_id":"17nbIIGX2ZTN8sfLyLtwgR"}]'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:46 GMT
+      - Wed, 22 Sep 2021 11:03:00 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4133-MAN
       X-Timer:
-      - S1610619826.330588,VS0,VE170
+      - S1632308580.215608,VS0,VE179
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/update/list_before_update.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/list_before_update.yaml
@@ -6,22 +6,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0Akek5AFpJCUDYry2Hkju2/acl/5LpMLuDvLHtcpJ8hzbX0VG/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/5eExXVGVxVxKhaiNduThkR/acl/17nbIIGX2ZTN8sfLyLtwgR/entries
     method: GET
   response:
-    body: '[{"updated_at":"2021-01-14T10:23:45Z","subnet":24,"comment":"ACL Entry
-      1","service_id":"0Akek5AFpJCUDYry2Hkju2","ip":"127.0.0.1","acl_id":"5LpMLuDvLHtcpJ8hzbX0VG","id":"61QD49PqouKtm7DBKI4PCo","created_at":"2021-01-14T10:23:45Z","negated":"0","deleted_at":null},{"deleted_at":null,"acl_id":"5LpMLuDvLHtcpJ8hzbX0VG","negated":"0","created_at":"2021-01-14T10:23:45Z","id":"5GuOrZyuqqeYps785EQyIu","service_id":"0Akek5AFpJCUDYry2Hkju2","comment":"ACL
-      Entry 2","subnet":24,"ip":"192.168.0.1","updated_at":"2021-01-14T10:23:45Z"}]'
+    body: '[{"comment":"ACL Entry 1","ip":"127.0.0.1","negated":"0","service_id":"5eExXVGVxVxKhaiNduThkR","updated_at":"2021-09-22T11:02:59Z","id":"6gcf6qN6a90w5WISByUzqp","subnet":24,"acl_id":"17nbIIGX2ZTN8sfLyLtwgR","created_at":"2021-09-22T11:02:59Z"},{"negated":"1","ip":"192.168.0.1","service_id":"5eExXVGVxVxKhaiNduThkR","subnet":24,"acl_id":"17nbIIGX2ZTN8sfLyLtwgR","updated_at":"2021-09-22T11:02:59Z","id":"68oskig9jsgpobiSaBYmv0","created_at":"2021-09-22T11:02:59Z","comment":"ACL
+      Entry 2"}]'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:45 GMT
+      - Wed, 22 Sep 2021 11:03:00 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,9 +34,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4133-MAN
       X-Timer:
-      - S1610619825.426292,VS0,VE465
+      - S1632308580.854118,VS0,VE155
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/acl_entries_batch/update/update_acl_entries.yaml
+++ b/fastly/fixtures/acl_entries_batch/update/update_acl_entries.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"entries":[{"op":"update","id":"61QD49PqouKtm7DBKI4PCo","ip":"127.0.0.2","subnet":"16","negated":true,"comment":"Updated
+    body: '{"entries":[{"op":"update","id":"6gcf6qN6a90w5WISByUzqp","ip":"127.0.0.2","subnet":16,"negated":"1","comment":"Updated
       ACL Entry 1"}]}'
     form: {}
     headers:
@@ -11,8 +11,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/0Akek5AFpJCUDYry2Hkju2/acl/5LpMLuDvLHtcpJ8hzbX0VG/entries
+      - FastlyGo/4.0.0 (+github.com/fastly/go-fastly; go1.17)
+    url: https://api.fastly.com/service/5eExXVGVxVxKhaiNduThkR/acl/17nbIIGX2ZTN8sfLyLtwgR/entries
     method: PATCH
   response:
     body: '{"status":"ok"}'
@@ -20,15 +20,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:23:46 GMT
+      - Wed, 22 Sep 2021 11:03:00 GMT
       Fastly-Ratelimit-Remaining:
-      - "982"
+      - "4982"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1632312000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -42,9 +42,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4136-MAN
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4133-MAN
       X-Timer:
-      - S1610619826.035265,VS0,VE271
+      - S1632308580.033600,VS0,VE154
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
This PR introduces a breaking change, which is necessary because currently the logic is broken (e.g. passing a bool type to the API doesn't work).

**NOTE**: We switch the input struct types from `bool` to `Compatibool` which is a custom type with a custom implementation of `encoding.TextMarshaler` and `encoding.TextUnmarshaler`. When coercing data back and force, the `Compatibool` type, results in a boolean being changed from `false` to `0`, and `true` to `1`. This means the request will work with our API endpoint as it expects (and returns) an integer.