### PR TITLE
Add compute_requests to usage response struct

### DIFF
--- a/fastly/stats.go
+++ b/fastly/stats.go
@@ -183,8 +183,9 @@ type UsageStatsResponse struct {
 
 // Usage represents usage data of a single service or region
 type Usage struct {
-	Bandwidth uint64 `mapstructure:"bandwidth"`
-	Requests  uint64 `mapstructure:"requests"`
+	Bandwidth       uint64 `mapstructure:"bandwidth"`
+	Requests        uint64 `mapstructure:"requests"`
+	ComputeRequests uint64 `mapstructure:"compute_requests"`
 }
 
 // RegionsUsage is a list of aggregated usage data by Fastly's region


### PR DESCRIPTION
This adds the missing `compute_requests` field to the SDK-supported usage endpoints:
 - https://developer.fastly.com/reference/api/metrics-stats/historical-stats/#get-usage-service
 - https://developer.fastly.com/reference/api/metrics-stats/historical-stats/#get-usage

These are already present in the test fixture files: https://github.com/fastly/go-fastly/blob/main/fastly/fixtures/stats/services_usage.yaml#L14