### PR TITLE
purge: fail to purge with query string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ NAME := $(notdir $(shell pwd))
 # Test Service ID
 FASTLY_TEST_SERVICE_ID ?=
 FASTLY_API_KEY ?=
+#
+# Enables support for tools such as https://github.com/rakyll/gotest
+TEST_COMMAND ?= go test
 
 all: mod-download dev-dependencies tidy fmt fiximports test vet staticcheck ## Runs all of the required cleaning and verification targets.
 .PHONY: all
@@ -40,12 +43,12 @@ dev-dependencies: ## Downloads the necessesary dev dependencies.
 
 test: ## Runs the test suite with VCR mocks enabled.
 	@echo "==> Testing ${NAME}"
-	@go test -timeout=30s -parallel=20 -tags="${GOTAGS}" ${GOPKGS} ${TESTARGS}
+	@$(TEST_COMMAND) -timeout=30s -parallel=20 -tags="${GOTAGS}" ${GOPKGS} ${TESTARGS}
 .PHONY: test
 
 test-race: ## Runs the test suite with the -race flag to identify race conditions, if they exist.
 	@echo "==> Testing ${NAME} (race)"
-	@go test -timeout=60s -race -tags="${GOTAGS}" ${GOPKGS} ${TESTARGS}
+	@$(TEST_COMMAND) -timeout=60s -race -tags="${GOTAGS}" ${GOPKGS} ${TESTARGS}
 .PHONY: test-race
 
 test-full: ## Runs the tests with VCR disabled (i.e., makes external calls).

--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -70,9 +70,7 @@ func constructRequestOptionsParam(us string) (map[string]string, error) {
 	// type, so we have to manually loop over the url.Values and copy the
 	// key/value pairs into a new map instance.
 	for k, v := range v {
-		if len(v) > 0 {
-			m[k] = v[0]
-		}
+		m[k] = v[0]
 	}
 	return m, nil
 }

--- a/fastly/purge_test.go
+++ b/fastly/purge_test.go
@@ -17,9 +17,16 @@ func TestROParams(t *testing.T) {
 				"beep": "boop",
 			},
 		},
-		"valid no qs": {
+		"no qs": {
 			input:  "https://www.example.com/",
 			output: map[string]string{},
+		},
+		"key no value": {
+			input: "https://www.example.com/?empty&foo=bar",
+			output: map[string]string{
+				"foo":   "bar",
+				"empty": "",
+			},
 		},
 	}
 

--- a/fastly/purge_test.go
+++ b/fastly/purge_test.go
@@ -1,8 +1,42 @@
 package fastly
 
 import (
+	"reflect"
 	"testing"
 )
+
+func TestROParams(t *testing.T) {
+	tests := map[string]struct {
+		input  string
+		output map[string]string
+	}{
+		"valid qs": {
+			input: "https://www.example.com/?foo=bar&beep=boop",
+			output: map[string]string{
+				"foo":  "bar",
+				"beep": "boop",
+			},
+		},
+		"valid no qs": {
+			input:  "https://www.example.com/",
+			output: map[string]string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			want := tc.output
+			have, err := constructRequestOptionsParam(tc.input)
+			if err != nil {
+				t.Errorf("got an unexpected error: %s", err)
+			}
+			if !reflect.DeepEqual(want, have) {
+				t.Errorf("want: %+v, have: %+v\n", want, have)
+			}
+		})
+	}
+}
 
 // TestClient_Purge validates no runtime panics are raised by the Purge method.
 //


### PR DESCRIPTION
A customer discovered purging URLs, that contained a query param, would fail to purge.

In the following example, the first URL would purge while the other two would not purge.

```
purgeURLs := []string{
  "https://example.com/john", 
  "https://example.com/john?payment=success", 
  "https://example.com/john?payment=cancelled",
}

for _, url := range purgeURLs {
  clearCache(url)
}

func (cp *cachePurger) clearCache(purgeURL string) {
  cp.client.Purge(&fastly.PurgeInput{URL: purgeURL})
}
```

Following a quick review of the API client code I discovered that the `.Post()` method internally calls `.Request()`, and that internally calls `.RawRequest()`. It's in that last method we see this:

https://github.com/fastly/go-fastly/blob/f56c86d8378942bf60fd173d6dacf7e192bf5ffe/fastly/request.go#L44-L48

Because the top-level `Purge()` method isn't setting `ro.Params` (which are passed all the way through to `RawRequest()`), it means the inner most method will replace any query string values with `params.Encode()`, which is going to be an empty string as there is no `ro.Param` content to iterate over and subsequently we never call `params.Add` to populate the `params` type, and thus `params.Encode()` returns an empty string.

The fix is to ensure the`Purge()` method parses the given URL and extracts its query string (if any) and assigns it to `ro.Params` so it's passed down to `RawRequest()` so the internal method can re-apply it as necessary.
