### PR TITLE
Backend resource tweaks

### DIFF
--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -221,7 +221,7 @@ type UpdateBackendInput struct {
 	SSLCACert           *string      `url:"ssl_ca_cert,omitempty"`
 	SSLCertHostname     *string      `url:"ssl_cert_hostname,omitempty"`
 	SSLCheckCert        *Compatibool `url:"ssl_check_cert,omitempty"`
-	SSLCiphers          string       `url:"ssl_ciphers,omitempty"`
+	SSLCiphers          *string      `url:"ssl_ciphers,omitempty"`
 	SSLClientCert       *string      `url:"ssl_client_cert,omitempty"`
 	SSLClientKey        *string      `url:"ssl_client_key,omitempty"`
 	SSLSNIHostname      *string      `url:"ssl_sni_hostname,omitempty"`

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -12,36 +12,36 @@ type Backend struct {
 	ServiceID      string `mapstructure:"service_id"`
 	ServiceVersion int    `mapstructure:"version"`
 
-	Name                string     `mapstructure:"name"`
-	Comment             string     `mapstructure:"comment"`
 	Address             string     `mapstructure:"address"`
-	Port                uint       `mapstructure:"port"`
-	OverrideHost        string     `mapstructure:"override_host"`
+	AutoLoadbalance     bool       `mapstructure:"auto_loadbalance"`
+	BetweenBytesTimeout uint       `mapstructure:"between_bytes_timeout"`
+	Comment             string     `mapstructure:"comment"`
 	ConnectTimeout      uint       `mapstructure:"connect_timeout"`
-	MaxConn             uint       `mapstructure:"max_conn"`
+	CreatedAt           *time.Time `mapstructure:"created_at"`
+	DeletedAt           *time.Time `mapstructure:"deleted_at"`
 	ErrorThreshold      uint       `mapstructure:"error_threshold"`
 	FirstByteTimeout    uint       `mapstructure:"first_byte_timeout"`
-	BetweenBytesTimeout uint       `mapstructure:"between_bytes_timeout"`
-	AutoLoadbalance     bool       `mapstructure:"auto_loadbalance"`
-	Weight              uint       `mapstructure:"weight"`
-	RequestCondition    string     `mapstructure:"request_condition"`
 	HealthCheck         string     `mapstructure:"healthcheck"`
 	Hostname            string     `mapstructure:"hostname"`
-	Shield              string     `mapstructure:"shield"`
-	UseSSL              bool       `mapstructure:"use_ssl"`
-	SSLCheckCert        bool       `mapstructure:"ssl_check_cert"`
+	MaxConn             uint       `mapstructure:"max_conn"`
+	MaxTLSVersion       string     `mapstructure:"max_tls_version"`
+	MinTLSVersion       string     `mapstructure:"min_tls_version"`
+	Name                string     `mapstructure:"name"`
+	OverrideHost        string     `mapstructure:"override_host"`
+	Port                uint       `mapstructure:"port"`
+	RequestCondition    string     `mapstructure:"request_condition"`
 	SSLCACert           string     `mapstructure:"ssl_ca_cert"`
+	SSLCertHostname     string     `mapstructure:"ssl_cert_hostname"`
+	SSLCheckCert        bool       `mapstructure:"ssl_check_cert"`
+	SSLCiphers          string     `mapstructure:"ssl_ciphers"`
 	SSLClientCert       string     `mapstructure:"ssl_client_cert"`
 	SSLClientKey        string     `mapstructure:"ssl_client_key"`
 	SSLHostname         string     `mapstructure:"ssl_hostname"`
-	SSLCertHostname     string     `mapstructure:"ssl_cert_hostname"`
 	SSLSNIHostname      string     `mapstructure:"ssl_sni_hostname"`
-	MinTLSVersion       string     `mapstructure:"min_tls_version"`
-	MaxTLSVersion       string     `mapstructure:"max_tls_version"`
-	SSLCiphers          string     `mapstructure:"ssl_ciphers"`
-	CreatedAt           *time.Time `mapstructure:"created_at"`
+	Shield              string     `mapstructure:"shield"`
 	UpdatedAt           *time.Time `mapstructure:"updated_at"`
-	DeletedAt           *time.Time `mapstructure:"deleted_at"`
+	UseSSL              bool       `mapstructure:"use_ssl"`
+	Weight              uint       `mapstructure:"weight"`
 }
 
 // backendsByName is a sortable list of backends.

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -96,36 +96,32 @@ type CreateBackendInput struct {
 	// ServiceVersion is the specific configuration version (required).
 	ServiceVersion int
 
-	Name                string      `url:"name,omitempty"`
-	Comment             string      `url:"comment,omitempty"`
-	Address             string      `url:"address,omitempty"`
-	Port                *uint       `url:"port,omitempty"`
-	OverrideHost        string      `url:"override_host,omitempty"`
-	ConnectTimeout      *uint       `url:"connect_timeout,omitempty"`
-	MaxConn             *uint       `url:"max_conn,omitempty"`
-	ErrorThreshold      *uint       `url:"error_threshold,omitempty"`
-	FirstByteTimeout    *uint       `url:"first_byte_timeout,omitempty"`
-	BetweenBytesTimeout *uint       `url:"between_bytes_timeout,omitempty"`
-	AutoLoadbalance     Compatibool `url:"auto_loadbalance,omitempty"`
-	Weight              *uint       `url:"weight,omitempty"`
-	RequestCondition    string      `url:"request_condition,omitempty"`
-	HealthCheck         string      `url:"healthcheck,omitempty"`
-	Shield              string      `url:"shield,omitempty"`
-	UseSSL              Compatibool `url:"use_ssl,omitempty"`
-	// NOTE: Fastly API sets "ssl_check_cert" to true as its default value
-	// if this parameter is not present in the request.
-	// Removing omitempty from this particular field so that we can still
-	// create a new backend with "ssl_check_cert: false" set.
-	SSLCheckCert    Compatibool `url:"ssl_check_cert"`
-	SSLCACert       string      `url:"ssl_ca_cert,omitempty"`
-	SSLClientCert   string      `url:"ssl_client_cert,omitempty"`
-	SSLClientKey    string      `url:"ssl_client_key,omitempty"`
-	SSLHostname     string      `url:"ssl_hostname,omitempty"`
-	SSLCertHostname string      `url:"ssl_cert_hostname,omitempty"`
-	SSLSNIHostname  string      `url:"ssl_sni_hostname,omitempty"`
-	MinTLSVersion   string      `url:"min_tls_version,omitempty"`
-	MaxTLSVersion   string      `url:"max_tls_version,omitempty"`
-	SSLCiphers      string      `url:"ssl_ciphers,omitempty"`
+	Address             string       `url:"address,omitempty"`
+	AutoLoadbalance     Compatibool  `url:"auto_loadbalance,omitempty"`
+	BetweenBytesTimeout *uint        `url:"between_bytes_timeout,omitempty"`
+	Comment             string       `url:"comment,omitempty"`
+	ConnectTimeout      *uint        `url:"connect_timeout,omitempty"`
+	ErrorThreshold      *uint        `url:"error_threshold,omitempty"`
+	FirstByteTimeout    *uint        `url:"first_byte_timeout,omitempty"`
+	HealthCheck         string       `url:"healthcheck,omitempty"`
+	MaxConn             *uint        `url:"max_conn,omitempty"`
+	MaxTLSVersion       string       `url:"max_tls_version,omitempty"`
+	MinTLSVersion       string       `url:"min_tls_version,omitempty"`
+	Name                string       `url:"name,omitempty"`
+	OverrideHost        string       `url:"override_host,omitempty"`
+	Port                uint         `url:"port,omitempty"`
+	RequestCondition    string       `url:"request_condition,omitempty"`
+	SSLCACert           string       `url:"ssl_ca_cert,omitempty"`
+	SSLCertHostname     string       `url:"ssl_cert_hostname,omitempty"`
+	SSLCheckCert        *Compatibool `url:"ssl_check_cert,omitempty"`
+	SSLCiphers          string       `url:"ssl_ciphers,omitempty"`
+	SSLClientCert       string       `url:"ssl_client_cert,omitempty"`
+	SSLClientKey        string       `url:"ssl_client_key,omitempty"`
+	SSLHostname         string       `url:"ssl_hostname,omitempty"`
+	SSLSNIHostname      string       `url:"ssl_sni_hostname,omitempty"`
+	Shield              string       `url:"shield,omitempty"`
+	UseSSL              Compatibool  `url:"use_ssl,omitempty"`
+	Weight              *uint        `url:"weight,omitempty"`
 }
 
 // CreateBackend creates a new Fastly backend.

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -203,32 +203,32 @@ type UpdateBackendInput struct {
 	// Name is the name of the backend to update.
 	Name string
 
-	NewName             *string      `url:"name,omitempty"`
-	Comment             *string      `url:"comment,omitempty"`
 	Address             *string      `url:"address,omitempty"`
-	Port                *uint        `url:"port,omitempty"`
-	OverrideHost        *string      `url:"override_host,omitempty"`
+	AutoLoadbalance     *Compatibool `url:"auto_loadbalance,omitempty"`
+	BetweenBytesTimeout *uint        `url:"between_bytes_timeout,omitempty"`
+	Comment             *string      `url:"comment,omitempty"`
 	ConnectTimeout      *uint        `url:"connect_timeout,omitempty"`
-	MaxConn             *uint        `url:"max_conn,omitempty"`
 	ErrorThreshold      *uint        `url:"error_threshold,omitempty"`
 	FirstByteTimeout    *uint        `url:"first_byte_timeout,omitempty"`
-	BetweenBytesTimeout *uint        `url:"between_bytes_timeout,omitempty"`
-	AutoLoadbalance     *Compatibool `url:"auto_loadbalance,omitempty"`
-	Weight              *uint        `url:"weight,omitempty"`
-	RequestCondition    *string      `url:"request_condition,omitempty"`
 	HealthCheck         *string      `url:"healthcheck,omitempty"`
-	Shield              *string      `url:"shield,omitempty"`
-	UseSSL              *Compatibool `url:"use_ssl,omitempty"`
-	SSLCheckCert        *Compatibool `url:"ssl_check_cert,omitempty"`
+	MaxConn             *uint        `url:"max_conn,omitempty"`
+	MaxTLSVersion       *string      `url:"max_tls_version,omitempty"`
+	MinTLSVersion       *string      `url:"min_tls_version,omitempty"`
+	NewName             *string      `url:"name,omitempty"`
+	OverrideHost        *string      `url:"override_host,omitempty"`
+	Port                *uint        `url:"port,omitempty"`
+	RequestCondition    *string      `url:"request_condition,omitempty"`
 	SSLCACert           *string      `url:"ssl_ca_cert,omitempty"`
+	SSLCertHostname     *string      `url:"ssl_cert_hostname,omitempty"`
+	SSLCheckCert        *Compatibool `url:"ssl_check_cert,omitempty"`
+	SSLCiphers          string       `url:"ssl_ciphers,omitempty"`
 	SSLClientCert       *string      `url:"ssl_client_cert,omitempty"`
 	SSLClientKey        *string      `url:"ssl_client_key,omitempty"`
 	SSLHostname         *string      `url:"ssl_hostname,omitempty"`
-	SSLCertHostname     *string      `url:"ssl_cert_hostname,omitempty"`
 	SSLSNIHostname      *string      `url:"ssl_sni_hostname,omitempty"`
-	MinTLSVersion       *string      `url:"min_tls_version,omitempty"`
-	MaxTLSVersion       *string      `url:"max_tls_version,omitempty"`
-	SSLCiphers          string       `url:"ssl_ciphers,omitempty"`
+	Shield              *string      `url:"shield,omitempty"`
+	UseSSL              *Compatibool `url:"use_ssl,omitempty"`
+	Weight              *uint        `url:"weight,omitempty"`
 }
 
 // UpdateBackend updates a specific backend.

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -224,7 +224,6 @@ type UpdateBackendInput struct {
 	SSLCiphers          string       `url:"ssl_ciphers,omitempty"`
 	SSLClientCert       *string      `url:"ssl_client_cert,omitempty"`
 	SSLClientKey        *string      `url:"ssl_client_key,omitempty"`
-	SSLHostname         *string      `url:"ssl_hostname,omitempty"`
 	SSLSNIHostname      *string      `url:"ssl_sni_hostname,omitempty"`
 	Shield              *string      `url:"shield,omitempty"`
 	UseSSL              *Compatibool `url:"use_ssl,omitempty"`

--- a/fastly/backend_test.go
+++ b/fastly/backend_test.go
@@ -23,6 +23,7 @@ func TestClient_Backends(t *testing.T) {
 			Address:        "integ-test.go-fastly.com",
 			ConnectTimeout: Uint(1500),
 			OverrideHost:   "origin.example.com",
+			SSLCheckCert:   CBool(false),
 			SSLCiphers:     "DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384",
 			SSLSNIHostname: "ssl-hostname.com",
 		})
@@ -63,8 +64,8 @@ func TestClient_Backends(t *testing.T) {
 	if b.OverrideHost != "origin.example.com" {
 		t.Errorf("bad override_host: %q", b.OverrideHost)
 	}
-	if b.SSLCheckCert != true {
-		t.Errorf("bad ssl_check_cert: %t", b.SSLCheckCert) // API defaults to true
+	if b.SSLCheckCert != false {
+		t.Errorf("bad ssl_check_cert: %t", b.SSLCheckCert) // API defaults to true and we want to allow setting false
 	}
 	if b.SSLSNIHostname != "ssl-hostname.com" {
 		t.Errorf("bad ssl_sni_hostname: %q", b.SSLSNIHostname)

--- a/fastly/backend_test.go
+++ b/fastly/backend_test.go
@@ -24,6 +24,7 @@ func TestClient_Backends(t *testing.T) {
 			ConnectTimeout: Uint(1500),
 			OverrideHost:   "origin.example.com",
 			SSLCiphers:     "DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384",
+			SSLSNIHostname: "ssl-hostname.com",
 		})
 	})
 	if err != nil {
@@ -64,6 +65,9 @@ func TestClient_Backends(t *testing.T) {
 	}
 	if b.SSLCheckCert != true {
 		t.Errorf("bad ssl_check_cert: %t", b.SSLCheckCert) // API defaults to true
+	}
+	if b.SSLSNIHostname != "ssl-hostname.com" {
+		t.Errorf("bad ssl_sni_hostname: %q", b.SSLSNIHostname)
 	}
 
 	// List
@@ -121,6 +125,7 @@ func TestClient_Backends(t *testing.T) {
 			Port:           Uint(1234),
 			SSLCiphers:     String("RC4:!COMPLEMENTOFDEFAULT"),
 			SSLCheckCert:   CBool(false),
+			SSLSNIHostname: String("ssl-hostname-updated.com"),
 		})
 	})
 	if err != nil {
@@ -137,6 +142,9 @@ func TestClient_Backends(t *testing.T) {
 	}
 	if ub.SSLCheckCert != false {
 		t.Errorf("bad ssl_check_cert: %t", ub.SSLCheckCert)
+	}
+	if ub.SSLSNIHostname != "ssl-hostname-updated.com" {
+		t.Errorf("bad ssl_sni_hostname: %q", ub.SSLSNIHostname)
 	}
 
 	// NOTE: The following test validates empty values are NOT sent.

--- a/fastly/director_test.go
+++ b/fastly/director_test.go
@@ -26,7 +26,7 @@ func TestClient_Directors(t *testing.T) {
 			ServiceVersion: tv.Number,
 			Name:           "test-backend",
 			Address:        "integ-test.go-fastly.com",
-			Port:           Uint(1234),
+			Port:           1234,
 			ConnectTimeout: Uint(1500),
 			OverrideHost:   "origin.example.com",
 			SSLCiphers:     "DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384",

--- a/fastly/fixtures/backends/cleanup.yaml
+++ b/fastly/fixtures/backends/cleanup.yaml
@@ -7,12 +7,12 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/backend/test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e test-backend, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 13 }''"}'
+      version =\u003e 14 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:39 GMT
+      - Thu, 27 Oct 2022 16:42:31 GMT
       Fastly-Ratelimit-Remaining:
-      - "9926"
+      - "9993"
       Fastly-Ratelimit-Reset:
-      - "1666612800"
+      - "1666890000"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612719.921657,VS0,VE139
+      - S1666888952.761916,VS0,VE154
     status: 404 Not Found
     code: 404
     duration: ""
@@ -51,12 +51,12 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/new-test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/backend/new-test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e new-test-backend, service =\u003e
-      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 13 }''"}'
+      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 14 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -65,11 +65,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:39 GMT
+      - Thu, 27 Oct 2022 16:42:32 GMT
       Fastly-Ratelimit-Remaining:
