### PR TITLE
Add `Backends` field to `Director`

### DIFF
--- a/fastly/director.go
+++ b/fastly/director.go
@@ -30,6 +30,7 @@ type Director struct {
 	ServiceVersion int    `mapstructure:"version"`
 
 	Name      string       `mapstructure:"name"`
+	Backends  []string     `mapstructure:"backends"`
 	Comment   string       `mapstructure:"comment"`
 	Shield    string       `mapstructure:"shield"`
 	Quorum    uint         `mapstructure:"quorum"`

--- a/fastly/fixtures/directors/cleanup.yaml
+++ b/fastly/fixtures/directors/cleanup.yaml
@@ -6,13 +6,14 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/75/director/test-director
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/director/test-director/backend/test-backend
     method: DELETE
   response:
-    body: '{"msg":"Record not found","detail":"Couldn''t find Director ''{ deleted
-      =\u003e 0000-00-00 00:00:00, name =\u003e test-director, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 75 }''"}'
+    body: '{"msg":"Record not found","detail":"Couldn''t find DirectorBackend ''{
+      backend =\u003e test-backend, deleted =\u003e 0000-00-00 00:00:00, director
+      =\u003e test-director, service =\u003e 7i6HN3TK9wS159v2gPAZ8A, version =\u003e
+      108 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +22,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:15:20 GMT
+      - Wed, 27 Apr 2022 11:03:46 GMT
       Fastly-Ratelimit-Remaining:
-      - "4984"
+      - "4993"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1651060800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -39,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-tyo11957-TYO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4122-MAN
       X-Timer:
-      - S1637910921.608891,VS0,VE271
+      - S1651057427.740035,VS0,VE193
     status: 404 Not Found
     code: 404
     duration: ""
@@ -50,13 +51,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/75/director/new-test-director
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/backend/test-backend
     method: DELETE
   response:
-    body: '{"msg":"Record not found","detail":"Couldn''t find Director ''{ deleted
-      =\u003e 0000-00-00 00:00:00, name =\u003e new-test-director, service =\u003e
-      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 75 }''"}'
+    body: '{"status":"ok"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -65,11 +64,55 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:15:21 GMT
+      - Wed, 27 Apr 2022 11:03:47 GMT
       Fastly-Ratelimit-Remaining:
-      - "4983"
+      - "4992"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1651060800"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4122-MAN
+      X-Timer:
+      - S1651057427.966642,VS0,VE386
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/director/test-director
+    method: DELETE
+  response:
+    body: '{"msg":"Record not found","detail":"Couldn''t find Director ''{ deleted
+      =\u003e 0000-00-00 00:00:00, name =\u003e test-director, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
+      version =\u003e 108 }''"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 27 Apr 2022 11:03:47 GMT
+      Fastly-Ratelimit-Remaining:
+      - "4991"
+      Fastly-Ratelimit-Reset:
+      - "1651060800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -83,9 +126,53 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11957-TYO
+      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4122-MAN
       X-Timer:
-      - S1637910921.887712,VS0,VE252
+      - S1651057427.384248,VS0,VE156
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/director/new-test-director
+    method: DELETE
+  response:
+    body: '{"msg":"Record not found","detail":"Couldn''t find Director ''{ deleted
+      =\u003e 0000-00-00 00:00:00, name =\u003e new-test-director, service =\u003e
+      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 108 }''"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 27 Apr 2022 11:03:47 GMT
+      Fastly-Ratelimit-Remaining:
+      - "4990"
+      Fastly-Ratelimit-Reset:
+      - "1651060800"
+      Status:
+      - 404 Not Found
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4122-MAN
+      X-Timer:
+      - S1651057428.570029,VS0,VE157
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/directors/create.yaml
+++ b/fastly/fixtures/directors/create.yaml
@@ -2,29 +2,35 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=75&name=test-director&quorum=50&retries=5&type=1
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=108&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&port=1234&ssl_check_cert=0&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384
     form:
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "75"
+      - "108"
+      address:
+      - integ-test.go-fastly.com
+      connect_timeout:
+      - "1500"
       name:
-      - test-director
-      quorum:
-      - "50"
-      retries:
-      - "5"
-      type:
-      - "1"
+      - test-backend
+      override_host:
+      - origin.example.com
+      port:
+      - "1234"
+      ssl_check_cert:
+      - "0"
+      ssl_ciphers:
+      - DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/75/director
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/backend
     method: POST
   response:
