### PR TITLE
fix(lint): avoid range variable being captured by func literal

### DIFF
--- a/fastly/purge_test.go
+++ b/fastly/purge_test.go
@@ -31,6 +31,7 @@ func TestROParams(t *testing.T) {
 	}
 
 	for name, tc := range tests {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			want := tc.output


### PR DESCRIPTION
This only affects the test file.