### PR TITLE
fix(kv_store): support parallel requests

### DIFF
--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -370,6 +370,7 @@ func (c *Client) InsertKVStoreKey(i *InsertKVStoreKeyInput) error {
 	resp, err := c.Put(path, &RequestOptions{
 		Body:       io.NopCloser(strings.NewReader(i.Value)),
 		BodyLength: int64(len(i.Value)),
+		Parallel:   true, // This will allow the Fastly CLI to make bulk inserts.
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
While developing a 'batch processing' pipeline into the Fastly CLI I discovered go-fastly was serialising the API calls even though the CLI was trying to process the calls concurrently. This fix means the CLI pipeline was sped up by ~84%.