-      - "9925"
+      - "9992"
       Fastly-Ratelimit-Reset:
-      - "1666612800"
+      - "1666890000"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -83,9 +83,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612719.085593,VS0,VE139
+      - S1666888952.002929,VS0,VE138
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/backends/cleanup.yaml
+++ b/fastly/fixtures/backends/cleanup.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/73/backend/test-backend
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e test-backend, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 73 }''"}'
+      version =\u003e 12 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:11:14 GMT
+      - Mon, 24 Oct 2022 11:38:07 GMT
       Fastly-Ratelimit-Remaining:
-      - "4995"
+      - "9934"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1666612800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
       X-Timer:
-      - S1637910674.135050,VS0,VE331
+      - S1666611487.396882,VS0,VE140
     status: 404 Not Found
     code: 404
     duration: ""
@@ -50,13 +50,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/73/backend/new-test-backend
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/new-test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e new-test-backend, service =\u003e
-      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 73 }''"}'
+      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 12 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -65,11 +65,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:11:14 GMT
+      - Mon, 24 Oct 2022 11:38:07 GMT
       Fastly-Ratelimit-Remaining:
-      - "4994"
+      - "9933"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1666612800"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -83,9 +83,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
       X-Timer:
-      - S1637910674.474800,VS0,VE243
+      - S1666611488.814707,VS0,VE148
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/backends/cleanup.yaml
+++ b/fastly/fixtures/backends/cleanup.yaml
@@ -7,12 +7,12 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e test-backend, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 12 }''"}'
+      version =\u003e 13 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,9 +21,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:07 GMT
+      - Mon, 24 Oct 2022 11:58:39 GMT
       Fastly-Ratelimit-Remaining:
