### PR TITLE
Support Health Check Headers

### DIFF
--- a/fastly/fixtures/health_checks/cleanup.yaml
+++ b/fastly/fixtures/health_checks/cleanup.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/77/healthcheck/test-healthcheck
+      - FastlyGo/6.7.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/131/healthcheck/test-healthcheck
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Healthcheck ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e test-healthcheck, service =\u003e
-      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 77 }''"}'
+      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 131 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:17:27 GMT
+      - Mon, 10 Oct 2022 11:57:58 GMT
       Fastly-Ratelimit-Remaining:
-      - "4972"
+      - "9917"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1665403200"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4129-MAN
       X-Timer:
-      - S1637911047.773785,VS0,VE283
+      - S1665403078.282367,VS0,VE141
     status: 404 Not Found
     code: 404
     duration: ""
@@ -50,13 +50,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/77/healthcheck/new-test-healthcheck
+      - FastlyGo/6.7.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/131/healthcheck/new-test-healthcheck
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Healthcheck ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e new-test-healthcheck, service =\u003e
-      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 77 }''"}'
+      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 131 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -65,11 +65,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:17:27 GMT
+      - Mon, 10 Oct 2022 11:57:58 GMT
       Fastly-Ratelimit-Remaining:
-      - "4971"
+      - "9916"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1665403200"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -83,9 +83,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4129-MAN
       X-Timer:
-      - S1637911047.182845,VS0,VE278
+      - S1665403078.461078,VS0,VE309
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/health_checks/create.yaml
+++ b/fastly/fixtures/health_checks/create.yaml
@@ -2,16 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=77&check_interval=2500&expected_response=200&host=example.com&http_version=1.1&initial=10&method=HEAD&name=test-healthcheck&path=%2Ffoo&threshold=10&timeout=1500&window=5000
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=131&check_interval=2500&expected_response=200&host=example.com&http_version=1.1&initial=10&method=HEAD&name=test-healthcheck&path=%2Ffoo&threshold=10&timeout=1500&window=5000&headers=%5B"Foo:Bar","Baz:Qux"%5D
     form:
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "77"
+      - "131"
       check_interval:
       - "2500"
       expected_response:
       - "200"
+      headers:
+      - '["Foo:Bar","Baz:Qux"]'
       host:
       - example.com
       http_version:
@@ -34,11 +36,12 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/77/healthcheck
+      - FastlyGo/6.7.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/131/healthcheck
     method: POST
   response:
-    body: '{"check_interval":2500,"expected_response":200,"host":"example.com","http_version":"1.1","initial":10,"method":"HEAD","name":"test-healthcheck","path":"/foo","threshold":10,"timeout":1500,"window":5000,"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":77,"updated_at":"2021-11-26T07:17:25Z","comment":"","created_at":"2021-11-26T07:17:25Z","deleted_at":null}'
+    body: '{"check_interval":2500,"expected_response":200,"host":"example.com","http_version":"1.1","initial":10,"method":"HEAD","name":"test-healthcheck","path":"/foo","threshold":10,"timeout":1500,"window":5000,"headers":["Baz:
+      Qux","Foo: Bar"],"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":131,"deleted_at":null,"updated_at":"2022-10-10T11:57:57Z","created_at":"2022-10-10T11:57:57Z","comment":""}'
     headers:
       Accept-Ranges:
       - bytes
@@ -47,11 +50,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:17:25 GMT
+      - Mon, 10 Oct 2022 11:57:57 GMT
       Fastly-Ratelimit-Remaining:
-      - "4975"
+      - "9920"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1665403200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -65,9 +68,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4129-MAN
       X-Timer:
-      - S1637911045.174887,VS0,VE292
+      - S1665403077.753161,VS0,VE358
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/health_checks/delete.yaml
+++ b/fastly/fixtures/health_checks/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/77/healthcheck/new-test-healthcheck
+      - FastlyGo/6.7.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/131/healthcheck/new-test-healthcheck
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:17:26 GMT
+      - Mon, 10 Oct 2022 11:57:58 GMT
       Fastly-Ratelimit-Remaining:
-      - "4973"
+      - "9918"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1665403200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4129-MAN
       X-Timer:
-      - S1637911046.431455,VS0,VE331
+      - S1665403078.883343,VS0,VE375
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/health_checks/get.yaml
+++ b/fastly/fixtures/health_checks/get.yaml
@@ -6,11 +6,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/77/healthcheck/test-healthcheck
+      - FastlyGo/6.7.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/131/healthcheck/test-healthcheck
     method: GET
   response:
-    body: '{"expected_response":200,"timeout":1500,"host":"example.com","name":"test-healthcheck","method":"HEAD","created_at":"2021-11-26T07:17:25Z","threshold":10,"initial":10,"deleted_at":null,"comment":"","http_version":"1.1","service_id":"7i6HN3TK9wS159v2gPAZ8A","path":"/foo","version":77,"updated_at":"2021-11-26T07:17:25Z","window":5000,"check_interval":2500}'
+    body: '{"threshold":10,"created_at":"2022-10-10T11:57:57Z","headers":["Baz: Qux","Foo:
+      Bar"],"deleted_at":null,"window":5000,"timeout":1500,"initial":10,"expected_response":200,"comment":"","method":"HEAD","host":"example.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":131,"path":"/foo","http_version":"1.1","name":"test-healthcheck","updated_at":"2022-10-10T11:57:57Z","check_interval":2500}'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +20,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:17:25 GMT
+      - Mon, 10 Oct 2022 11:57:57 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +34,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4129-MAN
       X-Timer:
-      - S1637911046.745707,VS0,VE236
+      - S1665403077.486537,VS0,VE137
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/health_checks/list.yaml
+++ b/fastly/fixtures/health_checks/list.yaml
@@ -6,11 +6,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/77/healthcheck
+      - FastlyGo/6.7.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/131/healthcheck
     method: GET
   response:
-    body: '[{"threshold":10,"service_id":"7i6HN3TK9wS159v2gPAZ8A","check_interval":2500,"path":"/foo","initial":10,"expected_response":200,"host":"example.com","timeout":1500,"method":"HEAD","updated_at":"2021-11-26T07:17:25Z","window":5000,"http_version":"1.1","created_at":"2021-11-26T07:17:25Z","deleted_at":null,"name":"test-healthcheck","comment":"","version":77}]'
+    body: '[{"http_version":"1.1","check_interval":2500,"initial":10,"name":"test-healthcheck","path":"/foo","headers":["Baz:
+      Qux","Foo: Bar"],"window":5000,"comment":"","threshold":10,"deleted_at":null,"version":131,"updated_at":"2022-10-10T11:57:57Z","method":"HEAD","created_at":"2022-10-10T11:57:57Z","host":"example.com","timeout":1500,"expected_response":200,"service_id":"7i6HN3TK9wS159v2gPAZ8A"}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +20,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:17:25 GMT
+      - Mon, 10 Oct 2022 11:57:57 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +34,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4129-MAN
       X-Timer:
-      - S1637911045.482615,VS0,VE248
+      - S1665403077.147678,VS0,VE314
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/health_checks/update.yaml
+++ b/fastly/fixtures/health_checks/update.yaml
@@ -2,25 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: Name=test-healthcheck&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=77&name=new-test-healthcheck
+    body: Name=test-healthcheck&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=131&name=new-test-healthcheck&headers=%5B"Beep:Boop"%5D
     form:
       Name:
       - test-healthcheck
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "77"
+      - "131"
+      headers:
+      - '["Beep:Boop"]'
       name:
       - new-test-healthcheck
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/77/healthcheck/test-healthcheck
+      - FastlyGo/6.7.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/131/healthcheck/test-healthcheck
     method: PUT
   response:
-    body: '{"check_interval":2500,"window":5000,"version":77,"updated_at":"2021-11-26T07:17:25Z","service_id":"7i6HN3TK9wS159v2gPAZ8A","path":"/foo","http_version":"1.1","initial":10,"comment":"","deleted_at":null,"method":"HEAD","threshold":10,"created_at":"2021-11-26T07:17:25Z","timeout":1500,"host":"example.com","name":"new-test-healthcheck","expected_response":200}'
+    body: '{"expected_response":200,"http_version":"1.1","version":131,"method":"HEAD","updated_at":"2022-10-10T11:57:57Z","comment":"","timeout":1500,"host":"example.com","name":"new-test-healthcheck","created_at":"2022-10-10T11:57:57Z","headers":["Beep:Boop"],"check_interval":2500,"path":"/foo","deleted_at":null,"threshold":10,"initial":10,"window":5000,"service_id":"7i6HN3TK9wS159v2gPAZ8A"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -29,11 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:17:26 GMT
+      - Mon, 10 Oct 2022 11:57:57 GMT
       Fastly-Ratelimit-Remaining:
