### PR TITLE
Secret Store: Support `PUT` & `PATCH` methods when creating secret

### DIFF
--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -303,6 +303,10 @@ var ErrMissingToken = NewFieldError("Token")
 // requires a "ProductID" key, but one was not set.
 var ErrMissingProductID = NewFieldError("ProductID")
 
+// ErrInvalidMethod is an error that is returned when the input struct
+// has an invalid Method value.
+var ErrInvalidMethod = NewFieldError("Method").Message("invalid")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 

--- a/fastly/fixtures/secret_store/TestClient_CreateOrRecreateSecret.yaml
+++ b/fastly/fixtures/secret_store/TestClient_CreateOrRecreateSecret.yaml
@@ -1,0 +1,41 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"name":"TestClient_CreateOrRecreateSecret","secret":"c2VjcmV0dW0gc2VydmFyZQ=="}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/8.0.1 (+github.com/fastly/go-fastly; go1.20.4)
+    url: https://api.fastly.com/resources/stores/secret/UwzCbVsOGmdRvKZwLTzVJL/secrets
+    method: PUT
+  response:
+    body: |
+      {
+        "name": "TestClient_CreateOrRecreateSecret",
+        "digest": "v+qtPCbd8PiqZcXxJfrvNDFbRzOR3PMN9ZNFcuZpOyU=",
+        "created_at": "2023-05-10T21:23:49Z"
+      }
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Fastly-Key
+      Access-Control-Allow-Methods:
+      - PUT, POST, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Length:
+      - "150"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2023 21:23:49 GMT
+      Fastly-Trace-Id:
+      - 2SN0KbwrBwGtKs8BZesOmV
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/secret_store/TestClient_CreateOrRecreateSecret/create_store_00.yaml
+++ b/fastly/fixtures/secret_store/TestClient_CreateOrRecreateSecret/create_store_00.yaml
@@ -1,0 +1,41 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"name":"TestClient_CreateOrRecreateSecret-00"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/8.0.1 (+github.com/fastly/go-fastly; go1.20.4)
+    url: https://api.fastly.com/resources/stores/secret
+    method: POST
+  response:
+    body: |
+      {
+        "id": "UwzCbVsOGmdRvKZwLTzVJL",
+        "name": "TestClient_CreateOrRecreateSecret-00",
+        "created_at": "2023-05-10T21:23:48Z"
+      }
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Fastly-Key
+      Access-Control-Allow-Methods:
+      - PUT, POST, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Length:
+      - "127"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2023 21:23:49 GMT
+      Fastly-Trace-Id:
+      - WzHwbHgZCNMDPDlmb8fyTT
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/fixtures/secret_store/TestClient_CreateOrRecreateSecret/delete_store_00.yaml
+++ b/fastly/fixtures/secret_store/TestClient_CreateOrRecreateSecret/delete_store_00.yaml
@@ -1,0 +1,31 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/8.0.1 (+github.com/fastly/go-fastly; go1.20.4)
+    url: https://api.fastly.com/resources/stores/secret/UwzCbVsOGmdRvKZwLTzVJL
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Fastly-Key
+      Access-Control-Allow-Methods:
+      - PUT, POST, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Date:
+      - Wed, 10 May 2023 21:23:54 GMT
+      Fastly-Trace-Id:
+      - aU4HtT27Xy3Wi18V4arhzC
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/fastly/fixtures/secret_store/TestClient_RecreateSecret.yaml
+++ b/fastly/fixtures/secret_store/TestClient_RecreateSecret.yaml
@@ -1,0 +1,80 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"name":"TestClient_RecreateSecret","secret":"c2VjcmV0dW0gc2VydmFyZQ=="}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/8.0.1 (+github.com/fastly/go-fastly; go1.20.4)
+    url: https://api.fastly.com/resources/stores/secret/McoBzaj4jHg6NmNWG7CRRj/secrets
+    method: POST
+  response:
+    body: |
+      {
+        "name": "TestClient_RecreateSecret",
+        "digest": "a0Fm/a1IJGE0b1s5789cjPVETdpQ21EC54kvA+0zGgA=",
+        "created_at": "2023-05-10T21:23:25Z"
+      }
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Fastly-Key
+      Access-Control-Allow-Methods:
+      - PUT, POST, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Length:
+      - "142"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2023 21:23:30 GMT
+      Fastly-Trace-Id:
+      - NQdd0KJMDp0a3hAGNVLqce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"name":"TestClient_RecreateSecret","secret":"c2VjcmV0dW0gc2VydmFyZQ=="}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/8.0.1 (+github.com/fastly/go-fastly; go1.20.4)
+    url: https://api.fastly.com/resources/stores/secret/McoBzaj4jHg6NmNWG7CRRj/secrets
+    method: PATCH
+  response:
+    body: |
+      {
+        "name": "TestClient_RecreateSecret",
+        "digest": "G12VYkOO6Ca4TaIQ48iqHRXhH5O1khQfNPv39oE/+MA=",
+        "created_at": "2023-05-10T21:23:30Z",
+        "recreated": true
+      }
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Fastly-Key
+      Access-Control-Allow-Methods:
+      - PUT, POST, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Length:
+      - "163"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2023 21:23:35 GMT
+      Fastly-Trace-Id:
+      - IdPvARo6XEHJ6BGZHgnkNz
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/secret_store/TestClient_RecreateSecret/create_store_00.yaml
+++ b/fastly/fixtures/secret_store/TestClient_RecreateSecret/create_store_00.yaml
@@ -1,0 +1,41 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"name":"TestClient_RecreateSecret-00"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/8.0.1 (+github.com/fastly/go-fastly; go1.20.4)
+    url: https://api.fastly.com/resources/stores/secret
+    method: POST
+  response:
+    body: |
+      {
+        "id": "McoBzaj4jHg6NmNWG7CRRj",
+        "name": "TestClient_RecreateSecret-00",
+        "created_at": "2023-05-10T21:23:24Z"
+      }
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Fastly-Key
+      Access-Control-Allow-Methods:
+      - PUT, POST, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Length:
+      - "119"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2023 21:23:25 GMT
+      Fastly-Trace-Id:
+      - kKMyNVd1yiQ2uAvdDsNCU9
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/fixtures/secret_store/TestClient_RecreateSecret/delete_store_00.yaml
+++ b/fastly/fixtures/secret_store/TestClient_RecreateSecret/delete_store_00.yaml
@@ -1,0 +1,31 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/8.0.1 (+github.com/fastly/go-fastly; go1.20.4)
+    url: https://api.fastly.com/resources/stores/secret/McoBzaj4jHg6NmNWG7CRRj
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, Fastly-Key
+      Access-Control-Allow-Methods:
+      - PUT, POST, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Date:
+      - Wed, 10 May 2023 21:23:40 GMT
+      Fastly-Trace-Id:
+      - xakeavsaljZig1M4TiA5aV
+    status: 204 No Content
+    code: 204
+    duration: ""


### PR DESCRIPTION
The method controls the behavior when creating a secret with a name that already exists in the store.

- `POST`:  Default. Create a secret and error if one already exists with the same name.
- `PUT`:   Create or recreate a secret.
- `PATCH`: Recreate a secret and error if one does not already exist with the same name.