### PR TITLE
Correctly set and advance current page

### DIFF
--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -125,10 +125,16 @@ func (c *Client) listACLEntriesWithPage(i *ListACLEntriesInput, p *ListAclEntrie
 		perPage = i.PerPage
 	}
 
+	// page is not specified, fetch from the beginning
 	if i.Page <= 0 && p.CurrentPage == 0 {
 		p.CurrentPage = 1
 	} else {
-		p.CurrentPage = p.CurrentPage + 1
+		// page is specified, fetch from a given page
+		if !p.consumed {
+			p.CurrentPage = i.Page
+		} else {
+			p.CurrentPage = p.CurrentPage + 1
+		}
 	}
 
 	path := fmt.Sprintf("/service/%s/acl/%s/entries", i.ServiceID, i.ACLID)

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -122,10 +122,16 @@ func (c *Client) listDictionaryItemsWithPage(i *ListDictionaryItemsInput, p *Lis
 		perPage = i.PerPage
 	}
 
+	// page is not specified, fetch from the beginning
 	if i.Page <= 0 && p.CurrentPage == 0 {
 		p.CurrentPage = 1
 	} else {
-		p.CurrentPage = p.CurrentPage + 1
+		// page is specified, fetch from a given page
+		if !p.consumed {
+			p.CurrentPage = i.Page
+		} else {
+			p.CurrentPage = p.CurrentPage + 1
+		}
 	}
 
 	path := fmt.Sprintf("/service/%s/dictionary/%s/items", i.ServiceID, i.DictionaryID)

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -128,10 +128,16 @@ func (c *Client) listServicesWithPage(i *ListServicesInput, p *ListServicesPagin
 		perPage = i.PerPage
 	}
 
+	// page is not specified, fetch from the beginning
 	if i.Page <= 0 && p.CurrentPage == 0 {
 		p.CurrentPage = 1
 	} else {
-		p.CurrentPage = p.CurrentPage + 1
+		// page is specified, fetch from a given page
+		if !p.consumed {
+			p.CurrentPage = i.Page
+		} else {
+			p.CurrentPage = p.CurrentPage + 1
+		}
 	}
 
 	requestOptions := &RequestOptions{


### PR DESCRIPTION
This is a bug fix. Right now, the `Page` field is not handled correctly and it always fetches the collection from the beginning.

```go
	paginator := client.NewListServicesPaginator(
		&fastly.ListServicesInput{
			PerPage: 2,
			Page:    5,
		},
	)
```

This PR attempts to fix this by setting `p.CurrentPage = i.Page` only in the initial iteration.
cc: @Integralist 