### PR TITLE
fix(kv_store): allow file read support

### DIFF
--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -367,7 +367,10 @@ func (c *Client) InsertKVStoreKey(i *InsertKVStoreKeyInput) error {
 	}
 
 	path := "/resources/stores/kv/" + i.ID + "/keys/" + i.Key
-	resp, err := c.Put(path, &RequestOptions{Body: io.NopCloser(strings.NewReader(i.Value))})
+	resp, err := c.Put(path, &RequestOptions{
+		Body:       io.NopCloser(strings.NewReader(i.Value)),
+		BodyLength: int64(len(i.Value)),
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When providing a large value for a KV Store entry, the API will return:

```
400 Bad Request: must include valid content-length header
```

This seems to be because the original implementation in go-fastly doesn't set `BodyLength` on the request and so the author must have presumed a smaller value would be provided and so never noticed that the API would return this Content-Length error when a user attempts to pass the contents of a large file as the value.