-      - "9934"
+      - "9926"
       Fastly-Ratelimit-Reset:
       - "1666612800"
       Status:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611487.396882,VS0,VE140
+      - S1666612719.921657,VS0,VE139
     status: 404 Not Found
     code: 404
     duration: ""
@@ -51,12 +51,12 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/new-test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/new-test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e new-test-backend, service =\u003e
-      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 12 }''"}'
+      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 13 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -65,9 +65,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:07 GMT
+      - Mon, 24 Oct 2022 11:58:39 GMT
       Fastly-Ratelimit-Remaining:
-      - "9933"
+      - "9925"
       Fastly-Ratelimit-Reset:
       - "1666612800"
       Status:
@@ -83,9 +83,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611488.814707,VS0,VE148
+      - S1666612719.085593,VS0,VE139
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/backends/create.yaml
+++ b/fastly/fixtures/backends/create.yaml
@@ -2,12 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=73&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&port=1234&ssl_check_cert=0&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=12&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384
     form:
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "73"
+      - "12"
       address:
       - integ-test.go-fastly.com
       connect_timeout:
@@ -16,21 +16,17 @@ interactions:
       - test-backend
       override_host:
       - origin.example.com
-      port:
-      - "1234"
-      ssl_check_cert:
-      - "0"
       ssl_ciphers:
       - DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/73/backend
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend
     method: POST
   response:
-    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","port":1234,"ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":73,"created_at":"2021-11-26T07:11:11Z","ipv4":null,"deleted_at":null,"ipv6":null,"ssl_ca_cert":null,"min_tls_version":null,"ssl_hostname":null,"auto_loadbalance":false,"updated_at":"2021-11-26T07:11:11Z","ssl_sni_hostname":null,"max_conn":200,"ssl_cert_hostname":null,"shield":null,"between_bytes_timeout":10000,"error_threshold":0,"hostname":"integ-test.go-fastly.com","ssl_client_key":null,"comment":"","use_ssl":false,"weight":100,"max_tls_version":null,"first_byte_timeout":15000,"client_cert":null,"healthcheck":null,"request_condition":"","ssl_client_cert":null}'
+    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":12,"ssl_check_cert":true,"client_cert":null,"comment":"","ssl_client_cert":null,"min_tls_version":null,"use_ssl":false,"error_threshold":0,"max_tls_version":null,"updated_at":"2022-10-24T11:38:05Z","ssl_hostname":null,"request_condition":"","ipv6":null,"ssl_client_key":null,"ipv4":null,"auto_loadbalance":false,"ssl_cert_hostname":null,"between_bytes_timeout":10000,"weight":100,"first_byte_timeout":15000,"hostname":"integ-test.go-fastly.com","max_conn":200,"port":80,"ssl_sni_hostname":null,"created_at":"2022-10-24T11:38:05Z","ssl_ca_cert":null,"shield":null,"deleted_at":null,"healthcheck":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -39,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:11:12 GMT
+      - Mon, 24 Oct 2022 11:38:05 GMT
       Fastly-Ratelimit-Remaining:
-      - "4998"
+      - "9939"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1666612800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,9 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4146-MAN
       X-Timer:
-      - S1637910671.382241,VS0,VE667
+      - S1666611485.710723,VS0,VE396
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/create.yaml
+++ b/fastly/fixtures/backends/create.yaml
@@ -2,12 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=13&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384&ssl_sni_hostname=ssl-hostname.com
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=14&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&ssl_check_cert=0&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384&ssl_sni_hostname=ssl-hostname.com
     form:
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "13"
+      - "14"
       address:
       - integ-test.go-fastly.com
       connect_timeout:
@@ -16,6 +16,8 @@ interactions:
       - test-backend
       override_host:
       - origin.example.com
+      ssl_check_cert:
+      - "0"
       ssl_ciphers:
       - DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384
       ssl_sni_hostname:
@@ -25,10 +27,10 @@ interactions:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/backend
     method: POST
   response:
-    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_sni_hostname":"ssl-hostname.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":13,"min_tls_version":null,"between_bytes_timeout":10000,"weight":100,"ssl_client_key":null,"comment":"","updated_at":"2022-10-24T11:58:36Z","ipv6":null,"use_ssl":false,"auto_loadbalance":false,"ssl_hostname":null,"created_at":"2022-10-24T11:58:36Z","ssl_client_cert":null,"shield":null,"ipv4":null,"request_condition":"","max_conn":200,"ssl_ca_cert":null,"max_tls_version":null,"ssl_cert_hostname":null,"error_threshold":0,"port":80,"first_byte_timeout":15000,"hostname":"integ-test.go-fastly.com","deleted_at":null,"healthcheck":null,"ssl_check_cert":true,"client_cert":null}'
+    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_sni_hostname":"ssl-hostname.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":14,"weight":100,"max_conn":200,"ipv6":null,"error_threshold":0,"client_cert":null,"updated_at":"2022-10-27T16:42:30Z","ssl_hostname":null,"created_at":"2022-10-27T16:42:30Z","shield":null,"first_byte_timeout":15000,"auto_loadbalance":false,"ipv4":null,"deleted_at":null,"port":80,"ssl_client_key":null,"max_tls_version":null,"ssl_ca_cert":null,"min_tls_version":null,"comment":"","ssl_client_cert":null,"ssl_cert_hostname":null,"request_condition":"","between_bytes_timeout":10000,"hostname":"integ-test.go-fastly.com","healthcheck":null,"use_ssl":false}'
     headers:
       Accept-Ranges:
       - bytes
@@ -37,11 +39,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:36 GMT
+      - Thu, 27 Oct 2022 16:42:30 GMT
       Fastly-Ratelimit-Remaining:
-      - "9931"
+      - "9998"
       Fastly-Ratelimit-Reset:
-      - "1666612800"
+      - "1666890000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -55,9 +57,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612716.721195,VS0,VE397
+      - S1666888950.124702,VS0,VE213
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/create.yaml
+++ b/fastly/fixtures/backends/create.yaml
@@ -2,12 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=12&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384
+    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=13&address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384&ssl_sni_hostname=ssl-hostname.com
     form:
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "12"
+      - "13"
       address:
       - integ-test.go-fastly.com
       connect_timeout:
@@ -18,15 +18,17 @@ interactions:
       - origin.example.com
       ssl_ciphers:
       - DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384
+      ssl_sni_hostname:
+      - ssl-hostname.com
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend
     method: POST
   response:
