### PR TITLE
doc: rename Compute@Edge to Compute

### DIFF
--- a/fastly/secret_store.go
+++ b/fastly/secret_store.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Secret Store.
-// A secret store is a persistent, globally distributed store for secrets accessible to Compute@Edge services during request processing.
+// A secret store is a persistent, globally distributed store for secrets accessible to Compute services during request processing.
 // https://developer.fastly.com/reference/api/secret-store/
 
 // SecretStoreMeta is the metadata returned from Secret Store paginated responses.


### PR DESCRIPTION
NOTE: I've not updated the CHANGELOG because that is a historical record and the name Compute@Edge exists within the context of the GitHub commits. I've also not updated the fixture files as this change requires the rename to have been rolled out to API endpoints.