### PR TITLE
Splunk token required

### DIFF
--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -269,6 +269,10 @@ var ErrNotImplemented = errors.New("not implemented")
 // already enabled for a service.
 var ErrManagedLoggingEnabled = errors.New("managed logging already enabled")
 
+// ErrMissingToken is an error that is returned when an input struct
+// requires a "Token" key, but one was not set.
+var ErrMissingToken = NewFieldError("Token")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 

--- a/fastly/splunk.go
+++ b/fastly/splunk.go
@@ -108,6 +108,10 @@ func (c *Client) CreateSplunk(i *CreateSplunkInput) (*Splunk, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
+	if i.Token == "" {
+		return nil, ErrMissingToken
+	}
+
 	path := fmt.Sprintf("/service/%s/version/%d/logging/splunk", i.ServiceID, i.ServiceVersion)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {


### PR DESCRIPTION
The internal Splunk logging endpoint expects a token to be provided.

**NOTE**: I don't consider this a breaking change because from a user's perspective they would currently get an API error telling them the token is missing and would be forced to set the `Token` field (i.e. making it required).