### PR TITLE
fastly: fix invalid package uploading test

### DIFF
--- a/fastly/fixtures/package/get.yaml
+++ b/fastly/fixtures/package/get.yaml
@@ -6,21 +6,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/package
+      - FastlyGo/7.0.0 (+github.com/fastly/go-fastly; go1.18.3)
+    url: https://api.fastly.com/service/I1VEQVKrgJFQszKVNY3FG7/version/2/package
     method: GET
   response:
-    body: '{"id":"4zATd3TnBo0By3br2HeA9U","metadata":{"name":"wasm-test","description":"Default
-      package template used by the Fastly CLI for Rust-based Compute@Edge projects.","authors":["fastly@fastly.com"],"language":"rust","size":2015936,"hashsum":"f99485bd301e23f028474d26d398da525de17a372ae9e7026891d7f85361d2540d14b3b091929c3f170eade573595e20b3405a9e29651ede59915f2e1652f616"},"deleted_at":null,"version":2,"updated_at":"2021-01-14T10:26:17Z","created_at":"2021-01-14T10:26:17Z","service_id":"7i6HN3TK9wS159v2gPAZ8A"}'
+    body: '{"service_id":"I1VEQVKrgJFQszKVNY3FG7","id":"OScOS6exfJIxlixRHMccN5","metadata":{"name":"wasm-test","description":"Default
+      package template used by the Fastly CLI for Rust-based Compute@Edge projects.","authors":["fastly@fastly.com"],"language":"rust","size":2015936,"hashsum":"f99485bd301e23f028474d26d398da525de17a372ae9e7026891d7f85361d2540d14b3b091929c3f170eade573595e20b3405a9e29651ede59915f2e1652f616"},"created_at":"2022-11-15T22:02:53Z","version":2,"updated_at":"2022-11-15T22:02:54Z","deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:26:18 GMT
+      - Tue, 15 Nov 2022 22:02:54 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -34,9 +34,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4135-MAN
+      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-mad22037-MAD
       X-Timer:
-      - S1610619978.210652,VS0,VE184
+      - S1668549775.623402,VS0,VE153
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/package/service_create.yaml
+++ b/fastly/fixtures/package/service_create.yaml
@@ -14,25 +14,25 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
+      - FastlyGo/7.0.0 (+github.com/fastly/go-fastly; go1.18.3)
     url: https://api.fastly.com/service
     method: POST
   response:
-    body: '{"customer_id":"51MumwLiSJyFTWhtbByYgR","comment":"go-fastly wasm client
-      test","name":"test_service_wasm_package","type":"wasm","paused":false,"id":"7i6HN3TK9wS159v2gPAZ8A","publish_key":"","updated_at":"2021-01-14T10:26:15Z","versions":[{"service_id":"7i6HN3TK9wS159v2gPAZ8A","comment":"","deployed":false,"deleted_at":null,"created_at":"2021-01-14T10:26:15Z","updated_at":"2021-01-14T10:26:15Z","testing":false,"staging":false,"number":1,"locked":false,"active":false}],"created_at":"2021-01-14T10:26:15Z","deleted_at":null}'
+    body: '{"customer_id":"2jBAEHPlLAI176TjYdnHpB","comment":"go-fastly wasm client
+      test","name":"test_service_wasm_package","type":"wasm","publish_key":"","created_at":"2022-11-15T22:02:51Z","updated_at":"2022-11-15T22:02:51Z","deleted_at":null,"versions":[{"updated_at":"2022-11-15T22:02:51Z","created_at":"2022-11-15T22:02:51Z","locked":false,"deleted_at":null,"active":false,"number":1,"staging":false,"comment":"","deployed":false,"testing":false,"service_id":"I1VEQVKrgJFQszKVNY3FG7"}],"paused":false,"id":"I1VEQVKrgJFQszKVNY3FG7"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:26:15 GMT
+      - Tue, 15 Nov 2022 22:02:51 GMT
       Fastly-Ratelimit-Remaining:
