### PR TITLE
feat(backend): add share_key field

### DIFF
--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -28,6 +28,7 @@ type Backend struct {
 	OverrideHost        string     `mapstructure:"override_host"`
 	Port                int        `mapstructure:"port"`
 	RequestCondition    string     `mapstructure:"request_condition"`
+	ShareKey            string     `mapstructure:"share_key"`
 	SSLCACert           string     `mapstructure:"ssl_ca_cert"`
 	SSLCertHostname     string     `mapstructure:"ssl_cert_hostname"`
 	SSLCheckCert        bool       `mapstructure:"ssl_check_cert"`
@@ -126,6 +127,8 @@ type CreateBackendInput struct {
 	Port *int `url:"port,omitempty"`
 	// RequestCondition is the name of a Condition, which if satisfied, will select this backend during a request.
 	RequestCondition *string `url:"request_condition,omitempty"`
+	// ShareKey is a value that when shared across backends will enable those backends to share the same health check.
+	ShareKey *string `url:"share_key,omitempty"`
 	// SSLCACert is a CA certificate attached to origin.
 	SSLCACert *string `url:"ssl_ca_cert,omitempty"`
 	// SSLCertHostname is an overrides ssl_hostname, but only for cert verification.
@@ -250,6 +253,8 @@ type UpdateBackendInput struct {
 	Port *int `url:"port,omitempty"`
 	// RequestCondition is the name of a Condition, which if satisfied, will select this backend during a request.
 	RequestCondition *string `url:"request_condition,omitempty"`
+	// ShareKey is a value that when shared across backends will enable those backends to share the same health check.
+	ShareKey *string `url:"share_key,omitempty"`
 	// SSLCACert is a CA certificate attached to origin.
 	SSLCACert *string `url:"ssl_ca_cert,omitempty"`
 	// SSLCertHostname is an overrides ssl_hostname, but only for cert verification.

--- a/fastly/backend_test.go
+++ b/fastly/backend_test.go
@@ -64,6 +64,9 @@ func TestClient_Backends(t *testing.T) {
 	if b.OverrideHost != "origin.example.com" {
 		t.Errorf("bad override_host: %q", b.OverrideHost)
 	}
+	if b.ShareKey != "" {
+		t.Errorf("bad share_key: %s", b.ShareKey)
+	}
 	if b.SSLCheckCert {
 		t.Errorf("bad ssl_check_cert: %t", b.SSLCheckCert) // API defaults to true and we want to allow setting false
 	}
@@ -124,6 +127,7 @@ func TestClient_Backends(t *testing.T) {
 			NewName:        String("new-test-backend"),
 			OverrideHost:   String("www.example.com"),
 			Port:           Int(1234),
+			ShareKey:       String("shared-key"),
 			SSLCiphers:     String("RC4:!COMPLEMENTOFDEFAULT"),
 			SSLCheckCert:   CBool(false),
 			SSLSNIHostname: String("ssl-hostname-updated.com"),
@@ -140,6 +144,9 @@ func TestClient_Backends(t *testing.T) {
 	}
 	if ub.Port != 1234 {
 		t.Errorf("bad port: %d", ub.Port)
+	}
+	if ub.ShareKey == "" || ub.ShareKey != "shared-key" {
+		t.Errorf("bad share_key: %s", ub.ShareKey)
 	}
 	if ub.SSLCheckCert {
 		t.Errorf("bad ssl_check_cert: %t", ub.SSLCheckCert)

--- a/fastly/fixtures/backends/cleanup.yaml
+++ b/fastly/fixtures/backends/cleanup.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/68/backend/test-backend
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/123/backend/test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e test-backend, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 68 }''"}'
+      version =\u003e 123 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:49 GMT
+      - Mon, 07 Aug 2023 10:02:10 GMT
       Fastly-Ratelimit-Remaining:
-      - "9928"
+      - "9993"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1691406000"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-2-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580889.983803,VS0,VE143
+      - S1691402530.907614,VS0,VE165
     status: 404 Not Found
     code: 404
     duration: ""
@@ -50,13 +50,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/68/backend/new-test-backend
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/123/backend/new-test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e new-test-backend, service =\u003e
-      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 68 }''"}'
+      7i6HN3TK9wS159v2gPAZ8A, version =\u003e 123 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -65,11 +65,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:49 GMT
+      - Mon, 07 Aug 2023 10:02:10 GMT
       Fastly-Ratelimit-Remaining:
-      - "9927"
+      - "9992"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1691406000"
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -83,9 +83,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-2-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580889.158036,VS0,VE134
+      - S1691402530.472495,VS0,VE170
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/backends/create.yaml
+++ b/fastly/fixtures/backends/create.yaml
@@ -22,11 +22,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/68/backend
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/123/backend
     method: POST
   response:
-    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_sni_hostname":"ssl-hostname.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":68,"use_ssl":false,"ssl_client_cert":null,"auto_loadbalance":false,"request_condition":"","port":80,"weight":100,"first_byte_timeout":15000,"max_conn":200,"ssl_cert_hostname":null,"created_at":"2022-11-04T16:54:46Z","deleted_at":null,"hostname":"integ-test.go-fastly.com","shield":null,"between_bytes_timeout":10000,"ipv6":null,"max_tls_version":null,"ssl_client_key":null,"client_cert":null,"min_tls_version":null,"ssl_hostname":null,"comment":"","updated_at":"2022-11-04T16:54:46Z","ssl_ca_cert":null,"healthcheck":null,"ipv4":null,"error_threshold":0}'
+    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_sni_hostname":"ssl-hostname.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":123,"first_byte_timeout":15000,"hostname":"integ-test.go-fastly.com","created_at":"2023-08-07T10:02:07Z","ssl_client_cert":null,"ipv4":null,"ssl_hostname":null,"deleted_at":null,"ssl_cert_hostname":null,"auto_loadbalance":false,"comment":"","ssl_ca_cert":null,"max_conn":200,"request_condition":"","updated_at":"2023-08-07T10:02:07Z","share_key":null,"weight":100,"healthcheck":null,"min_tls_version":null,"max_tls_version":null,"port":80,"use_ssl":false,"between_bytes_timeout":10000,"ssl_client_key":null,"keepalive_time":null,"client_cert":null,"shield":null,"error_threshold":0,"ipv6":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:47 GMT
+      - Mon, 07 Aug 2023 10:02:07 GMT
       Fastly-Ratelimit-Remaining:
-      - "9933"
+      - "9998"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1691406000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -53,9 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-1-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580887.651009,VS0,VE387
+      - S1691402528.541797,VS0,VE417
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/delete.yaml
+++ b/fastly/fixtures/backends/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/68/backend/new-test-backend
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/123/backend/new-test-backend
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:48 GMT
+      - Mon, 07 Aug 2023 10:02:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "9929"
+      - "9994"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1691406000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-1-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580889.741891,VS0,VE212
+      - S1691402530.558479,VS0,VE311
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/get.yaml
+++ b/fastly/fixtures/backends/get.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/68/backend/test-backend
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/123/backend/test-backend
     method: GET
   response:
-    body: '{"max_conn":200,"max_tls_version":null,"error_threshold":0,"deleted_at":null,"connect_timeout":1500,"ssl_cert_hostname":null,"ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","name":"test-backend","ipv6":null,"min_tls_version":null,"shield":null,"healthcheck":null,"client_cert":null,"request_condition":"","hostname":"integ-test.go-fastly.com","address":"integ-test.go-fastly.com","weight":100,"ssl_hostname":null,"first_byte_timeout":15000,"updated_at":"2022-11-04T16:54:46Z","ssl_client_key":null,"version":68,"ssl_sni_hostname":"ssl-hostname.com","port":80,"override_host":"origin.example.com","use_ssl":false,"ssl_client_cert":null,"ipv4":null,"between_bytes_timeout":10000,"created_at":"2022-11-04T16:54:46Z","auto_loadbalance":false,"comment":"","ssl_ca_cert":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A"}'
+    body: '{"use_ssl":false,"comment":"","address":"integ-test.go-fastly.com","between_bytes_timeout":10000,"auto_loadbalance":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_hostname":null,"ipv6":null,"ssl_sni_hostname":"ssl-hostname.com","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","created_at":"2023-08-07T10:02:07Z","override_host":"origin.example.com","version":123,"client_cert":null,"request_condition":"","ssl_ca_cert":null,"share_key":null,"port":80,"ipv4":null,"ssl_cert_hostname":null,"weight":100,"ssl_check_cert":false,"ssl_client_key":null,"healthcheck":null,"keepalive_time":null,"error_threshold":0,"min_tls_version":null,"max_conn":200,"deleted_at":null,"hostname":"integ-test.go-fastly.com","shield":null,"connect_timeout":1500,"updated_at":"2023-08-07T10:02:07Z","first_byte_timeout":15000,"ssl_client_cert":null,"name":"test-backend","max_tls_version":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:47 GMT
+      - Mon, 07 Aug 2023 10:02:08 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-2-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580887.252041,VS0,VE314
+      - S1691402528.237333,VS0,VE368
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/list.yaml
+++ b/fastly/fixtures/backends/list.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/68/backend
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/123/backend
     method: GET
   response:
-    body: '[{"use_ssl":false,"ssl_client_cert":null,"override_host":"origin.example.com","port":80,"ssl_sni_hostname":"ssl-hostname.com","version":68,"ssl_client_key":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","ssl_ca_cert":null,"comment":"","auto_loadbalance":false,"between_bytes_timeout":10000,"created_at":"2022-11-04T16:54:46Z","ipv4":null,"ssl_cert_hostname":null,"connect_timeout":1500,"deleted_at":null,"error_threshold":0,"max_tls_version":null,"max_conn":200,"first_byte_timeout":15000,"updated_at":"2022-11-04T16:54:46Z","weight":100,"ssl_hostname":null,"address":"integ-test.go-fastly.com","hostname":"integ-test.go-fastly.com","client_cert":null,"request_condition":"","healthcheck":null,"shield":null,"min_tls_version":null,"ipv6":null,"name":"test-backend","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_check_cert":false}]'
+    body: '[{"address":"integ-test.go-fastly.com","ssl_sni_hostname":"ssl-hostname.com","auto_loadbalance":false,"updated_at":"2023-08-07T10:02:07Z","ipv4":null,"use_ssl":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","max_tls_version":null,"first_byte_timeout":15000,"error_threshold":0,"ssl_client_key":null,"port":80,"ssl_check_cert":false,"healthcheck":null,"shield":null,"connect_timeout":1500,"ssl_client_cert":null,"ssl_cert_hostname":null,"override_host":"origin.example.com","comment":"","version":123,"name":"test-backend","created_at":"2023-08-07T10:02:07Z","ssl_ca_cert":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","between_bytes_timeout":10000,"deleted_at":null,"weight":100,"max_conn":200,"client_cert":null,"min_tls_version":null,"request_condition":"","ipv6":null,"ssl_hostname":null,"hostname":"integ-test.go-fastly.com","share_key":null,"keepalive_time":null}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:47 GMT
+      - Mon, 07 Aug 2023 10:02:08 GMT
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +33,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-4-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-2-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580887.065799,VS0,VE157
+      - S1691402528.995546,VS0,VE209
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update.yaml
+++ b/fastly/fixtures/backends/update.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: name=new-test-backend&override_host=www.example.com&port=1234&ssl_check_cert=0&ssl_ciphers=RC4%3A%21COMPLEMENTOFDEFAULT&ssl_sni_hostname=ssl-hostname-updated.com
+    body: name=new-test-backend&override_host=www.example.com&port=1234&share_key=shared-key&ssl_check_cert=0&ssl_ciphers=RC4%3A%21COMPLEMENTOFDEFAULT&ssl_sni_hostname=ssl-hostname-updated.com
     form:
       name:
       - new-test-backend
@@ -10,6 +10,8 @@ interactions:
       - www.example.com
       port:
       - "1234"
+      share_key:
+      - shared-key
       ssl_check_cert:
       - "0"
       ssl_ciphers:
@@ -20,11 +22,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/68/backend/test-backend
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/123/backend/test-backend
     method: PUT
   response:
-    body: '{"first_byte_timeout":15000,"healthcheck":null,"ssl_sni_hostname":"ssl-hostname-updated.com","deleted_at":null,"use_ssl":false,"ssl_hostname":null,"ssl_client_cert":null,"ssl_ca_cert":null,"ssl_client_key":null,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","service_id":"7i6HN3TK9wS159v2gPAZ8A","updated_at":"2022-11-04T16:54:46Z","override_host":"www.example.com","address":"integ-test.go-fastly.com","between_bytes_timeout":10000,"request_condition":"","ipv6":null,"max_tls_version":null,"hostname":"integ-test.go-fastly.com","shield":null,"comment":"","version":68,"ssl_cert_hostname":null,"ipv4":null,"weight":100,"error_threshold":0,"port":1234,"created_at":"2022-11-04T16:54:46Z","client_cert":null,"max_conn":200,"min_tls_version":null,"auto_loadbalance":false,"connect_timeout":1500,"ssl_check_cert":false,"name":"new-test-backend"}'
+    body: '{"created_at":"2023-08-07T10:02:07Z","shield":null,"first_byte_timeout":15000,"ssl_cert_hostname":null,"ssl_client_cert":null,"max_conn":200,"ssl_sni_hostname":"ssl-hostname-updated.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","ipv4":null,"between_bytes_timeout":10000,"override_host":"www.example.com","keepalive_time":null,"ssl_hostname":null,"port":1234,"auto_loadbalance":false,"ssl_check_cert":false,"use_ssl":false,"hostname":"integ-test.go-fastly.com","ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","deleted_at":null,"weight":100,"min_tls_version":null,"error_threshold":0,"ipv6":null,"name":"new-test-backend","updated_at":"2023-08-07T10:02:07Z","ssl_ca_cert":null,"share_key":"shared-key","connect_timeout":1500,"max_tls_version":null,"comment":"","client_cert":null,"ssl_client_key":null,"healthcheck":null,"request_condition":"","address":"integ-test.go-fastly.com","version":123}'
     headers:
       Accept-Ranges:
       - bytes
@@ -33,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:47 GMT
+      - Mon, 07 Aug 2023 10:02:08 GMT
       Fastly-Ratelimit-Remaining:
-      - "9932"
+      - "9997"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1691406000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -51,9 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-2-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580888.598907,VS0,VE387
+      - S1691402529.633661,VS0,VE263
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update_allow_empty_values.yaml
+++ b/fastly/fixtures/backends/update_allow_empty_values.yaml
@@ -12,11 +12,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/68/backend/new-test-backend
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/123/backend/new-test-backend
     method: PUT
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","request_condition":"","ssl_sni_hostname":"ssl-hostname-updated.com","weight":100,"ssl_client_key":null,"override_host":null,"version":68,"ipv6":null,"max_conn":200,"use_ssl":false,"healthcheck":null,"min_tls_version":null,"connect_timeout":1500,"address":"integ-test.go-fastly.com","name":"new-test-backend","ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","ssl_ca_cert":null,"deleted_at":null,"hostname":"integ-test.go-fastly.com","comment":"","updated_at":"2022-11-04T16:54:47Z","ssl_client_cert":null,"error_threshold":0,"shield":null,"ssl_check_cert":false,"created_at":"2022-11-04T16:54:46Z","port":0,"ssl_hostname":null,"between_bytes_timeout":10000,"max_tls_version":null,"client_cert":null,"auto_loadbalance":false,"ssl_cert_hostname":null,"ipv4":null,"first_byte_timeout":15000}'
+    body: '{"ssl_hostname":null,"ssl_ca_cert":null,"first_byte_timeout":15000,"override_host":null,"ssl_sni_hostname":"ssl-hostname-updated.com","weight":100,"min_tls_version":null,"version":123,"between_bytes_timeout":10000,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","ssl_client_cert":null,"updated_at":"2023-08-07T10:02:08Z","ipv6":null,"auto_loadbalance":false,"connect_timeout":1500,"keepalive_time":null,"share_key":"shared-key","error_threshold":0,"ipv4":null,"max_tls_version":null,"healthcheck":null,"deleted_at":null,"ssl_cert_hostname":null,"request_condition":"","client_cert":null,"created_at":"2023-08-07T10:02:07Z","hostname":"integ-test.go-fastly.com","shield":null,"use_ssl":false,"ssl_client_key":null,"max_conn":200,"ssl_check_cert":false,"name":"new-test-backend","comment":"","port":0,"address":"integ-test.go-fastly.com","service_id":"7i6HN3TK9wS159v2gPAZ8A"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -25,11 +25,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:48 GMT
+      - Mon, 07 Aug 2023 10:02:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "9930"
+      - "9995"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1691406000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-2-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580889.503553,VS0,VE214
+      - S1691402529.263955,VS0,VE245
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update_ignore_empty_values.yaml
+++ b/fastly/fixtures/backends/update_ignore_empty_values.yaml
@@ -8,11 +8,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/68/backend/new-test-backend
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/123/backend/new-test-backend
     method: PUT
   response:
-    body: '{"connect_timeout":1500,"deleted_at":null,"use_ssl":false,"address":"integ-test.go-fastly.com","port":1234,"name":"new-test-backend","ssl_client_key":null,"auto_loadbalance":false,"ipv6":null,"updated_at":"2022-11-04T16:54:47Z","healthcheck":null,"ssl_ca_cert":null,"min_tls_version":null,"request_condition":"","ssl_sni_hostname":"ssl-hostname-updated.com","error_threshold":0,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","first_byte_timeout":15000,"client_cert":null,"ssl_hostname":null,"ssl_client_cert":null,"comment":"","override_host":"www.example.com","weight":100,"version":68,"ssl_cert_hostname":null,"between_bytes_timeout":10000,"max_tls_version":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","hostname":"integ-test.go-fastly.com","created_at":"2022-11-04T16:54:46Z","max_conn":200,"ssl_check_cert":false,"shield":null,"ipv4":null}'
+    body: '{"min_tls_version":null,"healthcheck":null,"weight":100,"ssl_check_cert":false,"share_key":"shared-key","updated_at":"2023-08-07T10:02:08Z","connect_timeout":1500,"request_condition":"","error_threshold":0,"shield":null,"ipv6":null,"version":123,"keepalive_time":null,"ssl_sni_hostname":"ssl-hostname-updated.com","client_cert":null,"ssl_client_key":null,"between_bytes_timeout":10000,"use_ssl":false,"max_tls_version":null,"port":1234,"ipv4":null,"ssl_hostname":null,"override_host":"www.example.com","ssl_client_cert":null,"ssl_ciphers":"RC4:!COMPLEMENTOFDEFAULT","name":"new-test-backend","hostname":"integ-test.go-fastly.com","first_byte_timeout":15000,"created_at":"2023-08-07T10:02:07Z","address":"integ-test.go-fastly.com","max_conn":200,"ssl_ca_cert":null,"auto_loadbalance":false,"comment":"","service_id":"7i6HN3TK9wS159v2gPAZ8A","deleted_at":null,"ssl_cert_hostname":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:48 GMT
+      - Mon, 07 Aug 2023 10:02:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "9931"
+      - "9996"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1691406000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-1-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580888.015080,VS0,VE380
+      - S1691402529.925578,VS0,VE270
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/version.yaml
+++ b/fastly/fixtures/backends/version.yaml
@@ -2,19 +2,17 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A
-    form:
-      ServiceID:
-      - 7i6HN3TK9wS159v2gPAZ8A
+    body: ""
+    form: {}
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+      - FastlyGo/8.5.8 (+github.com/fastly/go-fastly; go1.18.5)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":68}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":123}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:54:46 GMT
+      - Mon, 07 Aug 2023 10:02:07 GMT
       Fastly-Ratelimit-Remaining:
-      - "9934"
+      - "9999"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1691406000"
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +39,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4143-MAN
+      - cache-control-cp-aws-us-east-2-prod-2-CONTROL-AWS-UE2, cache-lhr7321-LHR
       X-Timer:
-      - S1667580886.396536,VS0,VE208
+      - S1691402527.220659,VS0,VE288
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
I tested this locally using the following script and was seeing an API validation error. This validation error was fixed internally by Fastly and now when running the script I get the expected `valid! true` output.

```go
package main

import (
	"fmt"
	"log"
	"os"

	"github.com/fastly/go-fastly/v8/fastly"
)

func main() {
	client, err := fastly.NewClient(os.Getenv("FASTLY_API_KEY"))
	if err != nil {
		log.Fatal(err)
	}

	serviceID := "<REDACTED>"

	_, err = client.UpdateBackend(&fastly.UpdateBackendInput{
		Name:           "example-backend",
		ShareKey:       fastly.String("<REDACTED>"),
		ServiceID:      serviceID,
		ServiceVersion: 1,
	})
	if err != nil {
		log.Fatal(err)
	}

	valid, reason, err := client.ValidateVersion(&fastly.ValidateVersionInput{
		ServiceID:      serviceID,
		ServiceVersion: 1,
	})
	if err != nil {
		log.Fatal(err)
	}
	if !valid {
		log.Fatalf("not valid version '%s': %s", reason, err)
	}

	fmt.Printf("valid! %#v\n", valid)
}
```