-      - "4974"
+      - "9919"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1665403200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +49,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4129-MAN
       X-Timer:
-      - S1637911046.060367,VS0,VE314
+      - S1665403078.651554,VS0,VE205
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/health_checks/version.yaml
+++ b/fastly/fixtures/health_checks/version.yaml
@@ -10,11 +10,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
+      - FastlyGo/6.7.0 (+github.com/fastly/go-fastly; go1.16.15)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":77}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":131}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +23,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:17:25 GMT
+      - Mon, 10 Oct 2022 11:57:56 GMT
       Fastly-Ratelimit-Remaining:
-      - "4976"
+      - "9921"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1665403200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4129-MAN
       X-Timer:
-      - S1637911045.736312,VS0,VE432
+      - S1665403076.346639,VS0,VE373
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/health_check.go
+++ b/fastly/health_check.go
@@ -15,6 +15,7 @@ type HealthCheck struct {
 	Name             string     `mapstructure:"name"`
 	Comment          string     `mapstructure:"comment"`
 	Method           string     `mapstructure:"method"`
+	Headers          []string   `mapstructure:"headers"`
 	Host             string     `mapstructure:"host"`
 	Path             string     `mapstructure:"path"`
 	HTTPVersion      string     `mapstructure:"http_version"`
@@ -81,18 +82,19 @@ type CreateHealthCheckInput struct {
 	// ServiceVersion is the specific configuration version (required).
 	ServiceVersion int
 
-	Name             string `url:"name,omitempty"`
-	Comment          string `url:"comment,omitempty"`
-	Method           string `url:"method,omitempty"`
-	Host             string `url:"host,omitempty"`
-	Path             string `url:"path,omitempty"`
-	HTTPVersion      string `url:"http_version,omitempty"`
-	Timeout          *uint  `url:"timeout,omitempty"`
-	CheckInterval    *uint  `url:"check_interval,omitempty"`
-	ExpectedResponse *uint  `url:"expected_response,omitempty"`
-	Window           *uint  `url:"window,omitempty"`
-	Threshold        *uint  `url:"threshold,omitempty"`
-	Initial          *uint  `url:"initial,omitempty"`
+	Name             string   `url:"name,omitempty"`
+	Comment          string   `url:"comment,omitempty"`
+	Method           string   `url:"method,omitempty"`
+	Headers          []string `url:"headers,omitempty"`
+	Host             string   `url:"host,omitempty"`
+	Path             string   `url:"path,omitempty"`
+	HTTPVersion      string   `url:"http_version,omitempty"`
+	Timeout          *uint    `url:"timeout,omitempty"`
+	CheckInterval    *uint    `url:"check_interval,omitempty"`
+	ExpectedResponse *uint    `url:"expected_response,omitempty"`
+	Window           *uint    `url:"window,omitempty"`
+	Threshold        *uint    `url:"threshold,omitempty"`
+	Initial          *uint    `url:"initial,omitempty"`
 }
 
 // CreateHealthCheck creates a new Fastly health check.
@@ -105,8 +107,11 @@ func (c *Client) CreateHealthCheck(i *CreateHealthCheckInput) (*HealthCheck, err
 		return nil, ErrMissingServiceVersion
 	}
 
+	ro := new(RequestOptions)
+	ro.HealthCheckHeaders = true
+
 	path := fmt.Sprintf("/service/%s/version/%d/healthcheck", i.ServiceID, i.ServiceVersion)
-	resp, err := c.PostForm(path, i, nil)
+	resp, err := c.PostForm(path, i, ro)
 	if err != nil {
 		return nil, err
 	}
@@ -170,18 +175,19 @@ type UpdateHealthCheckInput struct {
 	// Name is the name of the health check to update.
 	Name string
 
-	NewName          *string `url:"name,omitempty"`
-	Comment          *string `url:"comment,omitempty"`
-	Method           *string `url:"method,omitempty"`
-	Host             *string `url:"host,omitempty"`
-	Path             *string `url:"path,omitempty"`
-	HTTPVersion      *string `url:"http_version,omitempty"`
-	Timeout          *uint   `url:"timeout,omitempty"`
-	CheckInterval    *uint   `url:"check_interval,omitempty"`
-	ExpectedResponse *uint   `url:"expected_response,omitempty"`
-	Window           *uint   `url:"window,omitempty"`
-	Threshold        *uint   `url:"threshold,omitempty"`
-	Initial          *uint   `url:"initial,omitempty"`
+	NewName          *string   `url:"name,omitempty"`
+	Comment          *string   `url:"comment,omitempty"`
+	Method           *string   `url:"method,omitempty"`
+	Headers          *[]string `url:"headers,omitempty"`
+	Host             *string   `url:"host,omitempty"`
+	Path             *string   `url:"path,omitempty"`
+	HTTPVersion      *string   `url:"http_version,omitempty"`
+	Timeout          *uint     `url:"timeout,omitempty"`
+	CheckInterval    *uint     `url:"check_interval,omitempty"`
+	ExpectedResponse *uint     `url:"expected_response,omitempty"`
+	Window           *uint     `url:"window,omitempty"`
+	Threshold        *uint     `url:"threshold,omitempty"`
+	Initial          *uint     `url:"initial,omitempty"`
 }
 
 // UpdateHealthCheck updates a specific health check.
@@ -198,8 +204,11 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 		return nil, ErrMissingName
 	}
 
