### PR TITLE
fix(kv_store): allow buffering io for key insert

### DIFF
--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -281,10 +281,6 @@ var ErrMissingOptionalNameComment = NewFieldError("Name, Comment").Message("at l
 // requires a "Tokens" key, but there needs to be at least one token entry.
 var ErrMissingTokensValue = NewFieldError("Tokens").Message("expect at least one token")
 
-// ErrMissingBodyLength is an error that is returned when an input struct
-// requires a "BodyLength" key, but one was not set.
-var ErrMissingBodyLength = NewFieldError("BodyLength")
-
 // ErrStatusNotOk is an error that indicates the response body returned by the
 // Fastly API was not `{"status": "ok"}`
 var ErrStatusNotOk = errors.New("unexpected 'status' field in API response body")

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -281,6 +281,10 @@ var ErrMissingOptionalNameComment = NewFieldError("Name, Comment").Message("at l
 // requires a "Tokens" key, but there needs to be at least one token entry.
 var ErrMissingTokensValue = NewFieldError("Tokens").Message("expect at least one token")
 
+// ErrMissingBodyLength is an error that is returned when an input struct
+// requires a "BodyLength" key, but one was not set.
+var ErrMissingBodyLength = NewFieldError("BodyLength")
+
 // ErrStatusNotOk is an error that indicates the response body returned by the
 // Fastly API was not `{"status": "ok"}`
 var ErrStatusNotOk = errors.New("unexpected 'status' field in API response body")

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -354,6 +354,8 @@ type InsertKVStoreKeyInput struct {
 	// This is for users who are passing very large files.
 	// Otherwise use the 'Value' field instead.
 	Body io.Reader
+	// BodyLength should be set with Body to indicate value for Content-Length.
+	BodyLength int64
 	// ID is the ID of the kv store (required).
 	ID string
 	// Key is the key to add (required).
@@ -376,7 +378,11 @@ func (c *Client) InsertKVStoreKey(i *InsertKVStoreKeyInput) error {
 	}
 
 	if i.Body != nil {
+		if i.BodyLength == 0 {
+			return ErrMissingBodyLength
+		}
 		ro.Body = bufio.NewReader(i.Body)
+		ro.BodyLength = i.BodyLength
 	} else {
 		ro.Body = strings.NewReader(i.Value)
 		ro.BodyLength = int64(len(i.Value))

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -348,14 +349,44 @@ func (c *Client) GetKVStoreKey(i *GetKVStoreKeyInput) (string, error) {
 	return string(output), nil
 }
 
+// LengthReader represents a type that can be read and exposes its length.
+type LengthReader interface {
+	io.Reader
+	Len() int
+}
+
+// FileLengthReader allows an os.File type to be passed as a LengthReader to the
+// InsertKVStoreKeyInput.Body field.
+func FileLengthReader(f *os.File) (LengthReader, error) {
+	s, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return &fileLenReader{
+		f:   f,
+		len: int(s.Size()),
+	}, nil
+}
+
+type fileLenReader struct {
+	f   *os.File
+	len int
+}
+
+func (f *fileLenReader) Read(p []byte) (int, error) {
+	return f.f.Read(p)
+}
+
+func (f *fileLenReader) Len() int {
+	return f.len
+}
+
 // InsertKVStoreKeyInput is the input to the InsertKVStoreKey function.
 type InsertKVStoreKeyInput struct {
 	// Body is the value to insert and will be streamed to the endpoint.
 	// This is for users who are passing very large files.
 	// Otherwise use the 'Value' field instead.
-	Body io.Reader
-	// BodyLength should be set with Body to indicate value for Content-Length.
-	BodyLength int64
+	Body LengthReader
 	// ID is the ID of the kv store (required).
 	ID string
 	// Key is the key to add (required).
@@ -378,11 +409,8 @@ func (c *Client) InsertKVStoreKey(i *InsertKVStoreKeyInput) error {
 	}
 
 	if i.Body != nil {
-		if i.BodyLength == 0 {
-			return ErrMissingBodyLength
-		}
 		ro.Body = bufio.NewReader(i.Body)
-		ro.BodyLength = i.BodyLength
+		ro.BodyLength = int64(i.Body.Len())
 	} else {
 		ro.Body = strings.NewReader(i.Value)
 		ro.BodyLength = int64(len(i.Value))

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -391,7 +391,7 @@ type InsertKVStoreKeyInput struct {
 	ID string
 	// Key is the key to add (required).
 	Key string
-	// Value is the value to insert.
+	// Value is the value to insert (ignored if Body is set).
 	Value string
 }
 


### PR DESCRIPTION
The following code demonstrates a working example...

```go
package main

import (
	"fmt"
	"log"
	"os"
	"strings"

	"github.com/fastly/go-fastly/v8/fastly"
)

func main() {
	client, err := fastly.NewClient(os.Getenv("FASTLY_API_KEY"))
	if err != nil {
		log.Fatal("failed to create NewClient: ", err)
	}

	id := "<REDACTED>"
	key := "gofastly-testing-kvstore-"
	key1 := key + "1"
	key2 := key + "2"
	key3 := key + "3"

	err = client.InsertKVStoreKey(&fastly.InsertKVStoreKeyInput{
		ID:    id,
		Key:   key1,
		Value: "some value that is small",
	})
	if err != nil {
		log.Fatal("failed to insert key 1: ", err)
	}

	body := "some larger value, e.g. a file"
	err = client.InsertKVStoreKey(&fastly.InsertKVStoreKeyInput{
		Body: strings.NewReader(body),
		ID:   id,
		Key:  key2,
	})
	if err != nil {
		log.Fatal("failed to insert key 2: ", err)
	}

	// The file is ~3.3MB
	largeFile, err := os.Open("large.txt")
	if err != nil {
		log.Fatal("failed to open large.txt", err)
	}

	lr, err := fastly.FileLengthReader(largeFile)
	if err != nil {
		log.Fatal("failed to create length reader", err)
	}

	err = client.InsertKVStoreKey(&fastly.InsertKVStoreKeyInput{
		Body: lr,
		ID:   id,
		Key:  key3,
	})
	if err != nil {
		log.Fatal("failed to insert key 3: ", err)
	}

	v, err := client.GetKVStoreKey(&fastly.GetKVStoreKeyInput{
		ID:  id,
		Key: key1,
	})
	if err != nil {
		log.Fatal("failed to get key 1: ", err)
	}

	fmt.Printf("1. %+v\n", v)

	v, err = client.GetKVStoreKey(&fastly.GetKVStoreKeyInput{
		ID:  id,
		Key: key2,
	})
	if err != nil {
		log.Fatal("failed to get key 2: ", err)
	}

	fmt.Printf("2. %+v\n", v)

	v, err = client.GetKVStoreKey(&fastly.GetKVStoreKeyInput{
		ID:  id,
		Key: key3,
	})
	if err != nil {
		log.Fatal("failed to get key 3: ", err)
	}

	fmt.Printf("3. %+v\n", v)
}
```