### PR TITLE
go.mod: downgrade to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,4 @@ require (
 	honnef.co/go/tools v0.2.2
 )
 
-require (
-	github.com/BurntSushi/toml v0.3.1 // indirect
-	golang.org/x/mod v0.5.1 // indirect
-	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-)
-
-go 1.17
+go 1.16


### PR DESCRIPTION
The upgrade to 1.17 caused problems with some customers and internal teams because of changes in the language that caused (as an example) unexpected panics to be triggered. 

No features from 1.17 are being used, we bumped the version to be on the latest and not expecting there to be any issue.

> **NOTE**: After discussing internally, it's likely we'll bump to 1.17 when 1.19 is released (so as to stay two versions behind the latest -- yes 1.18 isn't released yet but we're close 😉).