-    body: '{"name":"test-director","quorum":50,"retries":5,"type":1,"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":75,"capacity":100,"comment":"","created_at":"2021-11-26T07:15:18Z","backends":[],"updated_at":"2021-11-26T07:15:18Z","deleted_at":null,"shield":null}'
+    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","port":1234,"ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":108,"auto_loadbalance":false,"request_condition":"","first_byte_timeout":15000,"updated_at":"2022-04-27T11:03:45Z","deleted_at":null,"comment":"","ssl_client_key":null,"client_cert":null,"shield":null,"weight":100,"max_tls_version":null,"ssl_client_cert":null,"ssl_sni_hostname":null,"use_ssl":false,"min_tls_version":null,"created_at":"2022-04-27T11:03:45Z","max_conn":200,"error_threshold":0,"ssl_hostname":null,"ssl_ca_cert":null,"hostname":"integ-test.go-fastly.com","healthcheck":null,"ipv6":null,"ipv4":null,"ssl_cert_hostname":null,"between_bytes_timeout":10000}'
     headers:
       Accept-Ranges:
       - bytes
@@ -33,11 +39,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:15:18 GMT
+      - Wed, 27 Apr 2022 11:03:45 GMT
       Fastly-Ratelimit-Remaining:
-      - "4987"
+      - "4998"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1651060800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -51,9 +57,117 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-tyo11957-TYO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4122-MAN
       X-Timer:
-      - S1637910918.210918,VS0,VE288
+      - S1651057425.969083,VS0,VE231
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=108&name=test-director&quorum=50&retries=5&type=1
+    form:
+      ServiceID:
+      - 7i6HN3TK9wS159v2gPAZ8A
+      ServiceVersion:
+      - "108"
+      name:
+      - test-director
+      quorum:
+      - "50"
+      retries:
+      - "5"
+      type:
+      - "1"
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/director
+    method: POST
+  response:
+    body: '{"name":"test-director","quorum":50,"retries":5,"type":1,"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":108,"deleted_at":null,"shield":null,"backends":[],"comment":"","created_at":"2022-04-27T11:03:45Z","capacity":100,"updated_at":"2022-04-27T11:03:45Z"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 27 Apr 2022 11:03:45 GMT
+      Fastly-Ratelimit-Remaining:
+      - "4997"
+      Fastly-Ratelimit-Reset:
+      - "1651060800"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4122-MAN
+      X-Timer:
+      - S1651057425.220888,VS0,VE379
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: Backend=test-backend&Director=test-director&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=108
+    form:
+      Backend:
+      - test-backend
+      Director:
+      - test-director
+      ServiceID:
+      - 7i6HN3TK9wS159v2gPAZ8A
+      ServiceVersion:
+      - "108"
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/director/test-director/backend/test-backend
+    method: POST
+  response:
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":108,"director_name":"test-director","backend_name":"test-backend","updated_at":"2022-04-27T11:03:45Z","deleted_at":null,"created_at":"2022-04-27T11:03:45Z"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 27 Apr 2022 11:03:45 GMT
+      Fastly-Ratelimit-Remaining:
+      - "4996"
+      Fastly-Ratelimit-Reset:
+      - "1651060800"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4122-MAN
+      X-Timer:
+      - S1651057426.624363,VS0,VE175
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/directors/delete.yaml
+++ b/fastly/fixtures/directors/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/75/director/test-director
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/director/test-director
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:15:20 GMT
+      - Wed, 27 Apr 2022 11:03:46 GMT
       Fastly-Ratelimit-Remaining:
-      - "4985"
+      - "4994"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1651060800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-tyo11957-TYO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4122-MAN
       X-Timer:
-      - S1637910920.073703,VS0,VE521
+      - S1651057426.487396,VS0,VE218
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/directors/get.yaml
+++ b/fastly/fixtures/directors/get.yaml
@@ -6,20 +6,20 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/75/director/test-director
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/director/test-director
     method: GET
   response:
