### PR TITLE
Stats: Add test for fetching stats by service and field

### DIFF
--- a/fastly/fixtures/stats/service_stats_by_field_and_service.yaml
+++ b/fastly/fixtures/stats/service_stats_by_field_and_service.yaml
@@ -1,0 +1,40 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/6.0.1 (+github.com/fastly/go-fastly; go1.17.2)
+    url: https://api.fastly.com/stats/service/7i6HN3TK9wS159v2gPAZ8A/field/bandwidth?by=day&from=10+days+ago&region=usa&to=now
+    method: GET
+  response:
+    body: |
+      {"data":[{"bandwidth":1845740,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644019200},{"bandwidth":1841819,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644105600},{"bandwidth":1842228,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644192000},{"bandwidth":1843147,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644278400},{"bandwidth":1839636,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644364800},{"bandwidth":1840603,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644451200},{"bandwidth":1842864,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644537600},{"bandwidth":1845754,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644624000},{"bandwidth":1842504,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644710400},{"bandwidth":77255,"service_id":"7i6HN3TK9wS159v2gPAZ8A","start_time":1644796800}],"meta":{"to":"2022-02-14 16:50:48 UTC","from":"2022-02-04 16:50:48 UTC","by":"day","region":"usa"},"status":"success","msg":null}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 14 Feb 2022 16:50:48 GMT
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-lon4238-LON
+      X-Timer:
+      - S1644857448.343749,VS0,VE348
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/stats_test.go
+++ b/fastly/stats_test.go
@@ -40,6 +40,25 @@ func TestClient_GetStats_ByField(t *testing.T) {
 	}
 }
 
+func TestClient_GetStats_ByFieldAndService(t *testing.T) {
+	t.Parallel()
+
+	var err error
+	record(t, "stats/service_stats_by_field_and_service", func(c *Client) {
+		_, err = c.GetStats(&GetStatsInput{
+			Service: testServiceID,
+			Field:   "bandwidth",
+			From:    "10 days ago",
+			To:      "now",
+			By:      "day",
+			Region:  "usa",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestClient_GetStatsJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Before this change, there was no test covering the `/stats/service/:service_id/field/:field` endpoint ([docs](https://developer.fastly.com/reference/api/metrics-stats/historical-stats/#get-hist-stats-service-field)). This endpoint gets used when both a service ID and field name are given in the options.

The surprising thing about this case is that despite being for a specific field, when specifying both a service and field, one needs to be call the `GetStats` method, not the `GetStatsField` method, due to the format of the response. The new test case provides an example of proper usage.