### PR TITLE
resource: Improve parameter naming; support JSON encode

### DIFF
--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -157,10 +157,6 @@ var ErrMissingMonth = NewFieldError("Month")
 // requires a "Name" key, but one was not set.
 var ErrMissingName = NewFieldError("Name")
 
-// ErrMissingResourceID is an error that is returned when an input struct
-// requires a "ResourceID" key, but one was not set.
-var ErrMissingResourceID = NewFieldError("ResourceID")
-
 // ErrMissingNameValue is an error that is returned when an input struct
 // requires a "Name" key, but one was not set.
 var ErrMissingNameValue = NewFieldError("Name").Message("service name can't be an empty value")


### PR DESCRIPTION
The API documentation is inconsistent in the use of `resource_id`. This change departs from the API docs and consistently uses:
* `resource_id`: ID of the linked to object, e.g. the Object Store ID
* `id`: ID of the "resource", e.g. the Resource (link) ID

The API docs will be updated accordingly.

Additionaly, `json` tags have been added to the `Resource` type. This allows a `Resource` to be properly encoded as JSON.