### PR TITLE
Pagination to return interface not concrete type

### DIFF
--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -98,8 +98,8 @@ func (p *ListAclEntriesPaginator) GetNext() ([]*ACLEntry, error) {
 	return p.client.listACLEntriesWithPage(p.options, p)
 }
 
-// NewListACLEntriesPaginator returns a new ListAclEntriesPaginator
-func (c *Client) NewListACLEntriesPaginator(i *ListACLEntriesInput) *ListAclEntriesPaginator {
+// NewListACLEntriesPaginator returns a new paginator
+func (c *Client) NewListACLEntriesPaginator(i *ListACLEntriesInput) PaginatorACLEntries {
 	return &ListAclEntriesPaginator{
 		client:  c,
 		options: i,

--- a/fastly/acl_entry_test.go
+++ b/fastly/acl_entry_test.go
@@ -68,7 +68,7 @@ func TestClient_ACLEntries(t *testing.T) {
 
 	// List with paginator
 	var es2 []*ACLEntry
-	var paginator *ListAclEntriesPaginator
+	var paginator PaginatorACLEntries
 	record(t, fixtureBase+"list2", func(c *Client) {
 		paginator = c.NewListACLEntriesPaginator(&ListACLEntriesInput{
 			ServiceID: testService.ID,

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -97,7 +97,7 @@ func (p *ListDictionaryItemsPaginator) GetNext() ([]*DictionaryItem, error) {
 }
 
 // NewListDictionaryItemsPaginator returns a new paginator
-func (c *Client) NewListDictionaryItemsPaginator(i *ListDictionaryItemsInput) PaginatorDictItems {
+func (c *Client) NewListDictionaryItemsPaginator(i *ListDictionaryItemsInput) PaginatorDictionaryItems {
 	return &ListDictionaryItemsPaginator{
 		client:  c,
 		options: i,

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -96,8 +96,8 @@ func (p *ListDictionaryItemsPaginator) GetNext() ([]*DictionaryItem, error) {
 	return p.client.listDictionaryItemsWithPage(p.options, p)
 }
 
-// NewListDictionaryItemsPaginator returns a new ListDictionaryItemsPaginator
-func (c *Client) NewListDictionaryItemsPaginator(i *ListDictionaryItemsInput) *ListDictionaryItemsPaginator {
+// NewListDictionaryItemsPaginator returns a new paginator
+func (c *Client) NewListDictionaryItemsPaginator(i *ListDictionaryItemsInput) PaginatorDictItems {
 	return &ListDictionaryItemsPaginator{
 		client:  c,
 		options: i,

--- a/fastly/dictionary_item_test.go
+++ b/fastly/dictionary_item_test.go
@@ -67,7 +67,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 
 	// List with paginator
 	var dictionaryItems2 []*DictionaryItem
-	var paginator *ListDictionaryItemsPaginator
+	var paginator PaginatorDictItems
 	record(t, fixtureBase+"list2", func(c *Client) {
 		paginator = c.NewListDictionaryItemsPaginator(&ListDictionaryItemsInput{
 			ServiceID:    testService.ID,

--- a/fastly/dictionary_item_test.go
+++ b/fastly/dictionary_item_test.go
@@ -67,7 +67,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 
 	// List with paginator
 	var dictionaryItems2 []*DictionaryItem
-	var paginator PaginatorDictItems
+	var paginator PaginatorDictionaryItems
 	record(t, fixtureBase+"list2", func(c *Client) {
 		paginator = c.NewListDictionaryItemsPaginator(&ListDictionaryItemsInput{
 			ServiceID:    testService.ID,

--- a/fastly/paginator.go
+++ b/fastly/paginator.go
@@ -9,8 +9,8 @@ type PaginatorACLEntries interface {
 	GetNext() ([]*ACLEntry, error)
 }
 
-// PaginatorDictItems represents a paginator.
-type PaginatorDictItems interface {
+// PaginatorDictionaryItems represents a paginator.
+type PaginatorDictionaryItems interface {
 	HasNext() bool
 	Remaining() int
 	GetNext() ([]*DictionaryItem, error)

--- a/fastly/paginator.go
+++ b/fastly/paginator.go
@@ -1,0 +1,24 @@
+package fastly
+
+// TODO: In go 1.18 (Feb 2022) use generics to reduce the duplicated code.
+
+// PaginatorACLEntries represents a paginator.
+type PaginatorACLEntries interface {
+	HasNext() bool
+	Remaining() int
+	GetNext() ([]*ACLEntry, error)
+}
+
+// PaginatorDictItems represents a paginator.
+type PaginatorDictItems interface {
+	HasNext() bool
+	Remaining() int
+	GetNext() ([]*DictionaryItem, error)
+}
+
+// PaginatorServices represents a paginator.
+type PaginatorServices interface {
+	HasNext() bool
+	Remaining() int
+	GetNext() ([]*Service, error)
+}

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -110,8 +110,8 @@ func (p *ListServicesPaginator) GetNext() ([]*Service, error) {
 	return p.client.listServicesWithPage(p.options, p)
 }
 
-// NewListServicesPaginator returns a new ListServicesPaginator
-func (c *Client) NewListServicesPaginator(i *ListServicesInput) *ListServicesPaginator {
+// NewListServicesPaginator returns a new paginator
+func (c *Client) NewListServicesPaginator(i *ListServicesInput) PaginatorServices {
 	return &ListServicesPaginator{
 		client:  c,
 		options: i,

--- a/fastly/service_test.go
+++ b/fastly/service_test.go
@@ -55,7 +55,7 @@ func TestClient_Services(t *testing.T) {
 
 	// List with paginator
 	var ss2 []*Service
-	var paginator *ListServicesPaginator
+	var paginator PaginatorServices
 	record(t, "services/list_paginator", func(c *Client) {
 		paginator = c.NewListServicesPaginator(
 			&ListServicesInput{


### PR DESCRIPTION
The recent pagination implementations were designed to return concrete types, which include methods attached to the returned type that in some cases are responsible for making API calls.

In the Fastly CLI we're unable to mock these returned concrete types and so in this PR I've swapped them out for interfaces.

> **NOTE**: We can reduce the boilerplate once go 1.18 comes out and we have access to generics.

This is a breaking change and will require a new major version of the go-fastly client.