### PR TITLE
Add support for `modsec_rule_id` filter parameter

### DIFF
--- a/fastly/fixtures/waf_rules/list_all_fastly_filter_by_rule_ids.yaml
+++ b/fastly/fixtures/waf_rules/list_all_fastly_filter_by_rule_ids.yaml
@@ -1,0 +1,39 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
+    url: https://api.fastly.com/waf/rules?filter%5Bmodsec_rule_id%5D%5Bin%5D=1010060%2C1010070&page%5Bnumber%5D=1&page%5Bsize%5D=100
+    method: GET
+  response:
+    body: '{"data":[{"id":"62NGF4KWy1v17yyV1vmPdb","type":"waf_rule","attributes":{"modsec_rule_id":1010070,"publisher":"owasp","type":"threshold"}},{"id":"5o7EaPCRlKoEPZB7ziSXYV","type":"waf_rule","attributes":{"modsec_rule_id":1010060,"publisher":"owasp","type":"threshold"}}],"links":{"last":"https://api.fastly.com/waf/rules?filter[modsec_rule_id][in]=1010060,1010070\u0026page[number]=1\u0026page[size]=100","first":"https://api.fastly.com/waf/rules?filter[modsec_rule_id][in]=1010060,1010070\u0026page[number]=1\u0026page[size]=100"},"meta":{"current_page":1,"per_page":100,"record_count":2,"total_pages":1}}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - "603"
+      Content-Type:
+      - application/vnd.api+json
+      Date:
+      - Wed, 05 Jan 2022 11:16:49 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Content-Type-Options:
+      - nosniff
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11953-TYO
+      X-Timer:
+      - S1641381410.693492,VS0,VE246
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/waf_rules.go
+++ b/fastly/waf_rules.go
@@ -49,6 +49,8 @@ type ListWAFRulesInput struct {
 	FilterTagNames []string
 	// Limit the returned rules to a set by publishers.
 	FilterPublishers []string
+	// Limit the returned rules to a set by modsecurity rule IDs.
+	FilterModSecIDs []int
 	// Excludes individual rules by modsecurity rule IDs.
 	ExcludeMocSecIDs []int
 	// Limit the number of returned rules.
@@ -65,6 +67,7 @@ func (i *ListWAFRulesInput) formatFilters() map[string]string {
 	pairings := map[string]interface{}{
 		"filter[waf_tags][name][in]":  i.FilterTagNames,
 		"filter[publisher][in]":       i.FilterPublishers,
+		"filter[modsec_rule_id][in]":  i.FilterModSecIDs,
 		"filter[modsec_rule_id][not]": i.ExcludeMocSecIDs,
 		"page[size]":                  i.PageSize,
 		"page[number]":                i.PageNumber,
@@ -142,6 +145,8 @@ type ListAllWAFRulesInput struct {
 	FilterTagNames []string
 	// Limit the returned rules to a set by publishers.
 	FilterPublishers []string
+	// Limit the returned rules to a set by modsecurity rule IDs.
+	FilterModSecIDs []int
 	// Excludes individual rules by modsecurity rule IDs.
 	ExcludeMocSecIDs []int
 	// Include relationships. Optional, comma-separated values. Permitted values: waf_tags and waf_rule_revisions.
@@ -158,6 +163,7 @@ func (c *Client) ListAllWAFRules(i *ListAllWAFRulesInput) (*WAFRuleResponse, err
 		r, err := c.ListWAFRules(&ListWAFRulesInput{
 			FilterTagNames:   i.FilterTagNames,
 			FilterPublishers: i.FilterPublishers,
+			FilterModSecIDs:  i.FilterModSecIDs,
 			ExcludeMocSecIDs: i.ExcludeMocSecIDs,
 			Include:          i.Include,
 			PageNumber:       currentPage,

--- a/fastly/waf_rules.go
+++ b/fastly/waf_rules.go
@@ -52,6 +52,7 @@ type ListWAFRulesInput struct {
 	// Limit the returned rules to a set by modsecurity rule IDs.
 	FilterModSecIDs []int
 	// Excludes individual rules by modsecurity rule IDs.
+	// TODO: fix typo ExcludeMocSecIDs -> ExcludeModSecIDs
 	ExcludeMocSecIDs []int
 	// Limit the number of returned rules.
 	PageSize int

--- a/fastly/waf_rules_test.go
+++ b/fastly/waf_rules_test.go
@@ -74,6 +74,18 @@ func TestClient_WAF_Rules(t *testing.T) {
 	if fastlyRulesNumber-1 != len(rulesResp.Items) {
 		t.Errorf("expected %d rules: got %d", fastlyRulesNumber-1, len(rulesResp.Items))
 	}
+
+	record(t, fixtureBase+"/list_all_fastly_filter_by_rule_ids", func(c *Client) {
+		rulesResp, err = c.ListAllWAFRules(&ListAllWAFRulesInput{
+			FilterModSecIDs: []int{1010060, 1010070},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rulesResp.Items) != 2 {
+		t.Errorf("expected 2 rules: got %d", len(rulesResp.Items))
+	}
 }
 
 func TestClient_listWAFRules_formatFilters(t *testing.T) {
@@ -85,6 +97,7 @@ func TestClient_listWAFRules_formatFilters(t *testing.T) {
 			remote: &ListWAFRulesInput{
 				FilterTagNames:   []string{"tag1", "tag2"},
 				FilterPublishers: []string{"owasp", "trustwave"},
+				FilterModSecIDs:  []int{1010060, 1010070},
 				ExcludeMocSecIDs: []int{123456, 1234567},
 				PageSize:         2,
 				PageNumber:       2,
@@ -93,6 +106,7 @@ func TestClient_listWAFRules_formatFilters(t *testing.T) {
 			local: map[string]string{
 				"filter[waf_tags][name][in]":  "tag1,tag2",
 				"filter[publisher][in]":       "owasp,trustwave",
+				"filter[modsec_rule_id][in]":  "1010060,1010070",
 				"filter[modsec_rule_id][not]": "123456,1234567",
 				"page[size]":                  "2",
 				"page[number]":                "2",


### PR DESCRIPTION
https://developer.fastly.com/reference/api/waf/rules/#list-waf-rules

This is to support https://github.com/fastly/terraform-provider-fastly/issues/520