### PR TITLE
Avoid duplicate Close() call on http.Response.Body

### DIFF
--- a/fastly/client.go
+++ b/fastly/client.go
@@ -467,9 +467,7 @@ func checkResp(resp *http.Response, err error) (*http.Response, error) {
 
 // decodeBodyMap is used to decode an HTTP response body into a mapstructure struct.
 // It closes `body`.
-func decodeBodyMap(body io.ReadCloser, out interface{}) error {
-	defer body.Close()
-
+func decodeBodyMap(body io.Reader, out interface{}) error {
 	var parsed interface{}
 	dec := json.NewDecoder(body)
 	if err := dec.Decode(&parsed); err != nil {


### PR DESCRIPTION
When fixing https://github.com/fastly/go-fastly/issues/362 I neglected to notice that the `decodeBodyMap` function was already calling `.Close()` on the provided `http.Response.Body`.