### PR TITLE
build: bump minimum go version to 1.19

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - name: Restore cache
       id: cache
       uses: actions/cache@v2
@@ -46,7 +46,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.19.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ mod-download: ## Downloads the Go module.
 
 dev-dependencies: ## Downloads the necessary dev dependencies.
 	@echo "==> Downloading development dependencies"
-	@$(GO) install honnef.co/go/tools/cmd/staticcheck
+	@$(GO) install honnef.co/go/tools/cmd/staticcheck@2023.1.5
 	@$(GO) install golang.org/x/tools/cmd/goimports
 	@if [[ "$$(uname)" == 'Darwin' ]]; then brew install semgrep; fi
 .PHONY: dev-dependencies

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,4 @@ require (
 // Security: FASTLY_DEBUG_MODE wasn't redacting Fastly-Key.
 retract v8.5.3
 
-go 1.18
+go 1.19


### PR DESCRIPTION
The latest go version is 1.21 and I like to keep go-fastly two versions back from the latest.