### PR TITLE
Support `Fastly-RateLimit-Remaining`

### DIFF
--- a/fastly/client.go
+++ b/fastly/client.go
@@ -152,7 +152,7 @@ func (c *Client) init() (*Client, error) {
 	// Use the default limit as a first guess:
 	// https://developer.fastly.com/reference/api/#rate-limiting
 	c.remaining = 1000
-	// Remaining() is left at the epoch to indicate a refresh of remaining is overdue
+	// c.reset is left at the epoch to indicate a refresh of remaining is overdue
 
 	u, err := url.Parse(c.Address)
 	if err != nil {
@@ -167,14 +167,14 @@ func (c *Client) init() (*Client, error) {
 	return c, nil
 }
 
-// Remaining returns the number of non-read requests left before
+// RateLimitRemaining returns the number of non-read requests left before
 // rate limiting causes a 429 Too Many Requests error.
-func (c *Client) Remaining() int {
+func (c *Client) RateLimitRemaining() int {
 	return c.remaining
 }
 
-// Reset returns the next time the rate limiter's Remaining counter will be refilled.
-func (c *Client) Reset() time.Time {
+// Reset returns the next time the rate limiter's counter will be refilled.
+func (c *Client) RateLimitReset() time.Time {
 	return time.Unix(c.reset, 0)
 }
 
@@ -295,7 +295,6 @@ func (c *Client) Request(verb, p string, ro *RequestOptions) (*http.Response, er
 
 	}
 	resp, err := checkResp(c.HTTPClient.Do(req))
-
 	if err != nil {
 		return resp, err
 	}

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -173,7 +173,8 @@ func (c *Client) RateLimitRemaining() int {
 	return c.remaining
 }
 
-// Reset returns the next time the rate limiter's counter will be refilled.
+// RateLimitReset returns the next time the rate limiter's counter will be
+// reset.
 func (c *Client) RateLimitReset() time.Time {
 	return time.Unix(c.reset, 0)
 }

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -152,7 +152,6 @@ func (c *Client) init() (*Client, error) {
 	// Use the default limit as a first guess:
 	// https://developer.fastly.com/reference/api/#rate-limiting
 	c.remaining = 1000
-	// c.reset is left at the epoch to indicate a refresh of remaining is overdue
 
 	u, err := url.Parse(c.Address)
 	if err != nil {

--- a/fastly/example_remaining_test.go
+++ b/fastly/example_remaining_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fastly/go-fastly/v6/fastly"
 )
 
-func ExampleClient_Remaining() {
+func ExampleClient_RateLimitRemaining() {
 	token := "your_api_token"
 	sid := "your_service_id"
 	dictName := "your_dict_name"
@@ -40,8 +40,8 @@ func ExampleClient_Remaining() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Writes remaining before '429 Too Many Requests': %d\n", c.Remaining())
-	fmt.Printf("Next rate limit reset expected at %v\n", c.Reset())
+	fmt.Printf("Writes remaining before '429 Too Many Requests': %d\n", c.RateLimitRemaining())
+	fmt.Printf("Next rate limit reset expected at %v\n", c.RateLimitReset())
 
 	for i := 1; i < 10; i++ {
 		_, err := c.UpdateDictionaryItem(&fastly.UpdateDictionaryItemInput{
@@ -53,7 +53,7 @@ func ExampleClient_Remaining() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("Writes remaining before '429 Too Many Requests': %d\n", c.Remaining())
-		fmt.Printf("Next rate limit reset expected at %v\n", c.Reset())
+		fmt.Printf("Writes remaining before '429 Too Many Requests': %d\n", c.RateLimitRemaining())
+		fmt.Printf("Next rate limit reset expected at %v\n", c.RateLimitReset())
 	}
 }

--- a/fastly/example_remaining_test.go
+++ b/fastly/example_remaining_test.go
@@ -41,6 +41,7 @@ func ExampleClient_Remaining() {
 		log.Fatal(err)
 	}
 	fmt.Printf("Writes remaining before '429 Too Many Requests': %d\n", c.Remaining())
+	fmt.Printf("Next rate limit reset expected at %v\n", c.Reset())
 
 	for i := 1; i < 10; i++ {
 		_, err := c.UpdateDictionaryItem(&fastly.UpdateDictionaryItemInput{
@@ -53,5 +54,6 @@ func ExampleClient_Remaining() {
 			log.Fatal(err)
 		}
 		fmt.Printf("Writes remaining before '429 Too Many Requests': %d\n", c.Remaining())
+		fmt.Printf("Next rate limit reset expected at %v\n", c.Reset())
 	}
 }

--- a/fastly/example_remaining_test.go
+++ b/fastly/example_remaining_test.go
@@ -1,0 +1,57 @@
+package fastly_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/fastly/go-fastly/v6/fastly"
+)
+
+func ExampleClient_Remaining() {
+	token := "your_api_token"
+	sid := "your_service_id"
+	dictName := "your_dict_name"
+
+	c, err := fastly.NewClient(token)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	v, err := c.LatestVersion(&fastly.LatestVersionInput{ServiceID: sid})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dict, err := c.GetDictionary(&fastly.GetDictionaryInput{
+		ServiceID:      sid,
+		ServiceVersion: v.Number,
+		Name:           dictName,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = c.CreateDictionaryItem(&fastly.CreateDictionaryItemInput{
+		ServiceID:    sid,
+		DictionaryID: dict.ID,
+		ItemKey:      "test-dictionary-item",
+		ItemValue:    "value",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Writes remaining before '429 Too Many Requests': %d\n", c.Remaining())
+
+	for i := 1; i < 10; i++ {
+		_, err := c.UpdateDictionaryItem(&fastly.UpdateDictionaryItemInput{
+			ServiceID:    sid,
+			DictionaryID: dict.ID,
+			ItemKey:      "test-dictionary-item",
+			ItemValue:    fmt.Sprintf("value%d", i),
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Writes remaining before '429 Too Many Requests': %d\n", c.Remaining())
+	}
+}


### PR DESCRIPTION
Lets apps observe how close they are to a `429 Too Many Requests` HTTP response from Fastly.

https://developer.fastly.com/reference/api/#rate-limiting

Fixes https://github.com/fastly/go-fastly/issues/336