-    body: '{"version":75,"backends":[],"type":1,"capacity":100,"updated_at":"2021-11-26T07:15:18Z","created_at":"2021-11-26T07:15:18Z","quorum":50,"comment":"","deleted_at":null,"shield":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","retries":5,"name":"test-director"}'
+    body: '{"deleted_at":null,"comment":"","created_at":"2022-04-27T11:03:45Z","quorum":50,"updated_at":"2022-04-27T11:03:45Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","name":"test-director","capacity":100,"backends":["test-backend"],"type":1,"retries":5,"version":108,"shield":null}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-store, s-maxage=0
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:15:19 GMT
+      - Wed, 27 Apr 2022 11:03:46 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -27,15 +27,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish, 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS, MISS, MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - 0, 0, 0
+      - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11947-TYO, cache-tyo11957-TYO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4122-MAN
       X-Timer:
-      - S1637910919.097782,VS0,VE623
+      - S1651057426.996909,VS0,VE144
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/directors/list.yaml
+++ b/fastly/fixtures/directors/list.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/75/director
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/director
     method: GET
   response:
-    body: '[{"type":1,"capacity":100,"name":"test-director","updated_at":"2021-11-26T07:15:18Z","shield":null,"created_at":"2021-11-26T07:15:18Z","comment":"","service_id":"7i6HN3TK9wS159v2gPAZ8A","deleted_at":null,"backends":[],"retries":5,"version":75,"quorum":50}]'
+    body: '[{"updated_at":"2022-04-27T11:03:45Z","quorum":50,"comment":"","version":108,"name":"test-director","retries":5,"type":1,"created_at":"2022-04-27T11:03:45Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","backends":["test-backend"],"capacity":100,"deleted_at":null,"shield":null}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:15:19 GMT
+      - Wed, 27 Apr 2022 11:03:45 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11957-TYO
+      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4122-MAN
       X-Timer:
-      - S1637910919.505865,VS0,VE583
+      - S1651057426.825595,VS0,VE145
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/directors/update.yaml
+++ b/fastly/fixtures/directors/update.yaml
@@ -2,14 +2,14 @@
 version: 1
 interactions:
 - request:
-    body: Name=test-director&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=75&name=new-test-director&quorum=100
+    body: Name=test-director&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=108&name=new-test-director&quorum=100
     form:
       Name:
       - test-director
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "75"
+      - "108"
       name:
       - new-test-director
       quorum:
@@ -18,11 +18,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/75/director/test-director
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/108/director/test-director
     method: PUT
   response:
-    body: '{"shield":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","retries":5,"name":"test-director","version":75,"type":1,"backends":[],"capacity":100,"updated_at":"2021-11-26T07:15:18Z","created_at":"2021-11-26T07:15:18Z","quorum":100,"comment":"","deleted_at":null}'
+    body: '{"retries":5,"service_id":"7i6HN3TK9wS159v2gPAZ8A","type":1,"quorum":100,"updated_at":"2022-04-27T11:03:45Z","deleted_at":null,"capacity":100,"version":108,"backends":["test-backend"],"name":"test-director","shield":null,"comment":"","created_at":"2022-04-27T11:03:45Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -31,11 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:15:20 GMT
+      - Wed, 27 Apr 2022 11:03:46 GMT
       Fastly-Ratelimit-Remaining:
-      - "4986"
+      - "4995"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1651060800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +49,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-tyo11957-TYO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4122-MAN
       X-Timer:
-      - S1637910920.729706,VS0,VE338
+      - S1651057426.170599,VS0,VE216
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/directors/version.yaml
+++ b/fastly/fixtures/directors/version.yaml
@@ -10,11 +10,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
+      - FastlyGo/6.3.1 (+github.com/fastly/go-fastly; go1.16)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":75}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":108}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +23,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:15:18 GMT
+      - Wed, 27 Apr 2022 11:03:44 GMT
       Fastly-Ratelimit-Remaining:
-      - "4988"
+      - "4999"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1651060800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11957-TYO
+      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4122-MAN
       X-Timer:
-      - S1637910918.709131,VS0,VE490
+      - S1651057424.446273,VS0,VE491
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
**Problem**: The Fastly Terraform Provider is inefficiently checking for backend membership within a Director, resulting in API requests reaching 1000+ in some cases for customers.

**Solution**: Expose the `backends` field on the director so that the Terraform Provider can quickly validate which service backends are members of the director.