### PR TITLE
fix(tls-subscription): serialise warnings field

### DIFF
--- a/fastly/tls_subscription.go
+++ b/fastly/tls_subscription.go
@@ -33,11 +33,18 @@ type TLSAuthorizations struct {
 	// Challenges ...
 	// See https://github.com/google/jsonapi/pull/99
 	// WARNING: Nested structs only work with values, not pointers.
-	Challenges []TLSChallenge `jsonapi:"attr,challenges"`
-	CreatedAt  *time.Time     `jsonapi:"attr,created_at,iso8601,omitempty"`
-	ID         string         `jsonapi:"primary,tls_authorization"`
-	State      string         `jsonapi:"attr,state,omitempty"`
-	UpdatedAt  *time.Time     `jsonapi:"attr,updated_at,iso8601,omitempty"`
+	Challenges []TLSChallenge            `jsonapi:"attr,challenges"`
+	CreatedAt  *time.Time                `jsonapi:"attr,created_at,iso8601,omitempty"`
+	ID         string                    `jsonapi:"primary,tls_authorization"`
+	State      string                    `jsonapi:"attr,state,omitempty"`
+	UpdatedAt  *time.Time                `jsonapi:"attr,updated_at,iso8601,omitempty"`
+	Warnings   []TLSAuthorizationWarning `jsonapi:"attr,warnings,omitempty"`
+}
+
+// TLSAuthorizationWarning indicates possible issues with the TLS configuration.
+type TLSAuthorizationWarning struct {
+	Type         string `jsonapi:"attr,type"`
+	Instructions string `jsonapi:"attr,instructions"`
 }
 
 // TLSChallenge represents a DNS record to be added for a specific type of domain ownership challenge


### PR DESCRIPTION
Fixes: https://github.com/fastly/go-fastly/issues/408

We should expose `warnings` field, as a "passing" state doesn't always indicate a successful operation.

> **NOTE:** I've internally raised a question related to why the API returns a `200 OK` when it seems a warning (as reported in the customer issue, link above) suggests that in fact this would cause the TLS subscription operation to fail.