### PR TITLE
Add pagination support for GET `/service` endpoint

### DIFF
--- a/fastly/example_service_test.go
+++ b/fastly/example_service_test.go
@@ -1,0 +1,32 @@
+package fastly_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/fastly/go-fastly/v5/fastly"
+)
+
+func ExampleClient_NewListServicesPaginator() {
+	client, err := fastly.NewClient("your_api_token")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	paginator := client.NewListServicesPaginator(
+		&fastly.ListServicesInput{
+			PerPage: 50,
+		},
+	)
+
+	var ss []*fastly.Service
+	for paginator.HasNext() {
+		data, err := paginator.GetNext()
+		if err != nil {
+			break
+		}
+		ss = append(ss, data...)
+	}
+
+	fmt.Printf("retrieved %d services\n", len(ss))
+}

--- a/fastly/fixtures/services/list_paginator.yaml
+++ b/fastly/fixtures/services/list_paginator.yaml
@@ -1,0 +1,47 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/5.2.0 (+github.com/fastly/go-fastly; go1.17.3)
+    url: https://api.fastly.com/service?direction=descend&page=1&per_page=1&sort=created
+    method: GET
+  response:
+    body: '[{"version":1,"id":"7i6HN3TK9wS159v2gPAZ8A","versions":[{"updated_at":"2022-01-10T10:22:27Z","number":1,"created_at":"2022-01-10T10:21:11Z","comment":"","testing":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","locked":true,"deployed":false,"active":true,"deleted_at":null,"staging":false}],"paused":false,"deleted_at":null,"created_at":"2022-01-10T10:21:11Z","type":"vcl","updated_at":"2022-01-10T10:21:28Z","name":"tf-test","comment":"","customer_id":"2mEgzQsbxIHPAkmXcKCBG5"}]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Age:
+      - "0"
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 10 Jan 2022 10:23:55 GMT
+      Link:
+      - <https://api.fastly.com/service?direction=descend&page=51&per_page=1&sort=created>;
+        rel="last", <https://api.fastly.com/service?direction=descend&page=2&per_page=1&sort=created>;
+        rel="next"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-tyo11969-TYO
+      X-Timer:
+      - S1641810235.164889,VS0,VE268
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/service_test.go
+++ b/fastly/service_test.go
@@ -53,6 +53,26 @@ func TestClient_Services(t *testing.T) {
 		t.Errorf("bad services: %v", ss)
 	}
 
+	// List with paginator
+	var ss2 []*Service
+	var paginator *ListServicesPaginator
+	record(t, "services/list_paginator", func(c *Client) {
+		paginator = c.NewListServicesPaginator(
+			&ListServicesInput{
+				Direction: "descend",
+				Sort:      "created",
+				PerPage:   1,
+			},
+		)
+		ss2, err = paginator.GetNext()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss2) != 1 {
+		t.Errorf("expected 1 service but got: %d", len(ss2))
+	}
+
 	// Get
 	var ns *Service
 	record(t, "services/get", func(c *Client) {


### PR DESCRIPTION
continuing https://github.com/fastly/go-fastly/pull/321 but this time for [GET /service](https://developer.fastly.com/reference/api/services/service/#list-services) endpoint.