-    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":12,"ssl_check_cert":true,"client_cert":null,"comment":"","ssl_client_cert":null,"min_tls_version":null,"use_ssl":false,"error_threshold":0,"max_tls_version":null,"updated_at":"2022-10-24T11:38:05Z","ssl_hostname":null,"request_condition":"","ipv6":null,"ssl_client_key":null,"ipv4":null,"auto_loadbalance":false,"ssl_cert_hostname":null,"between_bytes_timeout":10000,"weight":100,"first_byte_timeout":15000,"hostname":"integ-test.go-fastly.com","max_conn":200,"port":80,"ssl_sni_hostname":null,"created_at":"2022-10-24T11:38:05Z","ssl_ca_cert":null,"shield":null,"deleted_at":null,"healthcheck":null}'
+    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_sni_hostname":"ssl-hostname.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":13,"min_tls_version":null,"between_bytes_timeout":10000,"weight":100,"ssl_client_key":null,"comment":"","updated_at":"2022-10-24T11:58:36Z","ipv6":null,"use_ssl":false,"auto_loadbalance":false,"ssl_hostname":null,"created_at":"2022-10-24T11:58:36Z","ssl_client_cert":null,"shield":null,"ipv4":null,"request_condition":"","max_conn":200,"ssl_ca_cert":null,"max_tls_version":null,"ssl_cert_hostname":null,"error_threshold":0,"port":80,"first_byte_timeout":15000,"hostname":"integ-test.go-fastly.com","deleted_at":null,"healthcheck":null,"ssl_check_cert":true,"client_cert":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,9 +37,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:05 GMT
+      - Mon, 24 Oct 2022 11:58:36 GMT
       Fastly-Ratelimit-Remaining:
-      - "9939"
+      - "9931"
       Fastly-Ratelimit-Reset:
       - "1666612800"
       Status:
@@ -53,9 +55,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611485.710723,VS0,VE396
+      - S1666612716.721195,VS0,VE397
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/delete.yaml
+++ b/fastly/fixtures/backends/delete.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/new-test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/backend/new-test-backend
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:38 GMT
+      - Thu, 27 Oct 2022 16:42:31 GMT
       Fastly-Ratelimit-Remaining:
-      - "9927"
+      - "9994"
       Fastly-Ratelimit-Reset:
-      - "1666612800"
+      - "1666890000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612719.516250,VS0,VE379
+      - S1666888952.519562,VS0,VE187
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/delete.yaml
+++ b/fastly/fixtures/backends/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/73/backend/new-test-backend
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/new-test-backend
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:11:14 GMT
+      - Mon, 24 Oct 2022 11:38:07 GMT
       Fastly-Ratelimit-Remaining:
-      - "4996"
+      - "9935"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1666612800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
       X-Timer:
-      - S1637910674.763873,VS0,VE332
+      - S1666611487.962981,VS0,VE384
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/delete.yaml
+++ b/fastly/fixtures/backends/delete.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/new-test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/new-test-backend
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,9 +19,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:07 GMT
+      - Mon, 24 Oct 2022 11:58:38 GMT
       Fastly-Ratelimit-Remaining:
-      - "9935"
+      - "9927"
       Fastly-Ratelimit-Reset:
       - "1666612800"
       Status:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611487.962981,VS0,VE384
+      - S1666612719.516250,VS0,VE379
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/get.yaml
+++ b/fastly/fixtures/backends/get.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/test-backend
     method: GET
   response:
-    body: '{"auto_loadbalance":false,"ipv4":null,"ssl_client_key":null,"ipv6":null,"override_host":"origin.example.com","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","request_condition":"","service_id":"7i6HN3TK9wS159v2gPAZ8A","max_tls_version":null,"error_threshold":0,"ssl_hostname":null,"updated_at":"2022-10-24T11:38:05Z","ssl_check_cert":true,"use_ssl":false,"ssl_client_cert":null,"min_tls_version":null,"comment":"","client_cert":null,"ssl_ca_cert":null,"connect_timeout":1500,"shield":null,"created_at":"2022-10-24T11:38:05Z","healthcheck":null,"deleted_at":null,"address":"integ-test.go-fastly.com","port":80,"ssl_sni_hostname":null,"max_conn":200,"name":"test-backend","hostname":"integ-test.go-fastly.com","weight":100,"first_byte_timeout":15000,"between_bytes_timeout":10000,"ssl_cert_hostname":null,"version":12}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","port":80,"between_bytes_timeout":10000,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_cert_hostname":null,"hostname":"integ-test.go-fastly.com","error_threshold":0,"name":"test-backend","version":13,"ssl_ca_cert":null,"override_host":"origin.example.com","updated_at":"2022-10-24T11:58:36Z","max_conn":200,"use_ssl":false,"max_tls_version":null,"shield":null,"deleted_at":null,"ipv6":null,"first_byte_timeout":15000,"healthcheck":null,"auto_loadbalance":false,"ssl_client_cert":null,"address":"integ-test.go-fastly.com","ssl_sni_hostname":"ssl-hostname.com","weight":100,"min_tls_version":null,"request_condition":"","created_at":"2022-10-24T11:58:36Z","ssl_check_cert":true,"connect_timeout":1500,"ipv4":null,"client_cert":null,"comment":"","ssl_client_key":null,"ssl_hostname":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:05 GMT
+      - Mon, 24 Oct 2022 11:58:36 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-4-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611486.506292,VS0,VE314
+      - S1666612717.505436,VS0,VE311
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/get.yaml
+++ b/fastly/fixtures/backends/get.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/backend/test-backend
     method: GET
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","port":80,"between_bytes_timeout":10000,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_cert_hostname":null,"hostname":"integ-test.go-fastly.com","error_threshold":0,"name":"test-backend","version":13,"ssl_ca_cert":null,"override_host":"origin.example.com","updated_at":"2022-10-24T11:58:36Z","max_conn":200,"use_ssl":false,"max_tls_version":null,"shield":null,"deleted_at":null,"ipv6":null,"first_byte_timeout":15000,"healthcheck":null,"auto_loadbalance":false,"ssl_client_cert":null,"address":"integ-test.go-fastly.com","ssl_sni_hostname":"ssl-hostname.com","weight":100,"min_tls_version":null,"request_condition":"","created_at":"2022-10-24T11:58:36Z","ssl_check_cert":true,"connect_timeout":1500,"ipv4":null,"client_cert":null,"comment":"","ssl_client_key":null,"ssl_hostname":null}'
+    body: '{"address":"integ-test.go-fastly.com","first_byte_timeout":15000,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_ca_cert":null,"ssl_client_cert":null,"ipv6":null,"use_ssl":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","client_cert":null,"between_bytes_timeout":10000,"deleted_at":null,"created_at":"2022-10-27T16:42:30Z","port":80,"request_condition":"","ssl_sni_hostname":"ssl-hostname.com","max_tls_version":null,"weight":100,"ssl_cert_hostname":null,"max_conn":200,"comment":"","auto_loadbalance":false,"connect_timeout":1500,"min_tls_version":null,"ssl_hostname":null,"hostname":"integ-test.go-fastly.com","name":"test-backend","version":14,"ipv4":null,"error_threshold":0,"ssl_check_cert":false,"ssl_client_key":null,"override_host":"origin.example.com","updated_at":"2022-10-27T16:42:30Z","healthcheck":null,"shield":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:36 GMT
+      - Thu, 27 Oct 2022 16:42:30 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-4-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612717.505436,VS0,VE311
+      - S1666888951.578124,VS0,VE145
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/get.yaml
+++ b/fastly/fixtures/backends/get.yaml
@@ -6,20 +6,20 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/73/backend/test-backend
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/test-backend
     method: GET
   response:
-    body: '{"ipv4":null,"ssl_hostname":null,"between_bytes_timeout":10000,"connect_timeout":1500,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","first_byte_timeout":15000,"max_tls_version":null,"auto_loadbalance":false,"ssl_client_cert":null,"weight":100,"request_condition":"","shield":null,"name":"test-backend","ssl_check_cert":false,"override_host":"origin.example.com","ssl_client_key":null,"deleted_at":null,"port":1234,"healthcheck":null,"created_at":"2021-11-26T07:11:11Z","updated_at":"2021-11-26T07:11:11Z","ipv6":null,"address":"integ-test.go-fastly.com","client_cert":null,"use_ssl":false,"hostname":"integ-test.go-fastly.com","max_conn":200,"min_tls_version":null,"ssl_cert_hostname":null,"ssl_ca_cert":null,"comment":"","ssl_sni_hostname":null,"version":73,"error_threshold":0,"service_id":"7i6HN3TK9wS159v2gPAZ8A"}'
+    body: '{"auto_loadbalance":false,"ipv4":null,"ssl_client_key":null,"ipv6":null,"override_host":"origin.example.com","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","request_condition":"","service_id":"7i6HN3TK9wS159v2gPAZ8A","max_tls_version":null,"error_threshold":0,"ssl_hostname":null,"updated_at":"2022-10-24T11:38:05Z","ssl_check_cert":true,"use_ssl":false,"ssl_client_cert":null,"min_tls_version":null,"comment":"","client_cert":null,"ssl_ca_cert":null,"connect_timeout":1500,"shield":null,"created_at":"2022-10-24T11:38:05Z","healthcheck":null,"deleted_at":null,"address":"integ-test.go-fastly.com","port":80,"ssl_sni_hostname":null,"max_conn":200,"name":"test-backend","hostname":"integ-test.go-fastly.com","weight":100,"first_byte_timeout":15000,"between_bytes_timeout":10000,"ssl_cert_hostname":null,"version":12}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-store, s-maxage=0
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:11:13 GMT
+      - Mon, 24 Oct 2022 11:38:05 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -27,15 +27,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish, 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS, MISS, MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - 0, 0, 0
+      - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-tyo11967-TYO, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
       X-Timer:
-      - S1637910673.521191,VS0,VE885
+      - S1666611486.506292,VS0,VE314
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/list.yaml
+++ b/fastly/fixtures/backends/list.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/73/backend
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend
     method: GET
   response:
-    body: '[{"first_byte_timeout":15000,"name":"test-backend","comment":"","override_host":"origin.example.com","updated_at":"2021-11-26T07:11:11Z","weight":100,"ipv6":null,"ssl_client_key":null,"ssl_sni_hostname":null,"created_at":"2021-11-26T07:11:11Z","ssl_client_cert":null,"use_ssl":false,"version":73,"ipv4":null,"address":"integ-test.go-fastly.com","between_bytes_timeout":10000,"hostname":"integ-test.go-fastly.com","request_condition":"","deleted_at":null,"max_tls_version":null,"client_cert":null,"min_tls_version":null,"auto_loadbalance":false,"port":1234,"ssl_cert_hostname":null,"shield":null,"ssl_ca_cert":null,"error_threshold":0,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","healthcheck":null,"ssl_check_cert":false,"connect_timeout":1500,"service_id":"7i6HN3TK9wS159v2gPAZ8A","max_conn":200,"ssl_hostname":null}]'
+    body: '[{"ipv6":null,"shield":null,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_cert_hostname":null,"ssl_sni_hostname":null,"use_ssl":false,"ssl_client_key":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","hostname":"integ-test.go-fastly.com","ipv4":null,"between_bytes_timeout":10000,"min_tls_version":null,"error_threshold":0,"first_byte_timeout":15000,"name":"test-backend","ssl_ca_cert":null,"client_cert":null,"comment":"","ssl_check_cert":true,"override_host":"origin.example.com","deleted_at":null,"connect_timeout":1500,"updated_at":"2022-10-24T11:38:05Z","healthcheck":null,"address":"integ-test.go-fastly.com","request_condition":"","max_tls_version":null,"ssl_client_cert":null,"created_at":"2022-10-24T11:38:05Z","weight":100,"ssl_hostname":null,"max_conn":200,"port":80,"auto_loadbalance":false,"version":12}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:11:12 GMT
+      - Mon, 24 Oct 2022 11:38:05 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4146-MAN
       X-Timer:
-      - S1637910672.081048,VS0,VE355
+      - S1666611485.133574,VS0,VE340
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/list.yaml
+++ b/fastly/fixtures/backends/list.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend
     method: GET
   response:
-    body: '[{"ipv6":null,"shield":null,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_cert_hostname":null,"ssl_sni_hostname":null,"use_ssl":false,"ssl_client_key":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","hostname":"integ-test.go-fastly.com","ipv4":null,"between_bytes_timeout":10000,"min_tls_version":null,"error_threshold":0,"first_byte_timeout":15000,"name":"test-backend","ssl_ca_cert":null,"client_cert":null,"comment":"","ssl_check_cert":true,"override_host":"origin.example.com","deleted_at":null,"connect_timeout":1500,"updated_at":"2022-10-24T11:38:05Z","healthcheck":null,"address":"integ-test.go-fastly.com","request_condition":"","max_tls_version":null,"ssl_client_cert":null,"created_at":"2022-10-24T11:38:05Z","weight":100,"ssl_hostname":null,"max_conn":200,"port":80,"auto_loadbalance":false,"version":12}]'
+    body: '[{"name":"test-backend","ssl_ca_cert":null,"first_byte_timeout":15000,"error_threshold":0,"updated_at":"2022-10-24T11:58:36Z","connect_timeout":1500,"deleted_at":null,"override_host":"origin.example.com","ssl_check_cert":true,"comment":"","client_cert":null,"request_condition":"","address":"integ-test.go-fastly.com","healthcheck":null,"version":13,"auto_loadbalance":false,"max_conn":200,"ssl_hostname":null,"port":80,"weight":100,"created_at":"2022-10-24T11:58:36Z","ssl_client_cert":null,"max_tls_version":null,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","shield":null,"ipv6":null,"use_ssl":false,"ssl_sni_hostname":"ssl-hostname.com","ssl_cert_hostname":null,"ssl_client_key":null,"min_tls_version":null,"between_bytes_timeout":10000,"ipv4":null,"hostname":"integ-test.go-fastly.com","service_id":"7i6HN3TK9wS159v2gPAZ8A"}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:05 GMT
+      - Mon, 24 Oct 2022 11:58:36 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611485.133574,VS0,VE340
+      - S1666612716.146406,VS0,VE326
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/list.yaml
+++ b/fastly/fixtures/backends/list.yaml
@@ -7,10 +7,10 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/backend
     method: GET
   response:
-    body: '[{"name":"test-backend","ssl_ca_cert":null,"first_byte_timeout":15000,"error_threshold":0,"updated_at":"2022-10-24T11:58:36Z","connect_timeout":1500,"deleted_at":null,"override_host":"origin.example.com","ssl_check_cert":true,"comment":"","client_cert":null,"request_condition":"","address":"integ-test.go-fastly.com","healthcheck":null,"version":13,"auto_loadbalance":false,"max_conn":200,"ssl_hostname":null,"port":80,"weight":100,"created_at":"2022-10-24T11:58:36Z","ssl_client_cert":null,"max_tls_version":null,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","shield":null,"ipv6":null,"use_ssl":false,"ssl_sni_hostname":"ssl-hostname.com","ssl_cert_hostname":null,"ssl_client_key":null,"min_tls_version":null,"between_bytes_timeout":10000,"ipv4":null,"hostname":"integ-test.go-fastly.com","service_id":"7i6HN3TK9wS159v2gPAZ8A"}]'
+    body: '[{"hostname":"integ-test.go-fastly.com","name":"test-backend","use_ssl":false,"healthcheck":null,"between_bytes_timeout":10000,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","comment":"","ssl_ca_cert":null,"min_tls_version":null,"connect_timeout":1500,"request_condition":"","ssl_cert_hostname":null,"ssl_client_cert":null,"port":80,"ipv4":null,"deleted_at":null,"max_tls_version":null,"ssl_client_key":null,"ssl_sni_hostname":"ssl-hostname.com","version":14,"auto_loadbalance":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","first_byte_timeout":15000,"ssl_check_cert":false,"shield":null,"created_at":"2022-10-27T16:42:30Z","ssl_hostname":null,"override_host":"origin.example.com","address":"integ-test.go-fastly.com","updated_at":"2022-10-27T16:42:30Z","client_cert":null,"ipv6":null,"error_threshold":0,"max_conn":200,"weight":100}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:36 GMT
+      - Thu, 27 Oct 2022 16:42:30 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612716.146406,VS0,VE326
+      - S1666888950.374709,VS0,VE166
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update.yaml
+++ b/fastly/fixtures/backends/update.yaml
@@ -2,29 +2,33 @@
 version: 1
 interactions:
 - request:
-    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=73&name=new-test-backend&override_host=www.example.com&ssl_ciphers=RC4%3A%21COMPLEMENTOFDEFAULT
+    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=12&name=new-test-backend&override_host=www.example.com&port=1234&ssl_check_cert=0&ssl_ciphers=RC4%3A%21COMPLEMENTOFDEFAULT
     form:
       Name:
       - test-backend
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "73"
+      - "12"
       name:
       - new-test-backend
       override_host:
       - www.example.com
+      port:
+      - "1234"
+      ssl_check_cert:
+      - "0"
       ssl_ciphers:
       - RC4:!COMPLEMENTOFDEFAULT
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/73/backend/test-backend
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/test-backend
     method: PUT
   response:
