### PR TITLE
fix(client): add title to legacy error format

### DIFF
--- a/fastly/errors_test.go
+++ b/fastly/errors_test.go
@@ -17,7 +17,7 @@ func TestNewHTTPError(t *testing.T) {
 		resp := &http.Response{
 			StatusCode: 404,
 			Body: io.NopCloser(bytes.NewBufferString(
-				`{"msg": "hello", "detail": "nope"}`)),
+				`{"msg": "hello", "detail": "nope", "title": "some title"}`)),
 		}
 		e := NewHTTPError(resp)
 
@@ -28,7 +28,8 @@ func TestNewHTTPError(t *testing.T) {
 		expected := strings.TrimSpace(`
 404 - Not Found:
 
-    Title:  hello
+    Title:  some title
+    Message:  hello
     Detail: nope
 `)
 		if e.Error() != expected {


### PR DESCRIPTION
Some APIs (e.g. Product Enablement) return a data structure compatible with `application/problem+json` but not the actual Content-Type that would cause go-fastly to be able to parse the data. 

The following code example is the scenario I'm trying to reach. This because we have discovered a buggy workflow in the Terraform provider and to resolve it we need to be able to determine if the user has 'self-enablement' turned on for their customer account. Without the changes in this PR we are unable to determine that because the status code by itself (400) is too generic.

We can't access the full message from Terraform as it chops off the message...
<img width="565" alt="Screenshot 2023-03-01 at 17 38 41" src="https://user-images.githubusercontent.com/180050/222218968-c6b14d80-8e3f-42af-9470-8bbfa6ad11ac.png">

By exposing the title we can convert to HTTPError and check the string directly...
```go
package main

import (
	"fmt"
	"log"
	"strings"

	"github.com/fastly/go-fastly/v7/fastly"
)

func main() {
	client, err := fastly.NewClient("<REDACTED>")
	if err != nil {
		log.Fatal(err)
	}

	err = client.DisableProduct(&fastly.ProductEnablementInput{
		ProductID: fastly.ProductImageOptimizer,
		ServiceID: "<REDACTED>",
	})
	if err != nil {
		if he, ok := err.(*fastly.HTTPError); ok {
			for _, e := range he.Errors {
				if strings.Contains(e.Title, "is not entitled to disable product") {
					fmt.Println(e.Title)
					return
				}
			}
		}
		log.Fatal(err)
	}
}
```