-      - "912"
+      - "992"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1668553200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -46,9 +46,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4135-MAN
+      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-mad22037-MAD
       X-Timer:
-      - S1610619975.882968,VS0,VE258
+      - S1668549771.189588,VS0,VE397
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/package/service_delete.yaml
+++ b/fastly/fixtures/package/service_delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A
+      - FastlyGo/7.0.0 (+github.com/fastly/go-fastly; go1.18.3)
+    url: https://api.fastly.com/service/I1VEQVKrgJFQszKVNY3FG7
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -15,15 +15,15 @@ interactions:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:26:19 GMT
+      - Tue, 15 Nov 2022 22:02:56 GMT
       Fastly-Ratelimit-Remaining:
-      - "908"
+      - "988"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1668553200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4135-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-mad22037-MAD
       X-Timer:
-      - S1610619980.540879,VS0,VE293
+      - S1668549776.453193,VS0,VE195
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/package/service_version.yaml
+++ b/fastly/fixtures/package/service_version.yaml
@@ -2,32 +2,30 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A
-    form:
-      ServiceID:
-      - 7i6HN3TK9wS159v2gPAZ8A
+    body: ""
+    form: {}
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
+      - FastlyGo/7.0.0 (+github.com/fastly/go-fastly; go1.18.3)
+    url: https://api.fastly.com/service/I1VEQVKrgJFQszKVNY3FG7/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":2}'
+    body: '{"service_id":"I1VEQVKrgJFQszKVNY3FG7","number":2}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:26:15 GMT
+      - Tue, 15 Nov 2022 22:02:52 GMT
       Fastly-Ratelimit-Remaining:
-      - "911"
+      - "991"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1668553200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4135-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-mad22037-MAD
       X-Timer:
-      - S1610619975.181803,VS0,VE246
+      - S1668549772.828238,VS0,VE225
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/package/update.yaml
+++ b/fastly/fixtures/package/update.yaml
@@ -8,27 +8,27 @@ interactions:
       Accept:
       - application/json
       Content-Type:
-      - multipart/form-data; boundary=d414d90512dd2f67a95698c80b637067bb85ecee14caa7c673ebe99ae45d
+      - multipart/form-data; boundary=d4d79bf336c8b328cb0ce7ec87854d192b926571500b26688ab9524cebde
       User-Agent:
-      - FastlyGo/2.1.0 (+github.com/fastly/go-fastly; go1.15.4)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/package
+      - FastlyGo/7.0.0 (+github.com/fastly/go-fastly; go1.18.3)
+    url: https://api.fastly.com/service/I1VEQVKrgJFQszKVNY3FG7/version/2/package
     method: PUT
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":2,"updated_at":"2021-01-14T10:26:17Z","created_at":"2021-01-14T10:26:17Z","id":"4zATd3TnBo0By3br2HeA9U","deleted_at":null,"metadata":{"name":"wasm-test","description":"Default
+    body: '{"service_id":"I1VEQVKrgJFQszKVNY3FG7","version":2,"created_at":"2022-11-15T22:02:53Z","updated_at":"2022-11-15T22:02:54Z","id":"OScOS6exfJIxlixRHMccN5","deleted_at":null,"metadata":{"name":"wasm-test","description":"Default
       package template used by the Fastly CLI for Rust-based Compute@Edge projects.","authors":["fastly@fastly.com"],"language":"rust","size":2015936,"hashsum":"f99485bd301e23f028474d26d398da525de17a372ae9e7026891d7f85361d2540d14b3b091929c3f170eade573595e20b3405a9e29651ede59915f2e1652f616"}}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Jan 2021 10:26:18 GMT
+      - Tue, 15 Nov 2022 22:02:54 GMT
       Fastly-Ratelimit-Remaining:
-      - "910"
+      - "990"
       Fastly-Ratelimit-Reset:
-      - "1610622000"
+      - "1668553200"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -42,9 +42,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4135-MAN
+      - cache-control-cp-aws-us-east-1-prod-3-CONTROL-AWS, cache-mad22037-MAD
       X-Timer:
-      - S1610619975.499132,VS0,VE2641
+      - S1668549772.424270,VS0,VE1708
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/package/update_invalid.yaml
+++ b/fastly/fixtures/package/update_invalid.yaml
@@ -8,44 +8,42 @@ interactions:
       Accept:
       - application/json
       Content-Type:
-      - multipart/form-data; boundary=4c8b70ff8a04f6e75c13187fc33320263f65b1c4d14dac7c6fdc43a8074f
+      - multipart/form-data; boundary=79ff1e4065e457395040733c77ef3c67bdda74e9c08fab96fe0d7e4eef13
       User-Agent:
-      - FastlyGo/1.15.0 (+github.com/fastly/go-fastly; go1.14.3)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/package
+      - FastlyGo/7.0.0 (+github.com/fastly/go-fastly; go1.18.3)
+    url: https://api.fastly.com/service/I1VEQVKrgJFQszKVNY3FG7/version/2/package
     method: PUT
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":2,"updated_at":"2020-06-24T13:01:11Z","deleted_at":null,"created_at":"2020-06-24T13:01:11Z","metadata":null,"id":"3C4JK2R0jXIemgqdtvwaov"}'
+    body: '{"msg":"Bad request","detail":"Failed to extract metadata from package"}'
     headers:
       Accept-Ranges:
       - bytes
-      - bytes
       Cache-Control:
-      - no-cache
+      - no-store
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Jun 2020 13:01:12 GMT
+      - Tue, 15 Nov 2022 22:02:56 GMT
       Fastly-Ratelimit-Remaining:
-      - "996"
+      - "989"
       Fastly-Ratelimit-Reset:
-      - "1593007200"
+      - "1668553200"
       Status:
-      - 200 OK
+      - 400 Bad Request
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
       - MISS, MISS
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-lon4225-LON
+      - cache-control-cp-aws-us-east-1-prod-7-CONTROL-AWS, cache-mad22037-MAD
       X-Timer:
-      - S1593003671.179657,VS0,VE1097
-    status: 200 OK
-    code: 200
+      - S1668549775.248550,VS0,VE921
+    status: 400 Bad Request
+    code: 400
     duration: ""

--- a/fastly/package_test.go
+++ b/fastly/package_test.go
@@ -142,11 +142,8 @@ func TestClient_Package(t *testing.T) {
 			PackagePath:    "test_assets/package/invalid.tar.gz",
 		})
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if wp.Metadata.Size > 0 || wp.Metadata.Language != "" || wp.Metadata.HashSum != "" || wp.Metadata.Description != "" ||
-		wp.Metadata.Name != "" {
+	if err == nil && (wp.Metadata.Size > 0 || wp.Metadata.Language != "" || wp.Metadata.HashSum != "" || wp.Metadata.Description != "" ||
+		wp.Metadata.Name != "") {
 		t.Fatal("Invalid package upload completed rather than failed.")
 	}
 
@@ -160,11 +157,8 @@ func TestClient_Package(t *testing.T) {
 			PackageContent: invalidPackageContent,
 		})
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if wp.Metadata.Size > 0 || wp.Metadata.Language != "" || wp.Metadata.HashSum != "" || wp.Metadata.Description != "" ||
-		wp.Metadata.Name != "" {
+	if err == nil && (wp.Metadata.Size > 0 || wp.Metadata.Language != "" || wp.Metadata.HashSum != "" || wp.Metadata.Description != "" ||
+		wp.Metadata.Name != "") {
 		t.Fatal("Invalid package upload completed rather than failed.")
 	}
 }


### PR DESCRIPTION
It seems like the expected response from Fastly API slightly changed since it was added the test for invalid packages. Now, instead of returning package info with zeroed properties, it properly returns a specific HTTP error (bad request).

This PR changes the test to be compliant with the new behaviour.

Signed-off-by: Gorka Lerchundi Osa <glertxundi@gmail.com>