-    body: '{"ssl_sni_hostname":null,"version":73,"service_id":"7i6HN3TK9wS159v2gPAZ8A","error_threshold":0,"updated_at":"2021-11-26T07:11:11Z","ipv6":null,"address":"integ-test.go-fastly.com","client_cert":null,"use_ssl":false,"hostname":"integ-test.go-fastly.com","max_conn":200,"min_tls_version":null,"ssl_cert_hostname":null,"ssl_ca_cert":null,"comment":"","shield":null,"name":"new-test-backend","ssl_check_cert":false,"override_host":"www.example.com","ssl_client_key":null,"deleted_at":null,"healthcheck":null,"port":1234,"created_at":"2021-11-26T07:11:11Z","ipv4":null,"ssl_hostname":null,"between_bytes_timeout":10000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","connect_timeout":1500,"first_byte_timeout":15000,"auto_loadbalance":false,"max_tls_version":null,"request_condition":"","weight":100,"ssl_client_cert":null}'
+    body: '{"max_conn":200,"weight":100,"ssl_hostname":null,"client_cert":null,"ipv6":null,"error_threshold":0,"override_host":"www.example.com","address":"integ-test.go-fastly.com","updated_at":"2022-10-24T11:38:05Z","auto_loadbalance":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_sni_hostname":null,"version":12,"shield":null,"created_at":"2022-10-24T11:38:05Z","first_byte_timeout":15000,"ssl_check_cert":false,"between_bytes_timeout":10000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","hostname":"integ-test.go-fastly.com","name":"new-test-backend","use_ssl":false,"healthcheck":null,"port":1234,"ipv4":null,"deleted_at":null,"ssl_client_key":null,"max_tls_version":null,"comment":"","connect_timeout":1500,"min_tls_version":null,"ssl_ca_cert":null,"request_condition":"","ssl_client_cert":null,"ssl_cert_hostname":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -33,11 +37,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:11:13 GMT
+      - Mon, 24 Oct 2022 11:38:06 GMT
       Fastly-Ratelimit-Remaining:
-      - "4997"
+      - "9938"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1666612800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -51,9 +55,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4146-MAN
       X-Timer:
-      - S1637910673.417876,VS0,VE334
+      - S1666611486.861388,VS0,VE226
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update.yaml
+++ b/fastly/fixtures/backends/update.yaml
@@ -2,14 +2,14 @@
 version: 1
 interactions:
 - request:
-    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=13&name=new-test-backend&override_host=www.example.com&port=1234&ssl_check_cert=0&ssl_ciphers=RC4%3A%21COMPLEMENTOFDEFAULT&ssl_sni_hostname=ssl-hostname-updated.com
+    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=14&name=new-test-backend&override_host=www.example.com&port=1234&ssl_check_cert=0&ssl_ciphers=RC4%3A%21COMPLEMENTOFDEFAULT&ssl_sni_hostname=ssl-hostname-updated.com
     form:
       Name:
       - test-backend
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "13"
+      - "14"
       name:
       - new-test-backend
       override_host:
@@ -27,10 +27,10 @@ interactions:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/backend/test-backend
     method: PUT
   response:
-    body: '{"ssl_cert_hostname":null,"between_bytes_timeout":10000,"weight":100,"first_byte_timeout":15000,"version":13,"max_conn":200,"hostname":"integ-test.go-fastly.com","name":"new-test-backend","address":"integ-test.go-fastly.com","port":1234,"ssl_sni_hostname":"ssl-hostname-updated.com","created_at":"2022-10-24T11:58:36Z","ssl_ca_cert":null,"connect_timeout":1500,"shield":null,"healthcheck":null,"deleted_at":null,"ssl_check_cert":false,"client_cert":null,"ssl_client_cert":null,"comment":"","min_tls_version":null,"use_ssl":false,"error_threshold":0,"max_tls_version":null,"updated_at":"2022-10-24T11:58:36Z","ssl_hostname":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","request_condition":"","ipv6":null,"ssl_client_key":null,"auto_loadbalance":false,"ipv4":null,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","override_host":"www.example.com"}'
+    body: '{"between_bytes_timeout":10000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","hostname":"integ-test.go-fastly.com","name":"new-test-backend","use_ssl":false,"healthcheck":null,"port":1234,"ipv4":null,"deleted_at":null,"max_tls_version":null,"ssl_client_key":null,"comment":"","ssl_ca_cert":null,"connect_timeout":1500,"min_tls_version":null,"request_condition":"","ssl_client_cert":null,"ssl_cert_hostname":null,"auto_loadbalance":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_sni_hostname":"ssl-hostname-updated.com","version":14,"shield":null,"created_at":"2022-10-27T16:42:30Z","first_byte_timeout":15000,"ssl_check_cert":false,"ssl_hostname":null,"client_cert":null,"error_threshold":0,"ipv6":null,"override_host":"www.example.com","address":"integ-test.go-fastly.com","updated_at":"2022-10-27T16:42:30Z","max_conn":200,"weight":100}'
     headers:
       Accept-Ranges:
       - bytes
@@ -39,11 +39,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:37 GMT
+      - Thu, 27 Oct 2022 16:42:30 GMT
       Fastly-Ratelimit-Remaining:
-      - "9930"
+      - "9997"
       Fastly-Ratelimit-Reset:
-      - "1666612800"
+      - "1666890000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,9 +57,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612717.845030,VS0,VE402
+      - S1666888951.754248,VS0,VE197
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update.yaml
+++ b/fastly/fixtures/backends/update.yaml
@@ -2,14 +2,14 @@
 version: 1
 interactions:
 - request:
-    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=12&name=new-test-backend&override_host=www.example.com&port=1234&ssl_check_cert=0&ssl_ciphers=RC4%3A%21COMPLEMENTOFDEFAULT
+    body: Name=test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=13&name=new-test-backend&override_host=www.example.com&port=1234&ssl_check_cert=0&ssl_ciphers=RC4%3A%21COMPLEMENTOFDEFAULT&ssl_sni_hostname=ssl-hostname-updated.com
     form:
       Name:
       - test-backend
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "12"
+      - "13"
       name:
       - new-test-backend
       override_host:
@@ -20,15 +20,17 @@ interactions:
       - "0"
       ssl_ciphers:
       - RC4:!COMPLEMENTOFDEFAULT
+      ssl_sni_hostname:
+      - ssl-hostname-updated.com
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/test-backend
     method: PUT
   response:
-    body: '{"max_conn":200,"weight":100,"ssl_hostname":null,"client_cert":null,"ipv6":null,"error_threshold":0,"override_host":"www.example.com","address":"integ-test.go-fastly.com","updated_at":"2022-10-24T11:38:05Z","auto_loadbalance":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_sni_hostname":null,"version":12,"shield":null,"created_at":"2022-10-24T11:38:05Z","first_byte_timeout":15000,"ssl_check_cert":false,"between_bytes_timeout":10000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","hostname":"integ-test.go-fastly.com","name":"new-test-backend","use_ssl":false,"healthcheck":null,"port":1234,"ipv4":null,"deleted_at":null,"ssl_client_key":null,"max_tls_version":null,"comment":"","connect_timeout":1500,"min_tls_version":null,"ssl_ca_cert":null,"request_condition":"","ssl_client_cert":null,"ssl_cert_hostname":null}'
+    body: '{"ssl_cert_hostname":null,"between_bytes_timeout":10000,"weight":100,"first_byte_timeout":15000,"version":13,"max_conn":200,"hostname":"integ-test.go-fastly.com","name":"new-test-backend","address":"integ-test.go-fastly.com","port":1234,"ssl_sni_hostname":"ssl-hostname-updated.com","created_at":"2022-10-24T11:58:36Z","ssl_ca_cert":null,"connect_timeout":1500,"shield":null,"healthcheck":null,"deleted_at":null,"ssl_check_cert":false,"client_cert":null,"ssl_client_cert":null,"comment":"","min_tls_version":null,"use_ssl":false,"error_threshold":0,"max_tls_version":null,"updated_at":"2022-10-24T11:58:36Z","ssl_hostname":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","request_condition":"","ipv6":null,"ssl_client_key":null,"auto_loadbalance":false,"ipv4":null,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","override_host":"www.example.com"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -37,9 +39,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:06 GMT
+      - Mon, 24 Oct 2022 11:58:37 GMT
       Fastly-Ratelimit-Remaining:
-      - "9938"
+      - "9930"
       Fastly-Ratelimit-Reset:
       - "1666612800"
       Status:
@@ -55,9 +57,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611486.861388,VS0,VE226
+      - S1666612717.845030,VS0,VE402
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update_allow_empty_values.yaml
+++ b/fastly/fixtures/backends/update_allow_empty_values.yaml
@@ -2,14 +2,14 @@
 version: 1
 interactions:
 - request:
