### PR TITLE
feat(auth): OAuth/PCKE callers

### DIFF
--- a/fastly/request.go
+++ b/fastly/request.go
@@ -1,6 +1,7 @@
 package fastly
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -54,6 +55,7 @@ func (c *Client) RawRequest(verb, p string, ro *RequestOptions) (*http.Request, 
 	// Set the API key.
 	if len(c.apiKey) > 0 {
 		request.Header.Set(APIKeyHeader, c.apiKey)
+		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
 	}
 
 	// Set the User-Agent.
@@ -92,6 +94,7 @@ func (c *Client) SimpleGet(target string) (*http.Response, error) {
 
 	if len(c.apiKey) > 0 {
 		request.Header.Set(APIKeyHeader, c.apiKey)
+		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
 	}
 	request.Header.Set("User-Agent", UserAgent)
 


### PR DESCRIPTION
In a future world, callers (such as the Fastly CLI) will authenticate using OAuth (specifically the PKCE extension flow) and so the token that is provided will need to be used with the `Authentication` HTTP request header.