+	ro := new(RequestOptions)
+	ro.HealthCheckHeaders = true
+
 	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
-	resp, err := c.PutForm(path, i, nil)
+	resp, err := c.PutForm(path, i, ro)
 	if err != nil {
 		return nil, err
 	}

--- a/fastly/health_check_test.go
+++ b/fastly/health_check_test.go
@@ -17,10 +17,14 @@ func TestClient_HealthChecks(t *testing.T) {
 	var hc *HealthCheck
 	record(t, "health_checks/create", func(c *Client) {
 		hc, err = c.CreateHealthCheck(&CreateHealthCheckInput{
-			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
-			Name:             "test-healthcheck",
-			Method:           "HEAD",
+			ServiceID:      testServiceID,
+			ServiceVersion: tv.Number,
+			Name:           "test-healthcheck",
+			Method:         "HEAD",
+			Headers: []string{
+				"Foo: Bar",
+				"Baz: Qux",
+			},
 			Host:             "example.com",
 			Path:             "/foo",
 			HTTPVersion:      "1.1",
@@ -86,6 +90,9 @@ func TestClient_HealthChecks(t *testing.T) {
 	if hc.Initial != 10 {
 		t.Errorf("bad initial: %q", hc.Initial)
 	}
+	if len(hc.Headers) != 2 {
+		t.Errorf("bad headers: %q", hc.Headers)
+	}
 
 	// List
 	var hcs []*HealthCheck
@@ -147,6 +154,12 @@ func TestClient_HealthChecks(t *testing.T) {
 	if hc.Initial != nhc.Initial {
 		t.Errorf("bad initial: %q", hc.Initial)
 	}
+	if len(nhc.Headers) != 2 {
+		t.Errorf("bad headers: %q", nhc.Headers)
+	}
+	if hc.Headers[0] != nhc.Headers[0] || hc.Headers[1] != nhc.Headers[1] {
+		t.Errorf("bad headers: %q", nhc.Headers)
+	}
 
 	// Update
 	var uhc *HealthCheck
@@ -156,13 +169,17 @@ func TestClient_HealthChecks(t *testing.T) {
 			ServiceVersion: tv.Number,
 			Name:           "test-healthcheck",
 			NewName:        String("new-test-healthcheck"),
+			Headers:        &[]string{"Beep: Boop"},
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if uhc.Name != "new-test-healthcheck" {
-		t.Errorf("bad name: %q", uhc.Name)
+		t.Errorf("bad update name: %q", uhc.Name)
+	}
+	if len(uhc.Headers) != 1 {
+		t.Errorf("bad headers: %q", uhc.Headers)
 	}
 
 	// Delete

--- a/fastly/request.go
+++ b/fastly/request.go
@@ -23,11 +23,11 @@ type RequestOptions struct {
 	// Can this request run in parallel
 	Parallel bool
 
-  // HealthCheckHeaders indicates if there is any special parsing required to
-  // support the health check API endpoint (refer to client.RequestForm).
-  //
-  // FIXME: For the future code-generated API client world.
-  HealthCheckHeaders bool
+	// HealthCheckHeaders indicates if there is any special parsing required to
+	// support the health check API endpoint (refer to client.RequestForm).
+	//
+	// FIXME: For the future code-generated API client world.
+	HealthCheckHeaders bool
 }
 
 // RawRequest accepts a verb, URL, and RequestOptions struct and returns the

--- a/fastly/request.go
+++ b/fastly/request.go
@@ -22,6 +22,12 @@ type RequestOptions struct {
 
 	// Can this request run in parallel
 	Parallel bool
+
+  // HealthCheckHeaders indicates if there is any special parsing required to
+  // support the health check API endpoint (refer to client.RequestForm).
+  //
+  // FIXME: For the future code-generated API client world.
+  HealthCheckHeaders bool
 }
 
 // RawRequest accepts a verb, URL, and RequestOptions struct and returns the

--- a/fastly/service_authorization.go
+++ b/fastly/service_authorization.go
@@ -27,12 +27,14 @@ type ServiceAuthorization struct {
 	Permission string     `jsonapi:"attr,permission,omitempty"`
 	CreatedAt  *time.Time `jsonapi:"attr,created_at,iso8601"`
 	UpdatedAt  *time.Time `jsonapi:"attr,updated_at,iso8601"`
-	DeltedAt   *time.Time `jsonapi:"attr,deleted_at,iso8601"`
-	User       *SAUser    `jsonapi:"relation,user,omitempty"`
-	Service    *SAService `jsonapi:"relation,service,omitempty"`
+	// FIXME: Typo (DeltedAt -> DeletedAt).
+	DeltedAt *time.Time `jsonapi:"attr,deleted_at,iso8601"`
+	User     *SAUser    `jsonapi:"relation,user,omitempty"`
+	Service  *SAService `jsonapi:"relation,service,omitempty"`
 }
 
 // SAResponse is an object containing the list of ServiceAuthorization results.
+// FIXME: Ambiguous name (SAResponse -> ServiceAuthorizations)
 type SAResponse struct {
 	Items []*ServiceAuthorization
 	Info  infoResponse
@@ -139,7 +141,7 @@ type CreateServiceAuthorizationInput struct {
 	// Permission is the level of permissions to grant the user to the service. Valid values are "full", "read_only", "purge_select" or "purge_all".
 	Permission string `jsonapi:"attr,permission,omitempty"`
 
-	// ServiceID is the ID of the service to grant permissions for.
+	// Service is the ID of the service to grant permissions for.
 	Service *SAService `jsonapi:"relation,service,omitempty"`
 
 	// UserID is the ID of the user which should have its permissions set.
@@ -175,6 +177,7 @@ type UpdateServiceAuthorizationInput struct {
 	ID string `jsonapi:"primary,service_authorization"`
 
 	// The permission to grant the user to the service referenced by this service authorization.
+	// FIXME: Should be singular (Permissions -> Permission).
 	Permissions string `jsonapi:"attr,permission,omitempty"`
 }
 

--- a/fastly/waf_rules.go
+++ b/fastly/waf_rules.go
@@ -52,7 +52,7 @@ type ListWAFRulesInput struct {
 	// Limit the returned rules to a set by modsecurity rule IDs.
 	FilterModSecIDs []int
 	// Excludes individual rules by modsecurity rule IDs.
-	// TODO: fix typo ExcludeMocSecIDs -> ExcludeModSecIDs
+	// FIXME: Should be d not c (ExcludeMocSecIDs -> ExcludeModSecIDs)
 	ExcludeMocSecIDs []int
 	// Limit the number of returned rules.
 	PageSize int


### PR DESCRIPTION
Example API call via `curl`:

```shell
curl -i -X POST "https://api.fastly.com/service/123/version/2/healthcheck" \
  -H "Fastly-Key: $FASTLY_API_KEY" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -H "Accept: application/json" \
  -d 'name=test-healthcheck4&host=example.com&path=%2Ftest.txt&headers=["Foo: Bar","Beep: Boop"]'
```