-    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=13&override_host=&port=0
+    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=14&override_host=&port=0
     form:
       Name:
       - new-test-backend
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "13"
+      - "14"
       override_host:
       - ""
       port:
@@ -19,10 +19,10 @@ interactions:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/new-test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/backend/new-test-backend
     method: PUT
   response:
-    body: '{"override_host":null,"address":"integ-test.go-fastly.com","updated_at":"2022-10-24T11:58:37Z","client_cert":null,"error_threshold":0,"ipv6":null,"ssl_hostname":null,"weight":100,"max_conn":200,"comment":"","ssl_ca_cert":null,"min_tls_version":null,"connect_timeout":1500,"request_condition":"","ssl_client_cert":null,"ssl_cert_hostname":null,"port":0,"ipv4":null,"deleted_at":null,"max_tls_version":null,"ssl_client_key":null,"hostname":"integ-test.go-fastly.com","name":"new-test-backend","use_ssl":false,"healthcheck":null,"between_bytes_timeout":10000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","first_byte_timeout":15000,"ssl_check_cert":false,"created_at":"2022-10-24T11:58:36Z","shield":null,"ssl_sni_hostname":"ssl-hostname-updated.com","version":13,"auto_loadbalance":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A"}'
+    body: '{"first_byte_timeout":15000,"address":"integ-test.go-fastly.com","ssl_client_cert":null,"ssl_ca_cert":null,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","service_id":"7i6HN3TK9wS159v2gPAZ8A","client_cert":null,"ipv6":null,"use_ssl":false,"created_at":"2022-10-27T16:42:30Z","deleted_at":null,"between_bytes_timeout":10000,"ssl_sni_hostname":"ssl-hostname-updated.com","port":0,"request_condition":"","weight":100,"ssl_cert_hostname":null,"max_tls_version":null,"comment":"","max_conn":200,"auto_loadbalance":false,"connect_timeout":1500,"min_tls_version":null,"ssl_hostname":null,"hostname":"integ-test.go-fastly.com","name":"new-test-backend","version":14,"ipv4":null,"ssl_client_key":null,"error_threshold":0,"ssl_check_cert":false,"override_host":null,"updated_at":"2022-10-27T16:42:30Z","healthcheck":null,"shield":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -31,11 +31,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:38 GMT
+      - Thu, 27 Oct 2022 16:42:31 GMT
       Fastly-Ratelimit-Remaining:
-      - "9928"
+      - "9995"
       Fastly-Ratelimit-Reset:
-      - "1666612800"
+      - "1666890000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +49,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612718.990897,VS0,VE222
+      - S1666888951.267177,VS0,VE224
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update_allow_empty_values.yaml
+++ b/fastly/fixtures/backends/update_allow_empty_values.yaml
@@ -2,14 +2,14 @@
 version: 1
 interactions:
 - request:
-    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=12&override_host=&port=0
+    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=13&override_host=&port=0
     form:
       Name:
       - new-test-backend
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "12"
+      - "13"
       override_host:
       - ""
       port:
@@ -19,10 +19,10 @@ interactions:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/new-test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/new-test-backend
     method: PUT
   response:
-    body: '{"healthcheck":null,"address":"integ-test.go-fastly.com","request_condition":"","auto_loadbalance":false,"version":12,"created_at":"2022-10-24T11:38:05Z","weight":100,"max_conn":200,"port":0,"ssl_hostname":null,"ssl_client_cert":null,"max_tls_version":null,"name":"new-test-backend","ssl_ca_cert":null,"first_byte_timeout":15000,"error_threshold":0,"updated_at":"2022-10-24T11:38:05Z","override_host":null,"deleted_at":null,"connect_timeout":1500,"comment":"","ssl_check_cert":false,"client_cert":null,"ssl_client_key":null,"between_bytes_timeout":10000,"min_tls_version":null,"hostname":"integ-test.go-fastly.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","ipv4":null,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","ipv6":null,"shield":null,"use_ssl":false,"ssl_sni_hostname":null,"ssl_cert_hostname":null}'
+    body: '{"override_host":null,"address":"integ-test.go-fastly.com","updated_at":"2022-10-24T11:58:37Z","client_cert":null,"error_threshold":0,"ipv6":null,"ssl_hostname":null,"weight":100,"max_conn":200,"comment":"","ssl_ca_cert":null,"min_tls_version":null,"connect_timeout":1500,"request_condition":"","ssl_client_cert":null,"ssl_cert_hostname":null,"port":0,"ipv4":null,"deleted_at":null,"max_tls_version":null,"ssl_client_key":null,"hostname":"integ-test.go-fastly.com","name":"new-test-backend","use_ssl":false,"healthcheck":null,"between_bytes_timeout":10000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","first_byte_timeout":15000,"ssl_check_cert":false,"created_at":"2022-10-24T11:58:36Z","shield":null,"ssl_sni_hostname":"ssl-hostname-updated.com","version":13,"auto_loadbalance":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -31,9 +31,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:06 GMT
+      - Mon, 24 Oct 2022 11:58:38 GMT
       Fastly-Ratelimit-Remaining:
-      - "9936"
+      - "9928"
       Fastly-Ratelimit-Reset:
       - "1666612800"
       Status:
@@ -49,9 +49,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611487.563762,VS0,VE370
+      - S1666612718.990897,VS0,VE222
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update_allow_empty_values.yaml
+++ b/fastly/fixtures/backends/update_allow_empty_values.yaml
@@ -1,0 +1,57 @@
+---
+version: 1
+interactions:
+- request:
+    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=12&override_host=&port=0
+    form:
+      Name:
+      - new-test-backend
+      ServiceID:
+      - 7i6HN3TK9wS159v2gPAZ8A
+      ServiceVersion:
+      - "12"
+      override_host:
+      - ""
+      port:
+      - "0"
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/new-test-backend
+    method: PUT
+  response:
+    body: '{"healthcheck":null,"address":"integ-test.go-fastly.com","request_condition":"","auto_loadbalance":false,"version":12,"created_at":"2022-10-24T11:38:05Z","weight":100,"max_conn":200,"port":0,"ssl_hostname":null,"ssl_client_cert":null,"max_tls_version":null,"name":"new-test-backend","ssl_ca_cert":null,"first_byte_timeout":15000,"error_threshold":0,"updated_at":"2022-10-24T11:38:05Z","override_host":null,"deleted_at":null,"connect_timeout":1500,"comment":"","ssl_check_cert":false,"client_cert":null,"ssl_client_key":null,"between_bytes_timeout":10000,"min_tls_version":null,"hostname":"integ-test.go-fastly.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","ipv4":null,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","ipv6":null,"shield":null,"use_ssl":false,"ssl_sni_hostname":null,"ssl_cert_hostname":null}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 24 Oct 2022 11:38:06 GMT
+      Fastly-Ratelimit-Remaining:
+      - "9936"
+      Fastly-Ratelimit-Reset:
+      - "1666612800"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4146-MAN
+      X-Timer:
+      - S1666611487.563762,VS0,VE370
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/backends/update_ignore_empty_values.yaml
+++ b/fastly/fixtures/backends/update_ignore_empty_values.yaml
@@ -1,0 +1,53 @@
+---
+version: 1
+interactions:
+- request:
+    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=12
+    form:
+      Name:
+      - new-test-backend
+      ServiceID:
+      - 7i6HN3TK9wS159v2gPAZ8A
+      ServiceVersion:
+      - "12"
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/new-test-backend
+    method: PUT
+  response:
+    body: '{"created_at":"2022-10-24T11:38:05Z","shield":null,"first_byte_timeout":15000,"ssl_check_cert":false,"auto_loadbalance":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_sni_hostname":null,"version":12,"port":1234,"ipv4":null,"deleted_at":null,"max_tls_version":null,"ssl_client_key":null,"comment":"","min_tls_version":null,"connect_timeout":1500,"ssl_ca_cert":null,"request_condition":"","ssl_cert_hostname":null,"ssl_client_cert":null,"between_bytes_timeout":10000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","name":"new-test-backend","hostname":"integ-test.go-fastly.com","use_ssl":false,"healthcheck":null,"weight":100,"max_conn":200,"client_cert":null,"ipv6":null,"error_threshold":0,"address":"integ-test.go-fastly.com","override_host":"www.example.com","updated_at":"2022-10-24T11:38:05Z","ssl_hostname":null}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 24 Oct 2022 11:38:06 GMT
+      Fastly-Ratelimit-Remaining:
+      - "9937"
+      Fastly-Ratelimit-Reset:
+      - "1666612800"
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
+      X-Timer:
+      - S1666611486.138761,VS0,VE396
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/backends/update_ignore_empty_values.yaml
+++ b/fastly/fixtures/backends/update_ignore_empty_values.yaml
@@ -2,23 +2,23 @@
 version: 1
 interactions:
 - request:
-    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=12
+    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=13
     form:
       Name:
       - new-test-backend
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "12"
+      - "13"
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/12/backend/new-test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/new-test-backend
     method: PUT
   response:
-    body: '{"created_at":"2022-10-24T11:38:05Z","shield":null,"first_byte_timeout":15000,"ssl_check_cert":false,"auto_loadbalance":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_sni_hostname":null,"version":12,"port":1234,"ipv4":null,"deleted_at":null,"max_tls_version":null,"ssl_client_key":null,"comment":"","min_tls_version":null,"connect_timeout":1500,"ssl_ca_cert":null,"request_condition":"","ssl_cert_hostname":null,"ssl_client_cert":null,"between_bytes_timeout":10000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","name":"new-test-backend","hostname":"integ-test.go-fastly.com","use_ssl":false,"healthcheck":null,"weight":100,"max_conn":200,"client_cert":null,"ipv6":null,"error_threshold":0,"address":"integ-test.go-fastly.com","override_host":"www.example.com","updated_at":"2022-10-24T11:38:05Z","ssl_hostname":null}'
+    body: '{"weight":100,"ssl_cert_hostname":null,"max_tls_version":null,"ssl_sni_hostname":"ssl-hostname-updated.com","port":1234,"request_condition":"","auto_loadbalance":false,"connect_timeout":1500,"comment":"","max_conn":200,"ssl_client_cert":null,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","ssl_ca_cert":null,"first_byte_timeout":15000,"address":"integ-test.go-fastly.com","created_at":"2022-10-24T11:58:36Z","between_bytes_timeout":10000,"deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","client_cert":null,"ipv6":null,"use_ssl":false,"ssl_client_key":null,"error_threshold":0,"ssl_check_cert":false,"ipv4":null,"shield":null,"updated_at":"2022-10-24T11:58:37Z","override_host":"www.example.com","healthcheck":null,"min_tls_version":null,"name":"new-test-backend","version":13,"ssl_hostname":null,"hostname":"integ-test.go-fastly.com"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -27,9 +27,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:06 GMT
+      - Mon, 24 Oct 2022 11:58:37 GMT
       Fastly-Ratelimit-Remaining:
-      - "9937"
+      - "9929"
       Fastly-Ratelimit-Reset:
       - "1666612800"
       Status:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611486.138761,VS0,VE396
+      - S1666612717.277051,VS0,VE375
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update_ignore_empty_values.yaml
+++ b/fastly/fixtures/backends/update_ignore_empty_values.yaml
@@ -2,23 +2,23 @@
 version: 1
 interactions:
 - request:
-    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=13
+    body: Name=new-test-backend&ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=14
     form:
       Name:
       - new-test-backend
       ServiceID:
       - 7i6HN3TK9wS159v2gPAZ8A
       ServiceVersion:
-      - "13"
+      - "14"
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
       - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/13/backend/new-test-backend
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/14/backend/new-test-backend
     method: PUT
   response:
-    body: '{"weight":100,"ssl_cert_hostname":null,"max_tls_version":null,"ssl_sni_hostname":"ssl-hostname-updated.com","port":1234,"request_condition":"","auto_loadbalance":false,"connect_timeout":1500,"comment":"","max_conn":200,"ssl_client_cert":null,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","ssl_ca_cert":null,"first_byte_timeout":15000,"address":"integ-test.go-fastly.com","created_at":"2022-10-24T11:58:36Z","between_bytes_timeout":10000,"deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","client_cert":null,"ipv6":null,"use_ssl":false,"ssl_client_key":null,"error_threshold":0,"ssl_check_cert":false,"ipv4":null,"shield":null,"updated_at":"2022-10-24T11:58:37Z","override_host":"www.example.com","healthcheck":null,"min_tls_version":null,"name":"new-test-backend","version":13,"ssl_hostname":null,"hostname":"integ-test.go-fastly.com"}'
+    body: '{"ssl_cert_hostname":null,"name":"new-test-backend","client_cert":null,"port":1234,"version":14,"max_conn":200,"ssl_client_cert":null,"updated_at":"2022-10-27T16:42:30Z","request_condition":"","address":"integ-test.go-fastly.com","auto_loadbalance":false,"min_tls_version":null,"shield":null,"ssl_client_key":null,"ssl_sni_hostname":"ssl-hostname-updated.com","ssl_hostname":null,"error_threshold":0,"healthcheck":null,"comment":"","deleted_at":null,"ipv4":null,"first_byte_timeout":15000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","between_bytes_timeout":10000,"max_tls_version":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ipv6":null,"weight":100,"created_at":"2022-10-27T16:42:30Z","hostname":"integ-test.go-fastly.com","ssl_check_cert":false,"connect_timeout":1500,"ssl_ca_cert":null,"override_host":"www.example.com","use_ssl":false}'
     headers:
       Accept-Ranges:
       - bytes
@@ -27,11 +27,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:37 GMT
+      - Thu, 27 Oct 2022 16:42:31 GMT
       Fastly-Ratelimit-Remaining:
-      - "9929"
+      - "9996"
       Fastly-Ratelimit-Reset:
-      - "1666612800"
+      - "1666890000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612717.277051,VS0,VE375
+      - S1666888951.051715,VS0,VE190
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/version.yaml
+++ b/fastly/fixtures/backends/version.yaml
@@ -10,11 +10,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/5.1.2 (+github.com/fastly/go-fastly; go1.17.3)
+      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":73}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":12}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +23,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Nov 2021 07:11:11 GMT
+      - Mon, 24 Oct 2022 11:38:04 GMT
       Fastly-Ratelimit-Remaining:
-      - "4999"
+      - "9940"
       Fastly-Ratelimit-Reset:
-      - "1637913600"
+      - "1666612800"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-tyo11949-TYO
+      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
       X-Timer:
-      - S1637910671.922519,VS0,VE453
+      - S1666611484.310831,VS0,VE373
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/version.yaml
+++ b/fastly/fixtures/backends/version.yaml
@@ -14,7 +14,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":13}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":14}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +23,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:58:35 GMT
+      - Thu, 27 Oct 2022 16:42:30 GMT
       Fastly-Ratelimit-Remaining:
-      - "9932"
+      - "9999"
       Fastly-Ratelimit-Reset:
-      - "1666612800"
+      - "1666890000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4133-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-man4132-MAN
       X-Timer:
-      - S1666612715.288705,VS0,VE403
+      - S1666888950.671453,VS0,VE420
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/version.yaml
+++ b/fastly/fixtures/backends/version.yaml
@@ -14,7 +14,7 @@ interactions:
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":12}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":13}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,9 +23,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 Oct 2022 11:38:04 GMT
+      - Mon, 24 Oct 2022 11:58:35 GMT
       Fastly-Ratelimit-Remaining:
-      - "9940"
+      - "9932"
       Fastly-Ratelimit-Reset:
       - "1666612800"
       Status:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4146-MAN
+      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4133-MAN
       X-Timer:
-      - S1666611484.310831,VS0,VE373
+      - S1666612715.288705,VS0,VE403
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
Issue https://github.com/fastly/go-fastly/issues/371 suggests setting `override_host` to an empty value is not updating the field. The existing test suite demonstrates that `override_host` can be overridden, and additional testing has shown that the field can be updated with a zero value if required.

This PR makes some amendments to the test suite, and also implements a breaking-change by modifying the input type of the port field.

## NOTES

To summarise the pre-existing implementation details...

If a struct field isn't populated, and is marshalled to JSON, then the field's zero value will be used (e.g. type string zero value == "", type int zero value == 0, etc).

You can use `omitempty` to prevent the field from being marshalled, but then you won't know if the zero value was intentional or not (e.g. a user might _want_ to set an type int field to zero or a type string field to an empty string).

To avoid that situation you need to have the field be set to a _pointer_ of the type. This is because the zero value for a pointer is `nil`. This means if the field is `nil` then the field was never set and won't be marshalled, but if the pointer points to a value, then we know it was set to the zero value intentionally.

> Reference: https://willnorris.com/2014/05/go-rest-apis-and-pointers/