### PR TITLE
fix: all relevant fields to be pointers

### DIFF
--- a/fastly/acl_entries_batch_test.go
+++ b/fastly/acl_entries_batch_test.go
@@ -11,15 +11,15 @@ func TestClient_BatchModifyACLEntries_Create(t *testing.T) {
 
 	// Given: a test service with an ACL and a batch of create operations,
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testACL := createTestACL(t, fixtureBase+"create_acl", testService.ID, testVersion.Number, nameSuffix)
+	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
 
 	batchCreateOperations := &BatchModifyACLEntriesInput{
-		ServiceID: testService.ID,
+		ServiceID: *testService.ID,
 		ACLID:     *testACL.ID,
 		Entries: []*BatchACLEntry{
 			{
@@ -52,7 +52,7 @@ func TestClient_BatchModifyACLEntries_Create(t *testing.T) {
 	var actualACLEntries []*ACLEntry
 	record(t, fixtureBase+"list_after_create", func(c *Client) {
 		actualACLEntries, err = c.ListACLEntries(&ListACLEntriesInput{
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			ACLID:     *testACL.ID,
 		})
 	})
@@ -107,15 +107,15 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 
 	// Given: a test service with an ACL and a batch of create operations,
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testACL := createTestACL(t, fixtureBase+"create_acl", testService.ID, testVersion.Number, nameSuffix)
+	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
 
 	batchCreateOperations := &BatchModifyACLEntriesInput{
-		ServiceID: testService.ID,
+		ServiceID: *testService.ID,
 		ACLID:     *testACL.ID,
 		Entries: []*BatchACLEntry{
 			{
@@ -146,7 +146,7 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 	var createdACLEntries []*ACLEntry
 	record(t, fixtureBase+"list_before_delete", func(client *Client) {
 		createdACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			ACLID:     *testACL.ID,
 		})
 	})
@@ -160,7 +160,7 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 
 	// When: I execute the batch delete operations against the Fastly API,
 	batchDeleteOperations := &BatchModifyACLEntriesInput{
-		ServiceID: testService.ID,
+		ServiceID: *testService.ID,
 		ACLID:     *testACL.ID,
 		Entries: []*BatchACLEntry{
 			{
@@ -181,7 +181,7 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 	var actualACLEntries []*ACLEntry
 	record(t, fixtureBase+"list_after_delete", func(client *Client) {
 		actualACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			ACLID:     *testACL.ID,
 		})
 	})
@@ -206,15 +206,15 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 
 	// Given: a test service with an ACL and ACL entries,
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testACL := createTestACL(t, fixtureBase+"create_acl", testService.ID, testVersion.Number, nameSuffix)
+	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
 
 	batchCreateOperations := &BatchModifyACLEntriesInput{
-		ServiceID: testService.ID,
+		ServiceID: *testService.ID,
 		ACLID:     *testACL.ID,
 		Entries: []*BatchACLEntry{
 			{
@@ -245,7 +245,7 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 	var createdACLEntries []*ACLEntry
 	record(t, fixtureBase+"list_before_update", func(client *Client) {
 		createdACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			ACLID:     *testACL.ID,
 		})
 	})
@@ -259,7 +259,7 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 
 	// When: I execute the batch update operations against the Fastly API,
 	batchUpdateOperations := &BatchModifyACLEntriesInput{
-		ServiceID: testService.ID,
+		ServiceID: *testService.ID,
 		ACLID:     *testACL.ID,
 		Entries: []*BatchACLEntry{
 			{
@@ -284,7 +284,7 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 	var actualACLEntries []*ACLEntry
 	record(t, fixtureBase+"list_after_update", func(client *Client) {
 		actualACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			ACLID:     *testACL.ID,
 		})
 	})

--- a/fastly/acl_entries_batch_test.go
+++ b/fastly/acl_entries_batch_test.go
@@ -15,7 +15,7 @@ func TestClient_BatchModifyACLEntries_Create(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ID, testVersion.Number, nameSuffix)
+	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
 
 	batchCreateOperations := &BatchModifyACLEntriesInput{
@@ -111,7 +111,7 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ID, testVersion.Number, nameSuffix)
+	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
 
 	batchCreateOperations := &BatchModifyACLEntriesInput{
@@ -210,7 +210,7 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ID, testVersion.Number, nameSuffix)
+	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
 
 	batchCreateOperations := &BatchModifyACLEntriesInput{

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -53,7 +53,7 @@ func (c *Client) GetACLEntries(i *GetACLEntriesInput) *ListPaginator[ACLEntry] {
 		input.PerPage = *i.PerPage
 	}
 	path := fmt.Sprintf(aclEntriesPath, i.ServiceID, i.ACLID)
-	return newPaginator[ACLEntry](c, input, path)
+	return NewPaginator[ACLEntry](c, input, path)
 }
 
 // ListACLEntriesInput is the input parameter to ListACLEntries function.

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -39,7 +39,7 @@ type GetACLEntriesInput struct {
 
 // GetACLEntries returns a ListPaginator for paginating through the resources.
 func (c *Client) GetACLEntries(i *GetACLEntriesInput) *ListPaginator[ACLEntry] {
-	input := &listInput{}
+	input := &ListOpts{}
 	if i.Direction != nil {
 		input.Direction = *i.Direction
 	}

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -39,7 +39,7 @@ type GetACLEntriesInput struct {
 
 // GetACLEntries returns a ListPaginator for paginating through the resources.
 func (c *Client) GetACLEntries(i *GetACLEntriesInput) *ListPaginator[ACLEntry] {
-	input := &ListOpts{}
+	input := ListOpts{}
 	if i.Direction != nil {
 		input.Direction = *i.Direction
 	}

--- a/fastly/acl_entry_test.go
+++ b/fastly/acl_entry_test.go
@@ -9,11 +9,11 @@ func TestClient_ACLEntries(t *testing.T) {
 	nameSuffix := "ACLEntries"
 
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"version", *testService.ID)
 
-	testACL := createTestACL(t, fixtureBase+"acl", testService.ID, testVersion.Number, nameSuffix)
+	testACL := createTestACL(t, fixtureBase+"acl", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
 
 	// Create
@@ -21,7 +21,7 @@ func TestClient_ACLEntries(t *testing.T) {
 	var e *ACLEntry
 	record(t, fixtureBase+"create", func(c *Client) {
 		e, err = c.CreateACLEntry(&CreateACLEntryInput{
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			ACLID:     *testACL.ID,
 			IP:        ToPointer("10.0.0.3"),
 			Subnet:    ToPointer(8),
@@ -55,7 +55,7 @@ func TestClient_ACLEntries(t *testing.T) {
 		es, err = c.ListACLEntries(&ListACLEntriesInput{
 			ACLID:     *testACL.ID,
 			Direction: ToPointer("descend"),
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			Sort:      ToPointer("created"),
 		})
 	})
@@ -75,7 +75,7 @@ func TestClient_ACLEntries(t *testing.T) {
 			ACLID:     *testACL.ID,
 			Direction: ToPointer("ascend"),
 			PerPage:   ToPointer(50),
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			Sort:      ToPointer("ip"),
 		})
 
@@ -102,7 +102,7 @@ func TestClient_ACLEntries(t *testing.T) {
 	var ne *ACLEntry
 	record(t, fixtureBase+"get", func(c *Client) {
 		ne, err = c.GetACLEntry(&GetACLEntryInput{
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			ACLID:     *testACL.ID,
 			ID:        *e.ID,
 		})
@@ -128,7 +128,7 @@ func TestClient_ACLEntries(t *testing.T) {
 	var ue *ACLEntry
 	record(t, fixtureBase+"update", func(c *Client) {
 		ue, err = c.UpdateACLEntry(&UpdateACLEntryInput{
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			ACLID:     *testACL.ID,
 			ID:        *e.ID,
 			IP:        ToPointer("10.0.0.4"),
@@ -157,7 +157,7 @@ func TestClient_ACLEntries(t *testing.T) {
 	// Delete
 	record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteACLEntry(&DeleteACLEntryInput{
-			ServiceID: testService.ID,
+			ServiceID: *testService.ID,
 			ACLID:     *testACL.ID,
 			ID:        *e.ID,
 		})

--- a/fastly/acl_entry_test.go
+++ b/fastly/acl_entry_test.go
@@ -13,7 +13,7 @@ func TestClient_ACLEntries(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"version", *testService.ID)
 
-	testACL := createTestACL(t, fixtureBase+"acl", *testService.ID, testVersion.Number, nameSuffix)
+	testACL := createTestACL(t, fixtureBase+"acl", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
 
 	// Create

--- a/fastly/acl_test.go
+++ b/fastly/acl_test.go
@@ -17,7 +17,7 @@ func TestClient_ACLs(t *testing.T) {
 	record(t, fixtureBase+"create", func(c *Client) {
 		a, err = c.CreateACL(&CreateACLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           ToPointer("test_acl"),
 		})
 	})
@@ -30,7 +30,7 @@ func TestClient_ACLs(t *testing.T) {
 	record(t, fixtureBase+"create_expected_error", func(c *Client) {
 		_, errExpected = c.CreateACL(&CreateACLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 		})
 	})
 	if errExpected == nil {
@@ -42,13 +42,13 @@ func TestClient_ACLs(t *testing.T) {
 		record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteACL(&DeleteACLInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: testVersion.Number,
+				ServiceVersion: *testVersion.Number,
 				Name:           "test_acl",
 			})
 
 			_ = c.DeleteACL(&DeleteACLInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: testVersion.Number,
+				ServiceVersion: *testVersion.Number,
 				Name:           "new_test_acl",
 			})
 		})
@@ -63,7 +63,7 @@ func TestClient_ACLs(t *testing.T) {
 	record(t, fixtureBase+"list", func(c *Client) {
 		as, err = c.ListACLs(&ListACLsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 		})
 	})
 	if err != nil {
@@ -78,7 +78,7 @@ func TestClient_ACLs(t *testing.T) {
 	record(t, fixtureBase+"get", func(c *Client) {
 		na, err = c.GetACL(&GetACLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           "test_acl",
 		})
 	})
@@ -94,7 +94,7 @@ func TestClient_ACLs(t *testing.T) {
 	record(t, fixtureBase+"update", func(c *Client) {
 		ua, err = c.UpdateACL(&UpdateACLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           "test_acl",
 			NewName:        ToPointer("new_test_acl"),
 		})
@@ -114,7 +114,7 @@ func TestClient_ACLs(t *testing.T) {
 	record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteACL(&DeleteACLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           "new_test_acl",
 		})
 	})

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -34,7 +34,6 @@ type Backend struct {
 	SSLCiphers          *string    `mapstructure:"ssl_ciphers"`
 	SSLClientCert       *string    `mapstructure:"ssl_client_cert"`
 	SSLClientKey        *string    `mapstructure:"ssl_client_key"`
-	SSLHostname         *string    `mapstructure:"ssl_hostname"`
 	SSLSNIHostname      *string    `mapstructure:"ssl_sni_hostname"`
 	ServiceID           *string    `mapstructure:"service_id"`
 	ServiceVersion      *int       `mapstructure:"version"`

--- a/fastly/backend_test.go
+++ b/fastly/backend_test.go
@@ -18,7 +18,7 @@ func TestClient_Backends(t *testing.T) {
 	record(t, "backends/create", func(c *Client) {
 		b, err = c.CreateBackend(&CreateBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-backend"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
 			ConnectTimeout: ToPointer(1500),
@@ -37,13 +37,13 @@ func TestClient_Backends(t *testing.T) {
 		record(t, "backends/cleanup", func(c *Client) {
 			_ = c.DeleteBackend(&DeleteBackendInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-backend",
 			})
 
 			_ = c.DeleteBackend(&DeleteBackendInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-backend",
 			})
 		})
@@ -79,7 +79,7 @@ func TestClient_Backends(t *testing.T) {
 	record(t, "backends/list", func(c *Client) {
 		bs, err = c.ListBackends(&ListBackendsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -94,7 +94,7 @@ func TestClient_Backends(t *testing.T) {
 	record(t, "backends/get", func(c *Client) {
 		nb, err = c.GetBackend(&GetBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-backend",
 		})
 	})
@@ -122,7 +122,7 @@ func TestClient_Backends(t *testing.T) {
 	record(t, "backends/update", func(c *Client) {
 		ub, err = c.UpdateBackend(&UpdateBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-backend",
 			NewName:        ToPointer("new-test-backend"),
 			OverrideHost:   ToPointer("www.example.com"),
@@ -159,7 +159,7 @@ func TestClient_Backends(t *testing.T) {
 	record(t, "backends/update_ignore_empty_values", func(c *Client) {
 		ub, err = c.UpdateBackend(&UpdateBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-backend",
 		})
 	})
@@ -181,7 +181,7 @@ func TestClient_Backends(t *testing.T) {
 	record(t, "backends/update_allow_empty_values", func(c *Client) {
 		ub, err = c.UpdateBackend(&UpdateBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-backend",
 			OverrideHost:   ToPointer(""),
 			Port:           ToPointer(0),
@@ -201,7 +201,7 @@ func TestClient_Backends(t *testing.T) {
 	record(t, "backends/delete", func(c *Client) {
 		err = c.DeleteBackend(&DeleteBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-backend",
 		})
 	})

--- a/fastly/basictypes_helper.go
+++ b/fastly/basictypes_helper.go
@@ -1,7 +1,7 @@
 package fastly
 
 type MultiConstraint interface {
-	~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | uint64 | ~bool
+	~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | uint64 | float64 | ~bool
 }
 
 // ToPointer converts T to *T.

--- a/fastly/basictypes_helper.go
+++ b/fastly/basictypes_helper.go
@@ -1,7 +1,7 @@
 package fastly
 
 // ToPointer converts T to *T.
-func ToPointer[T ~string | ~int | ~int32 | ~int64 | uint | uint8 | ~bool](v T) *T {
+func ToPointer[T ~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | ~bool](v T) *T {
 	return &v
 }
 

--- a/fastly/basictypes_helper.go
+++ b/fastly/basictypes_helper.go
@@ -1,5 +1,6 @@
 package fastly
 
+// MultiConstraint is a generic constraint for ToPointer/ToValue.
 type MultiConstraint interface {
 	~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | uint64 | float64 | ~bool
 }

--- a/fastly/basictypes_helper.go
+++ b/fastly/basictypes_helper.go
@@ -1,7 +1,7 @@
 package fastly
 
 type MultiConstraint interface {
-	~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | ~bool
+	~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | uint64 | ~bool
 }
 
 // ToPointer converts T to *T.

--- a/fastly/basictypes_helper.go
+++ b/fastly/basictypes_helper.go
@@ -1,13 +1,17 @@
 package fastly
 
+type MultiConstraint interface {
+	~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | ~bool
+}
+
 // ToPointer converts T to *T.
-func ToPointer[T ~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | ~bool](v T) *T {
+func ToPointer[T MultiConstraint](v T) *T {
 	return &v
 }
 
 // ToValue converts *T to T.
 // If v is nil, then return T's zero value.
-func ToValue[T ~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | ~bool](v *T) T {
+func ToValue[T MultiConstraint](v *T) T {
 	if v != nil {
 		return *v
 	}

--- a/fastly/basictypes_helper.go
+++ b/fastly/basictypes_helper.go
@@ -5,6 +5,16 @@ func ToPointer[T ~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | ~bool
 	return &v
 }
 
+// ToValue converts *T to T.
+// If v is nil, then return T's zero value.
+func ToValue[T ~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | ~bool](v *T) T {
+	if v != nil {
+		return *v
+	}
+	var zero T
+	return zero
+}
+
 // NullString is a helper that returns a pointer to the string value passed in
 // or nil if the string is empty.
 //

--- a/fastly/basictypes_helper.go
+++ b/fastly/basictypes_helper.go
@@ -1,7 +1,7 @@
 package fastly
 
 // ToPointer converts T to *T.
-func ToPointer[T ~string | ~int | uint | uint8 | ~bool](v T) *T {
+func ToPointer[T ~string | ~int | ~int32 | ~int64 | uint | uint8 | ~bool](v T) *T {
 	return &v
 }
 

--- a/fastly/bigquery_test.go
+++ b/fastly/bigquery_test.go
@@ -21,7 +21,7 @@ func TestClient_Bigqueries(t *testing.T) {
 	record(t, "bigqueries/create", func(c *Client) {
 		bq, err = c.CreateBigQuery(&CreateBigQueryInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-bigquery"),
 			ProjectID:      ToPointer("example-fastly-log"),
 			Dataset:        ToPointer("fastly_log_test"),
@@ -44,13 +44,13 @@ func TestClient_Bigqueries(t *testing.T) {
 		record(t, "bigqueries/cleanup", func(c *Client) {
 			_ = c.DeleteBigQuery(&DeleteBigQueryInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-bigquery",
 			})
 
 			_ = c.DeleteBigQuery(&DeleteBigQueryInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-bigquery",
 			})
 		})
@@ -98,7 +98,7 @@ func TestClient_Bigqueries(t *testing.T) {
 	record(t, "bigqueries/list", func(c *Client) {
 		bqs, err = c.ListBigQueries(&ListBigQueriesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -113,7 +113,7 @@ func TestClient_Bigqueries(t *testing.T) {
 	record(t, "bigqueries/get", func(c *Client) {
 		nbq, err = c.GetBigQuery(&GetBigQueryInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-bigquery",
 		})
 	})
@@ -159,7 +159,7 @@ func TestClient_Bigqueries(t *testing.T) {
 	record(t, "bigqueries/update", func(c *Client) {
 		ubq, err = c.UpdateBigQuery(&UpdateBigQueryInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-bigquery",
 			NewName:        ToPointer("new-test-bigquery"),
 		})
@@ -175,7 +175,7 @@ func TestClient_Bigqueries(t *testing.T) {
 	record(t, "bigqueries/delete", func(c *Client) {
 		err = c.DeleteBigQuery(&DeleteBigQueryInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-bigquery",
 		})
 	})

--- a/fastly/blobstorage_test.go
+++ b/fastly/blobstorage_test.go
@@ -22,7 +22,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/create", func(c *Client) {
 		bsCreateResp1, err = c.CreateBlobStorage(&CreateBlobStorageInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-blobstorage"),
 			Path:             ToPointer("/logs"),
 			AccountName:      ToPointer("test"),
@@ -46,7 +46,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/create2", func(c *Client) {
 		bsCreateResp2, err = c.CreateBlobStorage(&CreateBlobStorageInput{
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-blobstorage-2"),
 			Path:            ToPointer("/logs"),
 			AccountName:     ToPointer("test"),
@@ -70,7 +70,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/create3", func(c *Client) {
 		bsCreateResp3, err = c.CreateBlobStorage(&CreateBlobStorageInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-blobstorage-3"),
 			Path:             ToPointer("/logs"),
 			AccountName:      ToPointer("test"),
@@ -95,7 +95,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/create4", func(c *Client) {
 		_, err = c.CreateBlobStorage(&CreateBlobStorageInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-blobstorage-4"),
 			Path:             ToPointer("/logs"),
 			AccountName:      ToPointer("test"),
@@ -122,25 +122,25 @@ func TestClient_BlobStorages(t *testing.T) {
 		record(t, "blobstorages/cleanup", func(c *Client) {
 			_ = c.DeleteBlobStorage(&DeleteBlobStorageInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-blobstorage",
 			})
 
 			_ = c.DeleteBlobStorage(&DeleteBlobStorageInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-blobstorage-2",
 			})
 
 			_ = c.DeleteBlobStorage(&DeleteBlobStorageInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-blobstorage-3",
 			})
 
 			_ = c.DeleteBlobStorage(&DeleteBlobStorageInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-blobstorage",
 			})
 		})
@@ -215,7 +215,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/list", func(c *Client) {
 		bsl, err = c.ListBlobStorages(&ListBlobStoragesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -230,7 +230,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/get", func(c *Client) {
 		bsGetResp, err = c.GetBlobStorage(&GetBlobStorageInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-blobstorage",
 		})
 	})
@@ -285,7 +285,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/update", func(c *Client) {
 		bsUpdateResp1, err = c.UpdateBlobStorage(&UpdateBlobStorageInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-blobstorage",
 			NewName:          ToPointer("new-test-blobstorage"),
 			CompressionCodec: ToPointer("zstd"),
@@ -301,7 +301,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/update2", func(c *Client) {
 		bsUpdateResp2, err = c.UpdateBlobStorage(&UpdateBlobStorageInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-blobstorage-2",
 			CompressionCodec: ToPointer("zstd"),
 		})
@@ -315,7 +315,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/update3", func(c *Client) {
 		bsUpdateResp3, err = c.UpdateBlobStorage(&UpdateBlobStorageInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-blobstorage-3",
 			GzipLevel:      ToPointer(9),
 		})
@@ -350,7 +350,7 @@ func TestClient_BlobStorages(t *testing.T) {
 	record(t, "blobstorages/delete", func(c *Client) {
 		err = c.DeleteBlobStorage(&DeleteBlobStorageInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-blobstorage",
 		})
 	})

--- a/fastly/cache_setting_test.go
+++ b/fastly/cache_setting_test.go
@@ -18,7 +18,7 @@ func TestClient_CacheSettings(t *testing.T) {
 	record(t, "cache_settings/create", func(c *Client) {
 		cacheSetting, err = c.CreateCacheSetting(&CreateCacheSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-cache-setting"),
 			Action:         ToPointer(CacheSettingActionCache),
 			TTL:            ToPointer(1234),
@@ -34,13 +34,13 @@ func TestClient_CacheSettings(t *testing.T) {
 		record(t, "cache_settings/cleanup", func(c *Client) {
 			_ = c.DeleteCacheSetting(&DeleteCacheSettingInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-cache-setting",
 			})
 
 			_ = c.DeleteCacheSetting(&DeleteCacheSettingInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-cache-setting",
 			})
 		})
@@ -64,7 +64,7 @@ func TestClient_CacheSettings(t *testing.T) {
 	record(t, "cache_settings/list", func(c *Client) {
 		cacheSettings, err = c.ListCacheSettings(&ListCacheSettingsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -79,7 +79,7 @@ func TestClient_CacheSettings(t *testing.T) {
 	record(t, "cache_settings/get", func(c *Client) {
 		newCacheSetting, err = c.GetCacheSetting(&GetCacheSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-cache-setting",
 		})
 	})
@@ -104,7 +104,7 @@ func TestClient_CacheSettings(t *testing.T) {
 	record(t, "cache_settings/update", func(c *Client) {
 		updatedCacheSetting, err = c.UpdateCacheSetting(&UpdateCacheSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-cache-setting",
 			NewName:        ToPointer("new-test-cache-setting"),
 		})
@@ -120,7 +120,7 @@ func TestClient_CacheSettings(t *testing.T) {
 	record(t, "cache_settings/delete", func(c *Client) {
 		err = c.DeleteCacheSetting(&DeleteCacheSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-cache-setting",
 		})
 	})

--- a/fastly/cloudfiles_test.go
+++ b/fastly/cloudfiles_test.go
@@ -18,7 +18,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/create", func(c *Client) {
 		cloudfilesCreateResp1, err = c.CreateCloudfiles(&CreateCloudfilesInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-cloudfiles"),
 			User:             ToPointer("user"),
 			AccessKey:        ToPointer("secret-key"),
@@ -42,7 +42,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/create2", func(c *Client) {
 		cloudfilesCreateResp2, err = c.CreateCloudfiles(&CreateCloudfilesInput{
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-cloudfiles-2"),
 			User:            ToPointer("user"),
 			AccessKey:       ToPointer("secret-key"),
@@ -66,7 +66,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/create3", func(c *Client) {
 		cloudfilesCreateResp3, err = c.CreateCloudfiles(&CreateCloudfilesInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-cloudfiles-3"),
 			User:             ToPointer("user"),
 			AccessKey:        ToPointer("secret-key"),
@@ -92,7 +92,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/create4", func(c *Client) {
 		_, err = c.CreateCloudfiles(&CreateCloudfilesInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-cloudfiles-4"),
 			User:             ToPointer("user"),
 			AccessKey:        ToPointer("secret-key"),
@@ -119,25 +119,25 @@ func TestClient_Cloudfiles(t *testing.T) {
 		record(t, "cloudfiles/cleanup", func(c *Client) {
 			_ = c.DeleteCloudfiles(&DeleteCloudfilesInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-cloudfiles",
 			})
 
 			_ = c.DeleteCloudfiles(&DeleteCloudfilesInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-cloudfiles-2",
 			})
 
 			_ = c.DeleteCloudfiles(&DeleteCloudfilesInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-cloudfiles-3",
 			})
 
 			_ = c.DeleteCloudfiles(&DeleteCloudfilesInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-cloudfiles",
 			})
 		})
@@ -203,7 +203,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/list", func(c *Client) {
 		lc, err = c.ListCloudfiles(&ListCloudfilesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -218,7 +218,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/get", func(c *Client) {
 		cloudfilesGetResp, err = c.GetCloudfiles(&GetCloudfilesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-cloudfiles",
 		})
 	})
@@ -276,7 +276,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/update", func(c *Client) {
 		cloudfilesUpdateResp1, err = c.UpdateCloudfiles(&UpdateCloudfilesInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-cloudfiles",
 			NewName:          ToPointer("new-test-cloudfiles"),
 			User:             ToPointer("new-user"),
@@ -292,7 +292,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/update2", func(c *Client) {
 		cloudfilesUpdateResp2, err = c.UpdateCloudfiles(&UpdateCloudfilesInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-cloudfiles-2",
 			CompressionCodec: ToPointer("zstd"),
 		})
@@ -304,7 +304,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/update3", func(c *Client) {
 		cloudfilesUpdateResp3, err = c.UpdateCloudfiles(&UpdateCloudfilesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-cloudfiles-3",
 			GzipLevel:      ToPointer(9),
 		})
@@ -351,7 +351,7 @@ func TestClient_Cloudfiles(t *testing.T) {
 	record(t, "cloudfiles/delete", func(c *Client) {
 		err = c.DeleteCloudfiles(&DeleteCloudfilesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-cloudfiles",
 		})
 	})

--- a/fastly/condition_test.go
+++ b/fastly/condition_test.go
@@ -18,7 +18,7 @@ func TestClient_Conditions(t *testing.T) {
 	record(t, "conditions/create", func(c *Client) {
 		condition, err = c.CreateCondition(&CreateConditionInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test/condition"),
 			Statement:      ToPointer("req.url~+\"index.html\""),
 			Type:           ToPointer("REQUEST"),
@@ -34,7 +34,7 @@ func TestClient_Conditions(t *testing.T) {
 		record(t, "conditions/cleanup", func(c *Client) {
 			_ = c.DeleteCondition(&DeleteConditionInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test/condition",
 			})
 		})
@@ -58,7 +58,7 @@ func TestClient_Conditions(t *testing.T) {
 	record(t, "conditions/list", func(c *Client) {
 		conditions, err = c.ListConditions(&ListConditionsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -73,7 +73,7 @@ func TestClient_Conditions(t *testing.T) {
 	record(t, "conditions/get", func(c *Client) {
 		newCondition, err = c.GetCondition(&GetConditionInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test/condition",
 		})
 	})
@@ -98,7 +98,7 @@ func TestClient_Conditions(t *testing.T) {
 	record(t, "conditions/update", func(c *Client) {
 		updatedCondition, err = c.UpdateCondition(&UpdateConditionInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test/condition",
 			Statement:      ToPointer("req.url~+\"updated.html\""),
 		})
@@ -114,7 +114,7 @@ func TestClient_Conditions(t *testing.T) {
 	record(t, "conditions/delete", func(c *Client) {
 		err = c.DeleteCondition(&DeleteConditionInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test/condition",
 		})
 	})

--- a/fastly/datadog_test.go
+++ b/fastly/datadog_test.go
@@ -18,7 +18,7 @@ func TestClient_Datadog(t *testing.T) {
 	record(t, "datadog/create", func(c *Client) {
 		d, err = c.CreateDatadog(&CreateDatadogInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-datadog"),
 			Region:         ToPointer("US"),
 			Token:          ToPointer("abcd1234"),
@@ -35,13 +35,13 @@ func TestClient_Datadog(t *testing.T) {
 		record(t, "datadog/delete", func(c *Client) {
 			c.DeleteDatadog(&DeleteDatadogInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-datadog",
 			})
 
 			c.DeleteDatadog(&DeleteDatadogInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-datadog",
 			})
 		})
@@ -71,7 +71,7 @@ func TestClient_Datadog(t *testing.T) {
 	record(t, "datadog/list", func(c *Client) {
 		ld, err = c.ListDatadog(&ListDatadogInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -86,7 +86,7 @@ func TestClient_Datadog(t *testing.T) {
 	record(t, "datadog/get", func(c *Client) {
 		nd, err = c.GetDatadog(&GetDatadogInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-datadog",
 		})
 	})
@@ -114,7 +114,7 @@ func TestClient_Datadog(t *testing.T) {
 	record(t, "datadog/update", func(c *Client) {
 		ud, err = c.UpdateDatadog(&UpdateDatadogInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-datadog",
 			NewName:        ToPointer("new-test-datadog"),
 			Region:         ToPointer("EU"),
@@ -138,7 +138,7 @@ func TestClient_Datadog(t *testing.T) {
 	record(t, "datadog/delete", func(c *Client) {
 		err = c.DeleteDatadog(&DeleteDatadogInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-datadog",
 		})
 	})

--- a/fastly/dictionary.go
+++ b/fastly/dictionary.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,30 +10,12 @@ import (
 type Dictionary struct {
 	CreatedAt      *time.Time `mapstructure:"created_at"`
 	DeletedAt      *time.Time `mapstructure:"deleted_at"`
-	ID             string     `mapstructure:"id"`
-	Name           string     `mapstructure:"name"`
-	ServiceID      string     `mapstructure:"service_id"`
-	ServiceVersion int        `mapstructure:"version"`
+	ID             *string    `mapstructure:"id"`
+	Name           *string    `mapstructure:"name"`
+	ServiceID      *string    `mapstructure:"service_id"`
+	ServiceVersion *int       `mapstructure:"version"`
 	UpdatedAt      *time.Time `mapstructure:"updated_at"`
-	WriteOnly      bool       `mapstructure:"write_only"`
-}
-
-// dictionariesByName is a sortable list of dictionaries.
-type dictionariesByName []*Dictionary
-
-// Len implement the sortable interface.
-func (s dictionariesByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s dictionariesByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s dictionariesByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	WriteOnly      *bool      `mapstructure:"write_only"`
 }
 
 // ListDictionariesInput is used as input to the ListDictionaries function.
@@ -65,7 +46,6 @@ func (c *Client) ListDictionaries(i *ListDictionariesInput) ([]*Dictionary, erro
 	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
-	sort.Stable(dictionariesByName(bs))
 	return bs, nil
 }
 

--- a/fastly/dictionary_info.go
+++ b/fastly/dictionary_info.go
@@ -8,16 +8,16 @@ import (
 // DictionaryInfo represents a dictionary metadata response from the Fastly API.
 type DictionaryInfo struct {
 	// Digest is the hash of the dictionary content.
-	Digest string `mapstructure:"digest"`
+	Digest *string `mapstructure:"digest"`
 	// ItemCount is the number of items belonging to the dictionary.
-	ItemCount int `mapstructure:"item_count"`
+	ItemCount *int `mapstructure:"item_count"`
 	// LastUpdated is the Time-stamp (GMT) when the dictionary was last updated.
 	LastUpdated *time.Time `mapstructure:"last_updated"`
 }
 
 // GetDictionaryInfoInput is used as input to the GetDictionary function.
 type GetDictionaryInfoInput struct {
-	// ID is the alphanumeric string identifying a dictionary.
+	// ID is the alphanumeric string identifying a dictionary (required).
 	ID string
 	// ServiceID is the ID of the service Dictionary belongs to (required).
 	ServiceID string
@@ -27,16 +27,14 @@ type GetDictionaryInfoInput struct {
 
 // GetDictionaryInfo retrieves the specified resource.
 func (c *Client) GetDictionaryInfo(i *GetDictionaryInfoInput) (*DictionaryInfo, error) {
+	if i.ID == "" {
+		return nil, ErrMissingID
+	}
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
 	}
-
 	if i.ServiceVersion == 0 {
 		return nil, ErrMissingServiceVersion
-	}
-
-	if i.ID == "" {
-		return nil, ErrMissingID
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s/info", i.ServiceID, i.ServiceVersion, i.ID)

--- a/fastly/dictionary_info_test.go
+++ b/fastly/dictionary_info_test.go
@@ -13,7 +13,7 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", *testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	var (
@@ -46,7 +46,7 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 	record(t, fixtureBase+"get", func(c *Client) {
 		info, err = c.GetDictionaryInfo(&GetDictionaryInfoInput{
 			ServiceID:      *testService.ID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			ID:             *testDictionary.ID,
 		})
 	})

--- a/fastly/dictionary_info_test.go
+++ b/fastly/dictionary_info_test.go
@@ -24,17 +24,17 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 	record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(&BatchModifyDictionaryItemsInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
+			DictionaryID: *testDictionary.ID,
 			Items: []*BatchDictionaryItem{
 				{
-					Operation: CreateBatchOperation,
-					ItemKey:   "test-dictionary-item-0",
-					ItemValue: "value",
+					Operation: ToPointer(CreateBatchOperation),
+					ItemKey:   ToPointer("test-dictionary-item-0"),
+					ItemValue: ToPointer("value"),
 				},
 				{
-					Operation: CreateBatchOperation,
-					ItemKey:   "test-dictionary-item-1",
-					ItemValue: "value",
+					Operation: ToPointer(CreateBatchOperation),
+					ItemKey:   ToPointer("test-dictionary-item-1"),
+					ItemValue: ToPointer("value"),
 				},
 			},
 		})
@@ -47,41 +47,38 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 		info, err = c.GetDictionaryInfo(&GetDictionaryInfoInput{
 			ServiceID:      testService.ID,
 			ServiceVersion: testVersion.Number,
-			ID:             testDictionary.ID,
+			ID:             *testDictionary.ID,
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if info.ItemCount != 2 {
-		t.Errorf("bad item_count: %d", info.ItemCount)
+	if *info.ItemCount != 2 {
+		t.Errorf("bad item_count: %d", *info.ItemCount)
 	}
 }
 
 func TestClient_GetDictionaryInfo_validation(t *testing.T) {
 	var err error
+	_, err = testClient.GetDictionaryInfo(&GetDictionaryInfoInput{})
+	if err != ErrMissingID {
+		t.Errorf("bad error: %s", err)
+	}
+
 	_, err = testClient.GetDictionaryInfo(&GetDictionaryInfoInput{
-		ServiceID: "",
+		ID: "123",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
 	_, err = testClient.GetDictionaryInfo(&GetDictionaryInfoInput{
+		ID:             "123",
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
 	if err != ErrMissingServiceVersion {
-		t.Errorf("bad error: %s", err)
-	}
-
-	_, err = testClient.GetDictionaryInfo(&GetDictionaryInfoInput{
-		ServiceID:      "foo",
-		ServiceVersion: 1,
-		ID:             "",
-	})
-	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
 }

--- a/fastly/dictionary_info_test.go
+++ b/fastly/dictionary_info_test.go
@@ -9,11 +9,11 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 	nameSuffix := "DictionaryInfo"
 
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	var (
@@ -23,7 +23,7 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 
 	record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(&BatchModifyDictionaryItemsInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 			Items: []*BatchDictionaryItem{
 				{
@@ -45,7 +45,7 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 
 	record(t, fixtureBase+"get", func(c *Client) {
 		info, err = c.GetDictionaryInfo(&GetDictionaryInfoInput{
-			ServiceID:      testService.ID,
+			ServiceID:      *testService.ID,
 			ServiceVersion: testVersion.Number,
 			ID:             *testDictionary.ID,
 		})

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -37,7 +37,7 @@ type GetDictionaryItemsInput struct {
 
 // GetDictionaryItems returns a ListPaginator for paginating through the resources.
 func (c *Client) GetDictionaryItems(i *GetDictionaryItemsInput) *ListPaginator[DictionaryItem] {
-	input := &ListOpts{}
+	input := ListOpts{}
 	if i.Direction != nil {
 		input.Direction = *i.Direction
 	}

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -12,10 +12,10 @@ const dictionaryItemsPath = "/service/%s/dictionary/%s/items"
 type DictionaryItem struct {
 	CreatedAt    *time.Time `mapstructure:"created_at"`
 	DeletedAt    *time.Time `mapstructure:"deleted_at"`
-	DictionaryID string     `mapstructure:"dictionary_id"`
-	ItemKey      string     `mapstructure:"item_key"`
-	ItemValue    string     `mapstructure:"item_value"`
-	ServiceID    string     `mapstructure:"service_id"`
+	DictionaryID *string    `mapstructure:"dictionary_id"`
+	ItemKey      *string    `mapstructure:"item_key"`
+	ItemValue    *string    `mapstructure:"item_value"`
+	ServiceID    *string    `mapstructure:"service_id"`
 	UpdatedAt    *time.Time `mapstructure:"updated_at"`
 }
 
@@ -24,25 +24,34 @@ type GetDictionaryItemsInput struct {
 	// DictionaryID is the ID of the dictionary to retrieve items for (required).
 	DictionaryID string
 	// Direction is the direction in which to sort results.
-	Direction string
+	Direction *string
 	// Page is the current page.
-	Page int
+	Page *int
 	// PerPage is the number of records per page.
-	PerPage int
+	PerPage *int
 	// ServiceID is the ID of the service (required).
 	ServiceID string
 	// Sort is the field on which to sort.
-	Sort string
+	Sort *string
 }
 
 // GetDictionaryItems returns a ListPaginator for paginating through the resources.
 func (c *Client) GetDictionaryItems(i *GetDictionaryItemsInput) *ListPaginator[DictionaryItem] {
-	return newPaginator[DictionaryItem](c, &listInput{
-		Direction: i.Direction,
-		Sort:      i.Sort,
-		Page:      i.Page,
-		PerPage:   i.PerPage,
-	}, fmt.Sprintf(dictionaryItemsPath, i.ServiceID, i.DictionaryID))
+	input := &listInput{}
+	if i.Direction != nil {
+		input.Direction = *i.Direction
+	}
+	if i.Sort != nil {
+		input.Sort = *i.Sort
+	}
+	if i.Page != nil {
+		input.Page = *i.Page
+	}
+	if i.PerPage != nil {
+		input.PerPage = *i.PerPage
+	}
+	path := fmt.Sprintf(dictionaryItemsPath, i.ServiceID, i.DictionaryID)
+	return newPaginator[DictionaryItem](c, input, path)
 }
 
 // ListDictionaryItemsInput is used as input to the ListDictionaryItems function.
@@ -50,11 +59,11 @@ type ListDictionaryItemsInput struct {
 	// DictionaryID is the ID of the dictionary to retrieve items for (required).
 	DictionaryID string
 	// Direction is the direction in which to sort results.
-	Direction string
+	Direction *string
 	// ServiceID is the ID of the service (required).
 	ServiceID string
 	// Sort is the field on which to sort.
-	Sort string
+	Sort *string
 }
 
 // ListDictionaryItems retrieves all resources. Not suitable for large
@@ -86,9 +95,9 @@ func (c *Client) ListDictionaryItems(i *ListDictionaryItemsInput) ([]*Dictionary
 // CreateDictionaryItemInput is used as input to the CreateDictionaryItem function.
 type CreateDictionaryItemInput struct {
 	// ItemKey is the dictionary item key, maximum 256 characters.
-	ItemKey string `url:"item_key,omitempty"`
+	ItemKey *string `url:"item_key,omitempty"`
 	// ItemValue is the dictionary item value, maximum 8000 characters.
-	ItemValue string `url:"item_value,omitempty"`
+	ItemValue *string `url:"item_value,omitempty"`
 	// ServiceID is the ID of the service (required).
 	ServiceID string `url:"-"`
 	// DictionaryID is the ID of the dictionary to retrieve items for (required).
@@ -220,11 +229,11 @@ type BatchModifyDictionaryItemsInput struct {
 // BatchDictionaryItem represents a dictionary item.
 type BatchDictionaryItem struct {
 	// ItemKey is an item key (maximum 256 characters).
-	ItemKey string `json:"item_key"`
+	ItemKey *string `json:"item_key"`
 	// ItemValue is an item value (maximum 8000 characters).
-	ItemValue string `json:"item_value"`
+	ItemValue *string `json:"item_value"`
 	// Operation is a batching operation variant.
-	Operation BatchOperation `json:"op"`
+	Operation *BatchOperation `json:"op"`
 }
 
 // BatchModifyDictionaryItems bulk updates dictionary items.

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -51,7 +51,7 @@ func (c *Client) GetDictionaryItems(i *GetDictionaryItemsInput) *ListPaginator[D
 		input.PerPage = *i.PerPage
 	}
 	path := fmt.Sprintf(dictionaryItemsPath, i.ServiceID, i.DictionaryID)
-	return newPaginator[DictionaryItem](c, input, path)
+	return NewPaginator[DictionaryItem](c, input, path)
 }
 
 // ListDictionaryItemsInput is used as input to the ListDictionaryItems function.

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -37,7 +37,7 @@ type GetDictionaryItemsInput struct {
 
 // GetDictionaryItems returns a ListPaginator for paginating through the resources.
 func (c *Client) GetDictionaryItems(i *GetDictionaryItemsInput) *ListPaginator[DictionaryItem] {
-	input := &listInput{}
+	input := &ListOpts{}
 	if i.Direction != nil {
 		input.Direction = *i.Direction
 	}

--- a/fastly/dictionary_item_batch_test.go
+++ b/fastly/dictionary_item_batch_test.go
@@ -19,17 +19,17 @@ func TestClient_BatchModifyDictionaryItems_Create(t *testing.T) {
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
 		ServiceID:    testService.ID,
-		DictionaryID: testDictionary.ID,
+		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
-				Operation: CreateBatchOperation,
-				ItemKey:   "key1",
-				ItemValue: "val1",
+				Operation: ToPointer(CreateBatchOperation),
+				ItemKey:   ToPointer("key1"),
+				ItemValue: ToPointer("val1"),
 			},
 			{
-				Operation: CreateBatchOperation,
-				ItemKey:   "key2",
-				ItemValue: "val2",
+				Operation: ToPointer(CreateBatchOperation),
+				ItemKey:   ToPointer("key2"),
+				ItemValue: ToPointer("val2"),
 			},
 		},
 	}
@@ -48,7 +48,7 @@ func TestClient_BatchModifyDictionaryItems_Create(t *testing.T) {
 	record(t, fixtureBase+"list_after_create", func(c *Client) {
 		actualDictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
+			DictionaryID: *testDictionary.ID,
 		})
 	})
 	if err != nil {
@@ -64,14 +64,14 @@ func TestClient_BatchModifyDictionaryItems_Create(t *testing.T) {
 	for i, item := range actualDictionaryItems {
 		actualItemKey := item.ItemKey
 		expectedItemKey := batchCreateOperations.Items[i].ItemKey
-		if actualItemKey != expectedItemKey {
-			t.Errorf("First ItemKey did not match, expected %s, got %s", expectedItemKey, actualItemKey)
+		if *actualItemKey != *expectedItemKey {
+			t.Errorf("First ItemKey did not match, expected %s, got %s", *expectedItemKey, *actualItemKey)
 		}
 
 		actualItemValue := item.ItemValue
 		expectedItemValue := batchCreateOperations.Items[i].ItemValue
-		if actualItemValue != expectedItemValue {
-			t.Errorf("First ItemValue did not match, expected %s, got %s", expectedItemValue, actualItemValue)
+		if *actualItemValue != *expectedItemValue {
+			t.Errorf("First ItemValue did not match, expected %s, got %s", *expectedItemValue, *actualItemValue)
 		}
 	}
 }
@@ -91,17 +91,17 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
 		ServiceID:    testService.ID,
-		DictionaryID: testDictionary.ID,
+		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
-				Operation: CreateBatchOperation,
-				ItemKey:   "key1",
-				ItemValue: "val1",
+				Operation: ToPointer(CreateBatchOperation),
+				ItemKey:   ToPointer("key1"),
+				ItemValue: ToPointer("val1"),
 			},
 			{
-				Operation: CreateBatchOperation,
-				ItemKey:   "key2",
-				ItemValue: "val2",
+				Operation: ToPointer(CreateBatchOperation),
+				ItemKey:   ToPointer("key2"),
+				ItemValue: ToPointer("val2"),
 			},
 		},
 	}
@@ -117,12 +117,12 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 	// When: I execute the batch delete operations against the Fastly API,
 	batchDeleteOperations := &BatchModifyDictionaryItemsInput{
 		ServiceID:    testService.ID,
-		DictionaryID: testDictionary.ID,
+		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
-				Operation: DeleteBatchOperation,
-				ItemKey:   "key2",
-				ItemValue: "val2",
+				Operation: ToPointer(DeleteBatchOperation),
+				ItemKey:   ToPointer("key2"),
+				ItemValue: ToPointer("val2"),
 			},
 		},
 	}
@@ -139,7 +139,7 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 	record(t, fixtureBase+"list_after_delete", func(client *Client) {
 		actualDictionaryItems, err = client.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
+			DictionaryID: *testDictionary.ID,
 		})
 	})
 	if err != nil {
@@ -168,17 +168,17 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
 		ServiceID:    testService.ID,
-		DictionaryID: testDictionary.ID,
+		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
-				Operation: CreateBatchOperation,
-				ItemKey:   "key1",
-				ItemValue: "val1",
+				Operation: ToPointer(CreateBatchOperation),
+				ItemKey:   ToPointer("key1"),
+				ItemValue: ToPointer("val1"),
 			},
 			{
-				Operation: CreateBatchOperation,
-				ItemKey:   "key2",
-				ItemValue: "val2",
+				Operation: ToPointer(CreateBatchOperation),
+				ItemKey:   ToPointer("key2"),
+				ItemValue: ToPointer("val2"),
 			},
 		},
 	}
@@ -194,12 +194,12 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 	// When: I execute the batch update operations against the Fastly API,
 	batchUpdateOperations := &BatchModifyDictionaryItemsInput{
 		ServiceID:    testService.ID,
-		DictionaryID: testDictionary.ID,
+		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
-				Operation: UpdateBatchOperation,
-				ItemKey:   "key2",
-				ItemValue: "val2Updated",
+				Operation: ToPointer(UpdateBatchOperation),
+				ItemKey:   ToPointer("key2"),
+				ItemValue: ToPointer("val2Updated"),
 			},
 		},
 	}
@@ -216,7 +216,7 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 	record(t, fixtureBase+"list_after_update", func(c *Client) {
 		actualDictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
+			DictionaryID: *testDictionary.ID,
 		})
 	})
 	if err != nil {
@@ -232,30 +232,30 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 	actualItemKey := actualDictionaryItems[0].ItemKey
 	expectedItemKey := batchCreateOperations.Items[0].ItemKey
 
-	if actualItemKey != expectedItemKey {
-		t.Errorf("First ItemKey did not match, expected %s, got %s", expectedItemKey, actualItemKey)
+	if *actualItemKey != *expectedItemKey {
+		t.Errorf("First ItemKey did not match, expected %s, got %s", *expectedItemKey, *actualItemKey)
 	}
 
 	actualItemValue := actualDictionaryItems[0].ItemValue
 	expectedItemValue := batchCreateOperations.Items[0].ItemValue
 
 	// Confirm the second dictionary item contains the modifications.
-	if actualItemValue != expectedItemValue {
-		t.Errorf("First ItemValue did not match, expected %s, got %s", expectedItemValue, actualItemValue)
+	if *actualItemValue != *expectedItemValue {
+		t.Errorf("First ItemValue did not match, expected %s, got %s", *expectedItemValue, *actualItemValue)
 	}
 
 	actualItemKey = actualDictionaryItems[1].ItemKey
 	expectedItemKey = batchUpdateOperations.Items[0].ItemKey
 
-	if actualItemKey != expectedItemKey {
-		t.Errorf("Second ItemKey did not match, expected %s, got %s", expectedItemKey, actualItemKey)
+	if *actualItemKey != *expectedItemKey {
+		t.Errorf("Second ItemKey did not match, expected %s, got %s", *expectedItemKey, *actualItemKey)
 	}
 
 	actualItemValue = actualDictionaryItems[1].ItemValue
 	expectedItemValue = batchUpdateOperations.Items[0].ItemValue
 
-	if actualItemValue != expectedItemValue {
-		t.Errorf("Second ItemValue did not match, expected %s, got %s", expectedItemValue, actualItemValue)
+	if *actualItemValue != *expectedItemValue {
+		t.Errorf("Second ItemValue did not match, expected %s, got %s", *expectedItemValue, *actualItemValue)
 	}
 }
 
@@ -274,12 +274,12 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
 		ServiceID:    testService.ID,
-		DictionaryID: testDictionary.ID,
+		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
-				Operation: CreateBatchOperation,
-				ItemKey:   "key1",
-				ItemValue: "val1",
+				Operation: ToPointer(CreateBatchOperation),
+				ItemKey:   ToPointer("key1"),
+				ItemValue: ToPointer("val1"),
 			},
 		},
 	}
@@ -295,17 +295,17 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 	// When: I execute the batch upsert operations against the Fastly API
 	batchUpsertOperations := &BatchModifyDictionaryItemsInput{
 		ServiceID:    testService.ID,
-		DictionaryID: testDictionary.ID,
+		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
-				Operation: UpsertBatchOperation,
-				ItemKey:   "key1",
-				ItemValue: "val1Updated",
+				Operation: ToPointer(UpsertBatchOperation),
+				ItemKey:   ToPointer("key1"),
+				ItemValue: ToPointer("val1Updated"),
 			},
 			{
-				Operation: UpsertBatchOperation,
-				ItemKey:   "key2",
-				ItemValue: "val2",
+				Operation: ToPointer(UpsertBatchOperation),
+				ItemKey:   ToPointer("key2"),
+				ItemValue: ToPointer("val2"),
 			},
 		},
 	}
@@ -322,7 +322,7 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 	record(t, fixtureBase+"list_after_upsert", func(c *Client) {
 		actualDictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
+			DictionaryID: *testDictionary.ID,
 		})
 	})
 	if err != nil {
@@ -338,14 +338,14 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 	for i, item := range actualDictionaryItems {
 		actualItemKey := item.ItemKey
 		expectedItemKey := batchUpsertOperations.Items[i].ItemKey
-		if actualItemKey != expectedItemKey {
-			t.Errorf("First ItemKey did not match, expected %s, got %s", expectedItemKey, actualItemKey)
+		if *actualItemKey != *expectedItemKey {
+			t.Errorf("First ItemKey did not match, expected %s, got %s", *expectedItemKey, *actualItemKey)
 		}
 
 		actualItemValue := item.ItemValue
 		expectedItemValue := batchUpsertOperations.Items[i].ItemValue
-		if actualItemValue != expectedItemValue {
-			t.Errorf("First ItemValue did not match, expected %s, got %s", expectedItemValue, actualItemValue)
+		if *actualItemValue != *expectedItemValue {
+			t.Errorf("First ItemValue did not match, expected %s, got %s", *expectedItemValue, *actualItemValue)
 		}
 	}
 }

--- a/fastly/dictionary_item_batch_test.go
+++ b/fastly/dictionary_item_batch_test.go
@@ -10,15 +10,15 @@ func TestClient_BatchModifyDictionaryItems_Create(t *testing.T) {
 
 	// Given: a test service with a dictionary and a batch of create operations,
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
-		ServiceID:    testService.ID,
+		ServiceID:    *testService.ID,
 		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
@@ -47,7 +47,7 @@ func TestClient_BatchModifyDictionaryItems_Create(t *testing.T) {
 	var actualDictionaryItems []*DictionaryItem
 	record(t, fixtureBase+"list_after_create", func(c *Client) {
 		actualDictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 		})
 	})
@@ -82,15 +82,15 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 
 	// Given: a test service with a dictionary and dictionary items,
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
-		ServiceID:    testService.ID,
+		ServiceID:    *testService.ID,
 		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
@@ -116,7 +116,7 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 
 	// When: I execute the batch delete operations against the Fastly API,
 	batchDeleteOperations := &BatchModifyDictionaryItemsInput{
-		ServiceID:    testService.ID,
+		ServiceID:    *testService.ID,
 		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
@@ -138,7 +138,7 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 	var actualDictionaryItems []*DictionaryItem
 	record(t, fixtureBase+"list_after_delete", func(client *Client) {
 		actualDictionaryItems, err = client.ListDictionaryItems(&ListDictionaryItemsInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 		})
 	})
@@ -159,15 +159,15 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 
 	// Given: a test service with a dictionary and dictionary items,
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
-		ServiceID:    testService.ID,
+		ServiceID:    *testService.ID,
 		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
@@ -193,7 +193,7 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 
 	// When: I execute the batch update operations against the Fastly API,
 	batchUpdateOperations := &BatchModifyDictionaryItemsInput{
-		ServiceID:    testService.ID,
+		ServiceID:    *testService.ID,
 		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
@@ -215,7 +215,7 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 	var actualDictionaryItems []*DictionaryItem
 	record(t, fixtureBase+"list_after_update", func(c *Client) {
 		actualDictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 		})
 	})
@@ -265,15 +265,15 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 
 	// Given: a test service with a dictionary and dictionary items,
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
-		ServiceID:    testService.ID,
+		ServiceID:    *testService.ID,
 		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
@@ -294,7 +294,7 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 
 	// When: I execute the batch upsert operations against the Fastly API
 	batchUpsertOperations := &BatchModifyDictionaryItemsInput{
-		ServiceID:    testService.ID,
+		ServiceID:    *testService.ID,
 		DictionaryID: *testDictionary.ID,
 		Items: []*BatchDictionaryItem{
 			{
@@ -321,7 +321,7 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 	var actualDictionaryItems []*DictionaryItem
 	record(t, fixtureBase+"list_after_upsert", func(c *Client) {
 		actualDictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 		})
 	})

--- a/fastly/dictionary_item_batch_test.go
+++ b/fastly/dictionary_item_batch_test.go
@@ -14,7 +14,7 @@ func TestClient_BatchModifyDictionaryItems_Create(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
@@ -86,7 +86,7 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
@@ -163,7 +163,7 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{
@@ -269,7 +269,7 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	batchCreateOperations := &BatchModifyDictionaryItemsInput{

--- a/fastly/dictionary_item_test.go
+++ b/fastly/dictionary_item_test.go
@@ -9,11 +9,11 @@ func TestClient_DictionaryItems(t *testing.T) {
 	nameSuffix := "DictionaryItems"
 
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
-	defer deleteTestService(t, fixtureBase+"delete_service", testService.ID)
+	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ID)
 
-	testVersion := createTestVersion(t, fixtureBase+"version", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", *testService.ID, testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	// Create
@@ -21,7 +21,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	var createdDictionaryItem *DictionaryItem
 	record(t, fixtureBase+"create", func(c *Client) {
 		createdDictionaryItem, err = c.CreateDictionaryItem(&CreateDictionaryItemInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 			ItemKey:      ToPointer("test-dictionary-item"),
 			ItemValue:    ToPointer("value"),
@@ -35,7 +35,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	defer func() {
 		record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteDictionaryItem(&DeleteDictionaryItemInput{
-				ServiceID:    testService.ID,
+				ServiceID:    *testService.ID,
 				DictionaryID: *testDictionary.ID,
 				ItemKey:      "test-dictionary-item",
 			})
@@ -53,7 +53,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	var dictionaryItems []*DictionaryItem
 	record(t, fixtureBase+"list", func(c *Client) {
 		dictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 		})
 	})
@@ -72,7 +72,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 			DictionaryID: *testDictionary.ID,
 			Direction:    ToPointer("ascend"),
 			PerPage:      ToPointer(50),
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			Sort:         ToPointer("item_key"),
 		})
 
@@ -99,7 +99,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	var retrievedDictionaryItem *DictionaryItem
 	record(t, fixtureBase+"get", func(c *Client) {
 		retrievedDictionaryItem, err = c.GetDictionaryItem(&GetDictionaryItemInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 			ItemKey:      "test-dictionary-item",
 		})
@@ -118,7 +118,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	var updatedDictionaryItem *DictionaryItem
 	record(t, fixtureBase+"update", func(c *Client) {
 		updatedDictionaryItem, err = c.UpdateDictionaryItem(&UpdateDictionaryItemInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 			ItemKey:      "test-dictionary-item",
 			ItemValue:    "new-value",
@@ -134,7 +134,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	// Delete
 	record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteDictionaryItem(&DeleteDictionaryItemInput{
-			ServiceID:    testService.ID,
+			ServiceID:    *testService.ID,
 			DictionaryID: *testDictionary.ID,
 			ItemKey:      "test-dictionary-item",
 		})

--- a/fastly/dictionary_item_test.go
+++ b/fastly/dictionary_item_test.go
@@ -22,9 +22,9 @@ func TestClient_DictionaryItems(t *testing.T) {
 	record(t, fixtureBase+"create", func(c *Client) {
 		createdDictionaryItem, err = c.CreateDictionaryItem(&CreateDictionaryItemInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
-			ItemKey:      "test-dictionary-item",
-			ItemValue:    "value",
+			DictionaryID: *testDictionary.ID,
+			ItemKey:      ToPointer("test-dictionary-item"),
+			ItemValue:    ToPointer("value"),
 		})
 	})
 	if err != nil {
@@ -36,17 +36,17 @@ func TestClient_DictionaryItems(t *testing.T) {
 		record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteDictionaryItem(&DeleteDictionaryItemInput{
 				ServiceID:    testService.ID,
-				DictionaryID: testDictionary.ID,
+				DictionaryID: *testDictionary.ID,
 				ItemKey:      "test-dictionary-item",
 			})
 		})
 	}()
 
-	if createdDictionaryItem.ItemKey != "test-dictionary-item" {
-		t.Errorf("bad item_key: %q", createdDictionaryItem.ItemKey)
+	if *createdDictionaryItem.ItemKey != "test-dictionary-item" {
+		t.Errorf("bad item_key: %q", *createdDictionaryItem.ItemKey)
 	}
-	if createdDictionaryItem.ItemValue != "value" {
-		t.Errorf("bad item_value: %q", createdDictionaryItem.ItemValue)
+	if *createdDictionaryItem.ItemValue != "value" {
+		t.Errorf("bad item_value: %q", *createdDictionaryItem.ItemValue)
 	}
 
 	// List
@@ -54,7 +54,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	record(t, fixtureBase+"list", func(c *Client) {
 		dictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
+			DictionaryID: *testDictionary.ID,
 		})
 	})
 	if err != nil {
@@ -69,11 +69,11 @@ func TestClient_DictionaryItems(t *testing.T) {
 	var paginator *ListPaginator[DictionaryItem]
 	record(t, fixtureBase+"list2", func(c *Client) {
 		paginator = c.GetDictionaryItems(&GetDictionaryItemsInput{
-			DictionaryID: testDictionary.ID,
-			Direction:    "ascend",
-			PerPage:      50,
+			DictionaryID: *testDictionary.ID,
+			Direction:    ToPointer("ascend"),
+			PerPage:      ToPointer(50),
 			ServiceID:    testService.ID,
-			Sort:         "item_key",
+			Sort:         ToPointer("item_key"),
 		})
 
 		for paginator.HasNext() {
@@ -100,18 +100,18 @@ func TestClient_DictionaryItems(t *testing.T) {
 	record(t, fixtureBase+"get", func(c *Client) {
 		retrievedDictionaryItem, err = c.GetDictionaryItem(&GetDictionaryItemInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
+			DictionaryID: *testDictionary.ID,
 			ItemKey:      "test-dictionary-item",
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if retrievedDictionaryItem.ItemKey != "test-dictionary-item" {
-		t.Errorf("bad item_key: %q", retrievedDictionaryItem.ItemKey)
+	if *retrievedDictionaryItem.ItemKey != "test-dictionary-item" {
+		t.Errorf("bad item_key: %q", *retrievedDictionaryItem.ItemKey)
 	}
-	if retrievedDictionaryItem.ItemValue != "value" {
-		t.Errorf("bad item_value: %q", retrievedDictionaryItem.ItemValue)
+	if *retrievedDictionaryItem.ItemValue != "value" {
+		t.Errorf("bad item_value: %q", *retrievedDictionaryItem.ItemValue)
 	}
 
 	// Update
@@ -119,7 +119,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	record(t, fixtureBase+"update", func(c *Client) {
 		updatedDictionaryItem, err = c.UpdateDictionaryItem(&UpdateDictionaryItemInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
+			DictionaryID: *testDictionary.ID,
 			ItemKey:      "test-dictionary-item",
 			ItemValue:    "new-value",
 		})
@@ -127,15 +127,15 @@ func TestClient_DictionaryItems(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if updatedDictionaryItem.ItemValue != "new-value" {
-		t.Errorf("bad item_value: %q", updatedDictionaryItem.ItemValue)
+	if *updatedDictionaryItem.ItemValue != "new-value" {
+		t.Errorf("bad item_value: %q", *updatedDictionaryItem.ItemValue)
 	}
 
 	// Delete
 	record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteDictionaryItem(&DeleteDictionaryItemInput{
 			ServiceID:    testService.ID,
-			DictionaryID: testDictionary.ID,
+			DictionaryID: *testDictionary.ID,
 			ItemKey:      "test-dictionary-item",
 		})
 	})

--- a/fastly/dictionary_item_test.go
+++ b/fastly/dictionary_item_test.go
@@ -13,7 +13,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 
 	testVersion := createTestVersion(t, fixtureBase+"version", *testService.ID)
 
-	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", *testService.ID, testVersion.Number, nameSuffix)
+	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", *testService.ID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
 
 	// Create

--- a/fastly/dictionary_test.go
+++ b/fastly/dictionary_test.go
@@ -17,7 +17,7 @@ func TestClient_Dictionaries(t *testing.T) {
 	record(t, fixtureBase+"create", func(c *Client) {
 		d, err = c.CreateDictionary(&CreateDictionaryInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           ToPointer("test_dictionary"),
 		})
 	})
@@ -30,13 +30,13 @@ func TestClient_Dictionaries(t *testing.T) {
 		record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteDictionary(&DeleteDictionaryInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: testVersion.Number,
+				ServiceVersion: *testVersion.Number,
 				Name:           "test_dictionary",
 			})
 
 			_ = c.DeleteDictionary(&DeleteDictionaryInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: testVersion.Number,
+				ServiceVersion: *testVersion.Number,
 				Name:           "new_test_dictionary",
 			})
 		})
@@ -51,7 +51,7 @@ func TestClient_Dictionaries(t *testing.T) {
 	record(t, fixtureBase+"list", func(c *Client) {
 		ds, err = c.ListDictionaries(&ListDictionariesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 		})
 	})
 	if err != nil {
@@ -66,7 +66,7 @@ func TestClient_Dictionaries(t *testing.T) {
 	record(t, fixtureBase+"get", func(c *Client) {
 		nd, err = c.GetDictionary(&GetDictionaryInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           "test_dictionary",
 		})
 	})
@@ -82,7 +82,7 @@ func TestClient_Dictionaries(t *testing.T) {
 	record(t, fixtureBase+"update", func(c *Client) {
 		ud, err = c.UpdateDictionary(&UpdateDictionaryInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           "test_dictionary",
 			NewName:        ToPointer("new_test_dictionary"),
 		})
@@ -98,7 +98,7 @@ func TestClient_Dictionaries(t *testing.T) {
 	record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteDictionary(&DeleteDictionaryInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           "new_test_dictionary",
 		})
 	})

--- a/fastly/dictionary_test.go
+++ b/fastly/dictionary_test.go
@@ -42,8 +42,8 @@ func TestClient_Dictionaries(t *testing.T) {
 		})
 	}()
 
-	if d.Name != "test_dictionary" {
-		t.Errorf("bad name: %q", d.Name)
+	if *d.Name != "test_dictionary" {
+		t.Errorf("bad name: %q", *d.Name)
 	}
 
 	// List
@@ -73,8 +73,8 @@ func TestClient_Dictionaries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if d.Name != nd.Name {
-		t.Errorf("bad name: %q (%q)", d.Name, nd.Name)
+	if *d.Name != *nd.Name {
+		t.Errorf("bad name: %q (%q)", *d.Name, *nd.Name)
 	}
 
 	// Update
@@ -90,8 +90,8 @@ func TestClient_Dictionaries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ud.Name != "new_test_dictionary" {
-		t.Errorf("bad name: %q", ud.Name)
+	if *ud.Name != "new_test_dictionary" {
+		t.Errorf("bad name: %q", *ud.Name)
 	}
 
 	// Delete

--- a/fastly/diff_test.go
+++ b/fastly/diff_test.go
@@ -23,8 +23,8 @@ func TestClient_Diff(t *testing.T) {
 	record(t, "diff/get", func(c *Client) {
 		d, err = c.GetDiff(&GetDiffInput{
 			ServiceID: testServiceID,
-			From:      tv1.Number,
-			To:        tv2.Number,
+			From:      *tv1.Number,
+			To:        *tv2.Number,
 		})
 	})
 	if err != nil {
@@ -35,7 +35,7 @@ func TestClient_Diff(t *testing.T) {
 	record(t, "diff/create_backend", func(c *Client) {
 		_, err = c.CreateBackend(&CreateBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv2.Number,
+			ServiceVersion: *tv2.Number,
 			Name:           ToPointer("test-backend"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
 		})
@@ -49,7 +49,7 @@ func TestClient_Diff(t *testing.T) {
 		record(t, "diff/cleanup", func(c *Client) {
 			_ = c.DeleteBackend(&DeleteBackendInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv2.Number,
+				ServiceVersion: *tv2.Number,
 				Name:           "test-backend",
 			})
 		})
@@ -59,8 +59,8 @@ func TestClient_Diff(t *testing.T) {
 	record(t, "diff/get_again", func(c *Client) {
 		d, err = c.GetDiff(&GetDiffInput{
 			ServiceID: testServiceID,
-			From:      tv1.Number,
-			To:        tv2.Number,
+			From:      *tv1.Number,
+			To:        *tv2.Number,
 		})
 	})
 	if err != nil {

--- a/fastly/digitalocean.go
+++ b/fastly/digitalocean.go
@@ -3,51 +3,32 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // DigitalOcean represents a DigitalOcean response from the Fastly API.
 type DigitalOcean struct {
-	AccessKey         string     `mapstructure:"access_key"`
-	BucketName        string     `mapstructure:"bucket_name"`
-	CompressionCodec  string     `mapstructure:"compression_codec"`
+	AccessKey         *string    `mapstructure:"access_key"`
+	BucketName        *string    `mapstructure:"bucket_name"`
+	CompressionCodec  *string    `mapstructure:"compression_codec"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Domain            string     `mapstructure:"domain"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	GzipLevel         int        `mapstructure:"gzip_level"`
-	MessageType       string     `mapstructure:"message_type"`
-	Name              string     `mapstructure:"name"`
-	Path              string     `mapstructure:"path"`
-	Period            int        `mapstructure:"period"`
-	Placement         string     `mapstructure:"placement"`
-	PublicKey         string     `mapstructure:"public_key"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	SecretKey         string     `mapstructure:"secret_key"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TimestampFormat   string     `mapstructure:"timestamp_format"`
+	Domain            *string    `mapstructure:"domain"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	GzipLevel         *int       `mapstructure:"gzip_level"`
+	MessageType       *string    `mapstructure:"message_type"`
+	Name              *string    `mapstructure:"name"`
+	Path              *string    `mapstructure:"path"`
+	Period            *int       `mapstructure:"period"`
+	Placement         *string    `mapstructure:"placement"`
+	PublicKey         *string    `mapstructure:"public_key"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	SecretKey         *string    `mapstructure:"secret_key"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TimestampFormat   *string    `mapstructure:"timestamp_format"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// digitaloceansByName is a sortable list of DigitalOceans.
-type digitaloceansByName []*DigitalOcean
-
-// Len implement the sortable interface.
-func (d digitaloceansByName) Len() int {
-	return len(d)
-}
-
-// Swap implement the sortable interface.
-func (d digitaloceansByName) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
-}
-
-// Less implement the sortable interface.
-func (d digitaloceansByName) Less(i, j int) bool {
-	return d[i].Name < d[j].Name
 }
 
 // ListDigitalOceansInput is used as input to the ListDigitalOceans function.
@@ -78,7 +59,6 @@ func (c *Client) ListDigitalOceans(i *ListDigitalOceansInput) ([]*DigitalOcean, 
 	if err := decodeBodyMap(resp.Body, &digitaloceans); err != nil {
 		return nil, err
 	}
-	sort.Stable(digitaloceansByName(digitaloceans))
 	return digitaloceans, nil
 }
 
@@ -199,7 +179,7 @@ type UpdateDigitalOceanInput struct {
 	GzipLevel *int `url:"gzip_level,omitempty"`
 	// MessageType is how the message should be formatted (classic, loggly, logplex, blank).
 	MessageType *string `url:"message_type,omitempty"`
-	// Name is the name of the DigitalOcean to update.
+	// Name is the name of the DigitalOcean to update (required).
 	Name string `url:"-"`
 	// NewName is the new name for the resource.
 	NewName *string `url:"name,omitempty"`

--- a/fastly/digitalocean_test.go
+++ b/fastly/digitalocean_test.go
@@ -18,7 +18,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/create", func(c *Client) {
 		digitaloceanCreateResp1, err = c.CreateDigitalOcean(&CreateDigitalOceanInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-digitalocean"),
 			BucketName:       ToPointer("bucket-name"),
 			Domain:           ToPointer("fra1.digitaloceanspaces.com"),
@@ -42,7 +42,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/create2", func(c *Client) {
 		digitaloceanCreateResp2, err = c.CreateDigitalOcean(&CreateDigitalOceanInput{
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-digitalocean-2"),
 			BucketName:      ToPointer("bucket-name"),
 			Domain:          ToPointer("fra1.digitaloceanspaces.com"),
@@ -66,7 +66,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/create3", func(c *Client) {
 		digitaloceanCreateResp3, err = c.CreateDigitalOcean(&CreateDigitalOceanInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-digitalocean-3"),
 			BucketName:       ToPointer("bucket-name"),
 			Domain:           ToPointer("fra1.digitaloceanspaces.com"),
@@ -92,7 +92,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/create4", func(c *Client) {
 		_, err = c.CreateDigitalOcean(&CreateDigitalOceanInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-digitalocean-4"),
 			BucketName:       ToPointer("bucket-name"),
 			Domain:           ToPointer("fra1.digitaloceanspaces.com"),
@@ -119,25 +119,25 @@ func TestClient_DigitalOceans(t *testing.T) {
 		record(t, "digitaloceans/cleanup", func(c *Client) {
 			_ = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-digitalocean",
 			})
 
 			_ = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-digitalocean-2",
 			})
 
 			_ = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-digitalocean-3",
 			})
 
 			_ = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-digitalocean",
 			})
 		})
@@ -203,7 +203,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/list", func(c *Client) {
 		digitaloceans, err = c.ListDigitalOceans(&ListDigitalOceansInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -218,7 +218,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/get", func(c *Client) {
 		digitaloceanGetResp, err = c.GetDigitalOcean(&GetDigitalOceanInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-digitalocean",
 		})
 	})
@@ -273,7 +273,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/update", func(c *Client) {
 		digitaloceanUpdateResp1, err = c.UpdateDigitalOcean(&UpdateDigitalOceanInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-digitalocean",
 			NewName:          ToPointer("new-test-digitalocean"),
 			Domain:           ToPointer("nyc3.digitaloceanspaces.com"),
@@ -287,7 +287,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/update2", func(c *Client) {
 		digitaloceanUpdateResp2, err = c.UpdateDigitalOcean(&UpdateDigitalOceanInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-digitalocean-2",
 			CompressionCodec: ToPointer("zstd"),
 		})
@@ -299,7 +299,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/update3", func(c *Client) {
 		digitaloceanUpdateResp3, err = c.UpdateDigitalOcean(&UpdateDigitalOceanInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-digitalocean-3",
 			GzipLevel:      ToPointer(9),
 		})
@@ -337,7 +337,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 	record(t, "digitaloceans/delete", func(c *Client) {
 		err = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-digitalocean",
 		})
 	})

--- a/fastly/digitalocean_test.go
+++ b/fastly/digitalocean_test.go
@@ -143,61 +143,59 @@ func TestClient_DigitalOceans(t *testing.T) {
 		})
 	}()
 
-	if digitaloceanCreateResp1.Name != "test-digitalocean" {
-		t.Errorf("bad name: %q", digitaloceanCreateResp1.Name)
+	if *digitaloceanCreateResp1.Name != "test-digitalocean" {
+		t.Errorf("bad name: %q", *digitaloceanCreateResp1.Name)
 	}
-	if digitaloceanCreateResp1.BucketName != "bucket-name" {
-		t.Errorf("bad bucket_name: %q", digitaloceanCreateResp1.BucketName)
+	if *digitaloceanCreateResp1.BucketName != "bucket-name" {
+		t.Errorf("bad bucket_name: %q", *digitaloceanCreateResp1.BucketName)
 	}
-	if digitaloceanCreateResp1.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
-		t.Errorf("bad access_key: %q", digitaloceanCreateResp1.AccessKey)
+	if *digitaloceanCreateResp1.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("bad access_key: %q", *digitaloceanCreateResp1.AccessKey)
 	}
-	if digitaloceanCreateResp1.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
-		t.Errorf("bad secret_key: %q", digitaloceanCreateResp1.SecretKey)
+	if *digitaloceanCreateResp1.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Errorf("bad secret_key: %q", *digitaloceanCreateResp1.SecretKey)
 	}
-	if digitaloceanCreateResp1.Domain != "fra1.digitaloceanspaces.com" {
-		t.Errorf("bad domain: %q", digitaloceanCreateResp1.Domain)
+	if *digitaloceanCreateResp1.Domain != "fra1.digitaloceanspaces.com" {
+		t.Errorf("bad domain: %q", *digitaloceanCreateResp1.Domain)
 	}
-	if digitaloceanCreateResp1.Path != "/path" {
-		t.Errorf("bad path: %q", digitaloceanCreateResp1.Path)
+	if *digitaloceanCreateResp1.Path != "/path" {
+		t.Errorf("bad path: %q", *digitaloceanCreateResp1.Path)
 	}
-	if digitaloceanCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", digitaloceanCreateResp1.Period)
+	if *digitaloceanCreateResp1.Period != 12 {
+		t.Errorf("bad period: %q", *digitaloceanCreateResp1.Period)
 	}
-	if digitaloceanCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", digitaloceanCreateResp1.GzipLevel)
+	if *digitaloceanCreateResp1.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp1.GzipLevel)
 	}
-	if digitaloceanCreateResp1.Format != "format" {
-		t.Errorf("bad format: %q", digitaloceanCreateResp1.Format)
+	if *digitaloceanCreateResp1.Format != "format" {
+		t.Errorf("bad format: %q", *digitaloceanCreateResp1.Format)
 	}
-	if digitaloceanCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", digitaloceanCreateResp1.FormatVersion)
+	if *digitaloceanCreateResp1.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *digitaloceanCreateResp1.FormatVersion)
 	}
-	if digitaloceanCreateResp1.TimestampFormat != "%Y" {
-		t.Errorf("bad timestamp_format: %q", digitaloceanCreateResp1.TimestampFormat)
+	if *digitaloceanCreateResp1.TimestampFormat != "%Y" {
+		t.Errorf("bad timestamp_format: %q", *digitaloceanCreateResp1.TimestampFormat)
 	}
-	if digitaloceanCreateResp1.MessageType != "classic" {
-		t.Errorf("bad message_type: %q", digitaloceanCreateResp1.MessageType)
+	if *digitaloceanCreateResp1.MessageType != "classic" {
+		t.Errorf("bad message_type: %q", *digitaloceanCreateResp1.MessageType)
 	}
-	if digitaloceanCreateResp1.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", digitaloceanCreateResp1.Placement)
+	if *digitaloceanCreateResp1.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *digitaloceanCreateResp1.Placement)
 	}
-	if digitaloceanCreateResp1.PublicKey != pgpPublicKey() {
-		t.Errorf("bad public_key: %q", digitaloceanCreateResp1.PublicKey)
+	if *digitaloceanCreateResp1.PublicKey != pgpPublicKey() {
+		t.Errorf("bad public_key: %q", *digitaloceanCreateResp1.PublicKey)
 	}
-
-	if digitaloceanCreateResp2.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", digitaloceanCreateResp2.CompressionCodec)
+	if digitaloceanCreateResp2.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *digitaloceanCreateResp2.CompressionCodec)
 	}
-	if digitaloceanCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", digitaloceanCreateResp2.GzipLevel)
+	if *digitaloceanCreateResp2.GzipLevel != 8 {
+		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp2.GzipLevel)
 	}
-
-	if digitaloceanCreateResp3.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", digitaloceanCreateResp3.CompressionCodec)
+	if *digitaloceanCreateResp3.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *digitaloceanCreateResp3.CompressionCodec)
 	}
-	if digitaloceanCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", digitaloceanCreateResp3.GzipLevel)
+	if *digitaloceanCreateResp3.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -227,47 +225,47 @@ func TestClient_DigitalOceans(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if digitaloceanCreateResp1.Name != digitaloceanGetResp.Name {
-		t.Errorf("bad name: %q", digitaloceanCreateResp1.Name)
+	if *digitaloceanCreateResp1.Name != *digitaloceanGetResp.Name {
+		t.Errorf("bad name: %q", *digitaloceanCreateResp1.Name)
 	}
-	if digitaloceanCreateResp1.BucketName != digitaloceanGetResp.BucketName {
-		t.Errorf("bad bucket_name: %q", digitaloceanCreateResp1.BucketName)
+	if *digitaloceanCreateResp1.BucketName != *digitaloceanGetResp.BucketName {
+		t.Errorf("bad bucket_name: %q", *digitaloceanCreateResp1.BucketName)
 	}
-	if digitaloceanCreateResp1.AccessKey != digitaloceanGetResp.AccessKey {
-		t.Errorf("bad access_key: %q", digitaloceanCreateResp1.AccessKey)
+	if *digitaloceanCreateResp1.AccessKey != *digitaloceanGetResp.AccessKey {
+		t.Errorf("bad access_key: %q", *digitaloceanCreateResp1.AccessKey)
 	}
-	if digitaloceanCreateResp1.SecretKey != digitaloceanGetResp.SecretKey {
-		t.Errorf("bad secret_key: %q", digitaloceanCreateResp1.SecretKey)
+	if *digitaloceanCreateResp1.SecretKey != *digitaloceanGetResp.SecretKey {
+		t.Errorf("bad secret_key: %q", *digitaloceanCreateResp1.SecretKey)
 	}
-	if digitaloceanCreateResp1.Domain != digitaloceanGetResp.Domain {
-		t.Errorf("bad domain: %q", digitaloceanCreateResp1.Domain)
+	if *digitaloceanCreateResp1.Domain != *digitaloceanGetResp.Domain {
+		t.Errorf("bad domain: %q", *digitaloceanCreateResp1.Domain)
 	}
-	if digitaloceanCreateResp1.Path != digitaloceanGetResp.Path {
-		t.Errorf("bad path: %q", digitaloceanCreateResp1.Path)
+	if *digitaloceanCreateResp1.Path != *digitaloceanGetResp.Path {
+		t.Errorf("bad path: %q", *digitaloceanCreateResp1.Path)
 	}
-	if digitaloceanCreateResp1.Period != digitaloceanGetResp.Period {
-		t.Errorf("bad period: %q", digitaloceanCreateResp1.Period)
+	if *digitaloceanCreateResp1.Period != *digitaloceanGetResp.Period {
+		t.Errorf("bad period: %q", *digitaloceanCreateResp1.Period)
 	}
-	if digitaloceanCreateResp1.GzipLevel != digitaloceanGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", digitaloceanCreateResp1.GzipLevel)
+	if *digitaloceanCreateResp1.GzipLevel != *digitaloceanGetResp.GzipLevel {
+		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp1.GzipLevel)
 	}
-	if digitaloceanCreateResp1.Format != digitaloceanGetResp.Format {
-		t.Errorf("bad format: %q", digitaloceanCreateResp1.Format)
+	if *digitaloceanCreateResp1.Format != *digitaloceanGetResp.Format {
+		t.Errorf("bad format: %q", *digitaloceanCreateResp1.Format)
 	}
-	if digitaloceanCreateResp1.FormatVersion != digitaloceanGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", digitaloceanCreateResp1.FormatVersion)
+	if *digitaloceanCreateResp1.FormatVersion != *digitaloceanGetResp.FormatVersion {
+		t.Errorf("bad format_version: %q", *digitaloceanCreateResp1.FormatVersion)
 	}
-	if digitaloceanCreateResp1.TimestampFormat != digitaloceanGetResp.TimestampFormat {
-		t.Errorf("bad timestamp_format: %q", digitaloceanCreateResp1.TimestampFormat)
+	if *digitaloceanCreateResp1.TimestampFormat != *digitaloceanGetResp.TimestampFormat {
+		t.Errorf("bad timestamp_format: %q", *digitaloceanCreateResp1.TimestampFormat)
 	}
-	if digitaloceanCreateResp1.Placement != digitaloceanGetResp.Placement {
-		t.Errorf("bad placement: %q", digitaloceanCreateResp1.Placement)
+	if *digitaloceanCreateResp1.Placement != *digitaloceanGetResp.Placement {
+		t.Errorf("bad placement: %q", *digitaloceanCreateResp1.Placement)
 	}
-	if digitaloceanCreateResp1.PublicKey != digitaloceanGetResp.PublicKey {
-		t.Errorf("bad public_key: %q", digitaloceanCreateResp1.PublicKey)
+	if *digitaloceanCreateResp1.PublicKey != *digitaloceanGetResp.PublicKey {
+		t.Errorf("bad public_key: %q", *digitaloceanCreateResp1.PublicKey)
 	}
-	if digitaloceanCreateResp1.CompressionCodec != digitaloceanGetResp.CompressionCodec {
-		t.Errorf("bad compression_codec: %q", digitaloceanCreateResp1.CompressionCodec)
+	if *digitaloceanCreateResp1.CompressionCodec != *digitaloceanGetResp.CompressionCodec {
+		t.Errorf("bad compression_codec: %q", *digitaloceanCreateResp1.CompressionCodec)
 	}
 
 	// Update
@@ -310,31 +308,29 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if digitaloceanUpdateResp1.Name != "new-test-digitalocean" {
-		t.Errorf("bad name: %q", digitaloceanUpdateResp1.Name)
+	if *digitaloceanUpdateResp1.Name != "new-test-digitalocean" {
+		t.Errorf("bad name: %q", *digitaloceanUpdateResp1.Name)
 	}
-	if digitaloceanUpdateResp1.Domain != "nyc3.digitaloceanspaces.com" {
-		t.Errorf("bad domain: %q", digitaloceanUpdateResp1.Domain)
+	if *digitaloceanUpdateResp1.Domain != "nyc3.digitaloceanspaces.com" {
+		t.Errorf("bad domain: %q", *digitaloceanUpdateResp1.Domain)
 	}
-	if digitaloceanUpdateResp1.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", digitaloceanUpdateResp1.CompressionCodec)
+	if *digitaloceanUpdateResp1.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *digitaloceanUpdateResp1.CompressionCodec)
 	}
-	if digitaloceanUpdateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", digitaloceanUpdateResp1.GzipLevel)
+	if digitaloceanUpdateResp1.GzipLevel != nil {
+		t.Errorf("bad gzip_level: %q", *digitaloceanUpdateResp1.GzipLevel)
 	}
-
-	if digitaloceanUpdateResp2.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", digitaloceanUpdateResp2.CompressionCodec)
+	if *digitaloceanUpdateResp2.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *digitaloceanUpdateResp2.CompressionCodec)
 	}
-	if digitaloceanUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", digitaloceanUpdateResp2.GzipLevel)
+	if *digitaloceanUpdateResp2.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *digitaloceanUpdateResp2.GzipLevel)
 	}
-
-	if digitaloceanUpdateResp3.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", digitaloceanUpdateResp3.CompressionCodec)
+	if digitaloceanUpdateResp3.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *digitaloceanUpdateResp3.CompressionCodec)
 	}
-	if digitaloceanUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", digitaloceanUpdateResp3.GzipLevel)
+	if *digitaloceanUpdateResp3.GzipLevel != 9 {
+		t.Errorf("bad gzip_level: %q", *digitaloceanUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/director.go
+++ b/fastly/director.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -24,45 +23,21 @@ const (
 // DirectorType is a type of director.
 type DirectorType int
 
-// DirectorTypePtr returns pointer to DirectorType.
-func DirectorTypePtr(t DirectorType) *DirectorType {
-	dt := DirectorType(t)
-	return &dt
-}
-
 // Director represents a director response from the Fastly API.
 type Director struct {
-	Backends       []string     `mapstructure:"backends"`
-	Capacity       int          `mapstructure:"capacity"`
-	Comment        string       `mapstructure:"comment"`
-	CreatedAt      *time.Time   `mapstructure:"created_at"`
-	DeletedAt      *time.Time   `mapstructure:"deleted_at"`
-	Name           string       `mapstructure:"name"`
-	Quorum         int          `mapstructure:"quorum"`
-	Retries        int          `mapstructure:"retries"`
-	ServiceID      string       `mapstructure:"service_id"`
-	ServiceVersion int          `mapstructure:"version"`
-	Shield         string       `mapstructure:"shield"`
-	Type           DirectorType `mapstructure:"type"`
-	UpdatedAt      *time.Time   `mapstructure:"updated_at"`
-}
-
-// directorsByName is a sortable list of directors.
-type directorsByName []*Director
-
-// Len implement the sortable interface.
-func (s directorsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s directorsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s directorsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	Backends       []string      `mapstructure:"backends"`
+	Capacity       *int          `mapstructure:"capacity"`
+	Comment        *string       `mapstructure:"comment"`
+	CreatedAt      *time.Time    `mapstructure:"created_at"`
+	DeletedAt      *time.Time    `mapstructure:"deleted_at"`
+	Name           *string       `mapstructure:"name"`
+	Quorum         *int          `mapstructure:"quorum"`
+	Retries        *int          `mapstructure:"retries"`
+	ServiceID      *string       `mapstructure:"service_id"`
+	ServiceVersion *int          `mapstructure:"version"`
+	Shield         *string       `mapstructure:"shield"`
+	Type           *DirectorType `mapstructure:"type"`
+	UpdatedAt      *time.Time    `mapstructure:"updated_at"`
 }
 
 // ListDirectorsInput is used as input to the ListDirectors function.
@@ -93,7 +68,6 @@ func (c *Client) ListDirectors(i *ListDirectorsInput) ([]*Director, error) {
 	if err := decodeBodyMap(resp.Body, &ds); err != nil {
 		return nil, err
 	}
-	sort.Stable(directorsByName(ds))
 	return ds, nil
 }
 
@@ -195,7 +169,7 @@ type UpdateDirectorInput struct {
 	// Shield is selected POP to serve as a shield for the backends.
 	Shield *string `url:"shield,omitempty"`
 	// Type is what type of load balance group to use (random, hash, client).
-	Type DirectorType `url:"type,omitempty"`
+	Type *DirectorType `url:"type,omitempty"`
 }
 
 // UpdateDirector updates the specified resource.

--- a/fastly/director_backend.go
+++ b/fastly/director_backend.go
@@ -9,12 +9,12 @@ import (
 // DirectorBackend is the relationship between a director and a backend in the
 // Fastly API.
 type DirectorBackend struct {
-	Backend        string     `mapstructure:"backend_name"`
+	Backend        *string    `mapstructure:"backend_name"`
 	CreatedAt      *time.Time `mapstructure:"created_at"`
 	DeletedAt      *time.Time `mapstructure:"deleted_at"`
-	Director       string     `mapstructure:"director_name"`
-	ServiceID      string     `mapstructure:"service_id"`
-	ServiceVersion int        `mapstructure:"version"`
+	Director       *string    `mapstructure:"director_name"`
+	ServiceID      *string    `mapstructure:"service_id"`
+	ServiceVersion *int       `mapstructure:"version"`
 	UpdatedAt      *time.Time `mapstructure:"updated_at"`
 }
 
@@ -33,20 +33,17 @@ type CreateDirectorBackendInput struct {
 
 // CreateDirectorBackend creates a new resource.
 func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*DirectorBackend, error) {
-	if i.ServiceID == "" {
-		return nil, ErrMissingServiceID
+	if i.Backend == "" {
+		return nil, ErrMissingBackend
 	}
-
-	if i.ServiceVersion == 0 {
-		return nil, ErrMissingServiceVersion
-	}
-
 	if i.Director == "" {
 		return nil, ErrMissingDirector
 	}
-
-	if i.Backend == "" {
-		return nil, ErrMissingBackend
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+	if i.ServiceVersion == 0 {
+		return nil, ErrMissingServiceVersion
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
@@ -79,20 +76,17 @@ type GetDirectorBackendInput struct {
 
 // GetDirectorBackend retrieves the specified resource.
 func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBackend, error) {
-	if i.ServiceID == "" {
-		return nil, ErrMissingServiceID
+	if i.Backend == "" {
+		return nil, ErrMissingBackend
 	}
-
-	if i.ServiceVersion == 0 {
-		return nil, ErrMissingServiceVersion
-	}
-
 	if i.Director == "" {
 		return nil, ErrMissingDirector
 	}
-
-	if i.Backend == "" {
-		return nil, ErrMissingBackend
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+	if i.ServiceVersion == 0 {
+		return nil, ErrMissingServiceVersion
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
@@ -125,20 +119,17 @@ type DeleteDirectorBackendInput struct {
 
 // DeleteDirectorBackend deletes the specified resource.
 func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
-	if i.ServiceID == "" {
-		return ErrMissingServiceID
+	if i.Backend == "" {
+		return ErrMissingBackend
 	}
-
-	if i.ServiceVersion == 0 {
-		return ErrMissingServiceVersion
-	}
-
 	if i.Director == "" {
 		return ErrMissingDirector
 	}
-
-	if i.Backend == "" {
-		return ErrMissingBackend
+	if i.ServiceID == "" {
+		return ErrMissingServiceID
+	}
+	if i.ServiceVersion == 0 {
+		return ErrMissingServiceVersion
 	}
 
 	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",

--- a/fastly/director_backend_test.go
+++ b/fastly/director_backend_test.go
@@ -39,11 +39,11 @@ func TestClient_DirectorBackends(t *testing.T) {
 		})
 	}()
 
-	if b.Director != "director" {
-		t.Errorf("bad director: %q", b.Director)
+	if *b.Director != "director" {
+		t.Errorf("bad director: %q", *b.Director)
 	}
-	if b.Backend != "backend" {
-		t.Errorf("bad backend: %q", b.Backend)
+	if *b.Backend != "backend" {
+		t.Errorf("bad backend: %q", *b.Backend)
 	}
 
 	// Get
@@ -60,11 +60,11 @@ func TestClient_DirectorBackends(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if b.Director != nb.Director {
-		t.Errorf("bad director: %q", b.Director)
+	if *b.Director != *nb.Director {
+		t.Errorf("bad director: %q", *b.Director)
 	}
-	if b.Backend != nb.Backend {
-		t.Errorf("bad backend: %q", b.Backend)
+	if *b.Backend != *nb.Backend {
+		t.Errorf("bad backend: %q", *b.Backend)
 	}
 
 	// Delete
@@ -83,16 +83,27 @@ func TestClient_DirectorBackends(t *testing.T) {
 
 func TestClient_CreateDirectorBackend_validation(t *testing.T) {
 	var err error
+	_, err = testClient.CreateDirectorBackend(&CreateDirectorBackendInput{})
+	if err != ErrMissingBackend {
+		t.Errorf("bad error: %s", err)
+	}
 	_, err = testClient.CreateDirectorBackend(&CreateDirectorBackendInput{
-		ServiceID: "",
+		Backend: "foo",
+	})
+	if err != ErrMissingDirector {
+		t.Errorf("bad error: %s", err)
+	}
+	_, err = testClient.CreateDirectorBackend(&CreateDirectorBackendInput{
+		Backend:  "foo",
+		Director: "bar",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
-
 	_, err = testClient.CreateDirectorBackend(&CreateDirectorBackendInput{
-		ServiceID:      "foo",
-		ServiceVersion: 0,
+		Backend:   "foo",
+		Director:  "bar",
+		ServiceID: "baz",
 	})
 	if err != ErrMissingServiceVersion {
 		t.Errorf("bad error: %s", err)
@@ -101,74 +112,58 @@ func TestClient_CreateDirectorBackend_validation(t *testing.T) {
 
 func TestClient_GetDirectorBackend_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
-		ServiceID: "",
-	})
-	if err != ErrMissingServiceID {
+	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{})
+	if err != ErrMissingBackend {
 		t.Errorf("bad error: %s", err)
 	}
-
 	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
-		ServiceID:      "foo",
-		ServiceVersion: 0,
-	})
-	if err != ErrMissingServiceVersion {
-		t.Errorf("bad error: %s", err)
-	}
-
-	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
-		ServiceID:      "foo",
-		ServiceVersion: 1,
-		Director:       "",
+		Backend: "foo",
 	})
 	if err != ErrMissingDirector {
 		t.Errorf("bad error: %s", err)
 	}
-
 	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
-		ServiceID:      "foo",
-		ServiceVersion: 1,
-		Director:       "director",
-		Backend:        "",
+		Backend:  "foo",
+		Director: "bar",
 	})
-	if err != ErrMissingBackend {
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
+		Backend:   "foo",
+		Director:  "bar",
+		ServiceID: "baz",
+	})
+	if err != ErrMissingServiceVersion {
 		t.Errorf("bad error: %s", err)
 	}
 }
 
 func TestClient_DeleteDirectorBackend_validation(t *testing.T) {
 	var err error
-	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
-		ServiceID: "",
-	})
-	if err != ErrMissingServiceID {
+	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{})
+	if err != ErrMissingBackend {
 		t.Errorf("bad error: %s", err)
 	}
-
 	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
-		ServiceID:      "foo",
-		ServiceVersion: 0,
-	})
-	if err != ErrMissingServiceVersion {
-		t.Errorf("bad error: %s", err)
-	}
-
-	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
-		ServiceID:      "foo",
-		ServiceVersion: 1,
-		Director:       "",
+		Backend: "foo",
 	})
 	if err != ErrMissingDirector {
 		t.Errorf("bad error: %s", err)
 	}
-
 	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
-		ServiceID:      "foo",
-		ServiceVersion: 1,
-		Director:       "director",
-		Backend:        "",
+		Backend:  "foo",
+		Director: "bar",
 	})
-	if err != ErrMissingBackend {
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
+		Backend:   "foo",
+		Director:  "bar",
+		ServiceID: "baz",
+	})
+	if err != ErrMissingServiceVersion {
 		t.Errorf("bad error: %s", err)
 	}
 }

--- a/fastly/director_backend_test.go
+++ b/fastly/director_backend_test.go
@@ -18,7 +18,7 @@ func TestClient_DirectorBackends(t *testing.T) {
 	record(t, "director_backends/create", func(c *Client) {
 		b, err = c.CreateDirectorBackend(&CreateDirectorBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Director:       "director",
 			Backend:        "backend",
 		})
@@ -32,7 +32,7 @@ func TestClient_DirectorBackends(t *testing.T) {
 		record(t, "director_backends/cleanup", func(c *Client) {
 			_ = c.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Director:       "director",
 				Backend:        "backend",
 			})
@@ -51,7 +51,7 @@ func TestClient_DirectorBackends(t *testing.T) {
 	record(t, "director_backends/get", func(c *Client) {
 		nb, err = c.GetDirectorBackend(&GetDirectorBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Director:       "director",
 			Backend:        "backend",
 		})
@@ -71,7 +71,7 @@ func TestClient_DirectorBackends(t *testing.T) {
 	record(t, "director_backends/delete", func(c *Client) {
 		err = c.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Director:       "director",
 			Backend:        "backend",
 		})

--- a/fastly/director_test.go
+++ b/fastly/director_test.go
@@ -36,7 +36,7 @@ func TestClient_Directors(t *testing.T) {
 			ServiceVersion: tv.Number,
 			Name:           ToPointer("test-director"),
 			Quorum:         ToPointer(50),
-			Type:           DirectorTypePtr(DirectorTypeRandom),
+			Type:           ToPointer(DirectorTypeRandom),
 			Retries:        ToPointer(5),
 		})
 		_, errDirectorBackend = c.CreateDirectorBackend(&CreateDirectorBackendInput{
@@ -62,7 +62,7 @@ func TestClient_Directors(t *testing.T) {
 			_ = c.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 				ServiceID:      testServiceID,
 				ServiceVersion: tv.Number,
-				Director:       d.Name,
+				Director:       *d.Name,
 				Backend:        *b.Name,
 			})
 
@@ -86,17 +86,17 @@ func TestClient_Directors(t *testing.T) {
 		})
 	}()
 
-	if d.Name != "test-director" {
-		t.Errorf("bad name: %q", d.Name)
+	if *d.Name != "test-director" {
+		t.Errorf("bad name: %q", *d.Name)
 	}
-	if d.Quorum != 50 {
-		t.Errorf("bad quorum: %q", d.Quorum)
+	if *d.Quorum != 50 {
+		t.Errorf("bad quorum: %q", *d.Quorum)
 	}
-	if d.Type != DirectorTypeRandom {
-		t.Errorf("bad type: %d", d.Type)
+	if *d.Type != DirectorTypeRandom {
+		t.Errorf("bad type: %d", *d.Type)
 	}
-	if d.Retries != 5 {
-		t.Errorf("bad retries: %d", d.Retries)
+	if *d.Retries != 5 {
+		t.Errorf("bad retries: %d", *d.Retries)
 	}
 
 	// List
@@ -129,17 +129,17 @@ func TestClient_Directors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if d.Name != nb.Name {
-		t.Errorf("bad name: %q (%q)", d.Name, nb.Name)
+	if *d.Name != *nb.Name {
+		t.Errorf("bad name: %q (%q)", *d.Name, *nb.Name)
 	}
-	if d.Quorum != nb.Quorum {
-		t.Errorf("bad quorum: %q (%q)", d.Quorum, nb.Quorum)
+	if *d.Quorum != *nb.Quorum {
+		t.Errorf("bad quorum: %q (%q)", *d.Quorum, *nb.Quorum)
 	}
-	if d.Type != nb.Type {
-		t.Errorf("bad type: %q (%q)", d.Type, nb.Type)
+	if *d.Type != *nb.Type {
+		t.Errorf("bad type: %q (%q)", *d.Type, *nb.Type)
 	}
-	if d.Retries != nb.Retries {
-		t.Errorf("bad retries: %q (%q)", d.Retries, nb.Retries)
+	if *d.Retries != *nb.Retries {
+		t.Errorf("bad retries: %q (%q)", *d.Retries, *nb.Retries)
 	}
 	if len(nb.Backends) == 0 || nb.Backends[0] != *b.Name {
 		t.Error("bad backend: expected a backend")
@@ -159,8 +159,8 @@ func TestClient_Directors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ub.Quorum != 100 {
-		t.Errorf("bad quorum: %q", ub.Quorum)
+	if *ub.Quorum != 100 {
+		t.Errorf("bad quorum: %q", *ub.Quorum)
 	}
 
 	// Delete

--- a/fastly/director_test.go
+++ b/fastly/director_test.go
@@ -23,7 +23,7 @@ func TestClient_Directors(t *testing.T) {
 	record(t, "directors/create", func(c *Client) {
 		b, errBackend = c.CreateBackend(&CreateBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-backend"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
 			Port:           ToPointer(1234),
@@ -33,7 +33,7 @@ func TestClient_Directors(t *testing.T) {
 		})
 		d, errDirector = c.CreateDirector(&CreateDirectorInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-director"),
 			Quorum:         ToPointer(50),
 			Type:           ToPointer(DirectorTypeRandom),
@@ -41,7 +41,7 @@ func TestClient_Directors(t *testing.T) {
 		})
 		_, errDirectorBackend = c.CreateDirectorBackend(&CreateDirectorBackendInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Director:       "test-director",
 			Backend:        *b.Name,
 		})
@@ -61,26 +61,26 @@ func TestClient_Directors(t *testing.T) {
 		record(t, "directors/cleanup", func(c *Client) {
 			_ = c.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Director:       *d.Name,
 				Backend:        *b.Name,
 			})
 
 			_ = c.DeleteBackend(&DeleteBackendInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           *b.Name,
 			})
 
 			_ = c.DeleteDirector(&DeleteDirectorInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-director",
 			})
 
 			_ = c.DeleteDirector(&DeleteDirectorInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-director",
 			})
 		})
@@ -107,7 +107,7 @@ func TestClient_Directors(t *testing.T) {
 	record(t, "directors/list", func(c *Client) {
 		bs, err = c.ListDirectors(&ListDirectorsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -122,7 +122,7 @@ func TestClient_Directors(t *testing.T) {
 	record(t, "directors/get", func(c *Client) {
 		nb, err = c.GetDirector(&GetDirectorInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-director",
 		})
 	})
@@ -150,7 +150,7 @@ func TestClient_Directors(t *testing.T) {
 	record(t, "directors/update", func(c *Client) {
 		ub, err = c.UpdateDirector(&UpdateDirectorInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-director",
 			NewName:        ToPointer("new-test-director"),
 			Quorum:         ToPointer(100),
@@ -167,7 +167,7 @@ func TestClient_Directors(t *testing.T) {
 	record(t, "directors/delete", func(c *Client) {
 		err = c.DeleteDirector(&DeleteDirectorInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-director",
 		})
 	})

--- a/fastly/domain.go
+++ b/fastly/domain.go
@@ -5,37 +5,18 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Domain represents the the domain name Fastly will serve content for.
 type Domain struct {
-	Comment        string     `mapstructure:"comment"`
+	Comment        *string    `mapstructure:"comment"`
 	CreatedAt      *time.Time `mapstructure:"created_at"`
 	DeletedAt      *time.Time `mapstructure:"deleted_at"`
-	Name           string     `mapstructure:"name"`
-	ServiceID      string     `mapstructure:"service_id"`
-	ServiceVersion int        `mapstructure:"version"`
+	Name           *string    `mapstructure:"name"`
+	ServiceID      *string    `mapstructure:"service_id"`
+	ServiceVersion *int       `mapstructure:"version"`
 	UpdatedAt      *time.Time `mapstructure:"updated_at"`
-}
-
-// domainsByName is a sortable list of backends.
-type domainsByName []*Domain
-
-// Len implement the sortable interface.
-func (s domainsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s domainsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s domainsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListDomainsInput is used as input to the ListDomains function.
@@ -66,7 +47,6 @@ func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 	if err := decodeBodyMap(resp.Body, &ds); err != nil {
 		return nil, err
 	}
-	sort.Stable(domainsByName(ds))
 	return ds, nil
 }
 
@@ -74,7 +54,7 @@ func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 type CreateDomainInput struct {
 	// Comment is a personal, freeform descriptive note.
 	Comment *string `url:"comment,omitempty"`
-	// Name is the name of the domain that the service will respond to (required).
+	// Name is the name of the domain that the service will respond to.
 	Name *string `url:"name,omitempty"`
 	// ServiceID is the ID of the service (required).
 	ServiceID string `url:"-"`
@@ -254,9 +234,9 @@ func (c *Client) ValidateDomain(i *ValidateDomainInput) (*DomainValidationResult
 // DomainValidationResult defines an idiomatic representation of the API
 // response.
 type DomainValidationResult struct {
-	CName    string
-	Metadata DomainMetadata
-	Valid    bool
+	CName    *string
+	Metadata *DomainMetadata
+	Valid    *bool
 }
 
 // UnmarshalJSON works around the badly designed API response by coercing the
@@ -288,12 +268,12 @@ func (d *DomainValidationResult) UnmarshalJSON(data []byte) error {
 
 // DomainMetadata represents a domain name configured for a Fastly service.
 type DomainMetadata struct {
-	Comment        string     `json:"comment"`
+	Comment        *string    `json:"comment"`
 	CreatedAt      *time.Time `json:"created_at"`
 	DeletedAt      *time.Time `json:"deleted_at"`
-	Name           string     `json:"name"`
-	ServiceID      string     `json:"service_id"`
-	ServiceVersion int        `json:"version"`
+	Name           *string    `json:"name"`
+	ServiceID      *string    `json:"service_id"`
+	ServiceVersion *int       `json:"version"`
 	UpdatedAt      *time.Time `json:"updated_at"`
 }
 

--- a/fastly/domain_inspector.go
+++ b/fastly/domain_inspector.go
@@ -10,123 +10,123 @@ import (
 // DomainInspector represents the response format returned for a request to
 // the historical Domain Inspector metrics endpoint.
 type DomainInspector struct {
-	Data   []DomainData `mapstructure:"data"`
-	Meta   DomainMeta   `mapstructure:"meta"`
-	Status string       `mapstructure:"status"`
+	Data   []*DomainData `mapstructure:"data"`
+	Meta   *DomainMeta   `mapstructure:"meta"`
+	Status *string       `mapstructure:"status"`
 }
 
 // DomainData represents the series of values over time for a single
 // dimension combination.
 type DomainData struct {
-	Dimensions map[string]string `mapstructure:"dimensions"`
-	Values     []DomainMetrics   `mapstructure:"values"`
+	Dimensions map[string]*string `mapstructure:"dimensions"`
+	Values     []*DomainMetrics   `mapstructure:"values"`
 }
 
 // DomainMetrics represents the possible metrics that can be returned by a call
 // to the Domain Inspector endpoints.
 type DomainMetrics struct {
-	Bandwidth                  uint64  `mapstructure:"bandwidth"`
-	BereqBodyBytes             uint64  `mapstructure:"bereq_body_bytes"`
-	BereqHeaderBytes           uint64  `mapstructure:"bereq_header_bytes"`
-	EdgeHitRatio               float64 `mapstructure:"edge_hit_ratio"`
-	EdgeHitRequests            uint64  `mapstructure:"edge_hit_requests"`
-	EdgeMissRequests           uint64  `mapstructure:"edge_miss_requests"`
-	EdgeRequests               uint64  `mapstructure:"edge_requests"`
-	EdgeRespBodyBytes          uint64  `mapstructure:"edge_resp_body_bytes"`
-	EdgeRespHeaderBytes        uint64  `mapstructure:"edge_resp_header_bytes"`
-	OriginFetchRespBodyBytes   uint64  `mapstructure:"origin_fetch_resp_body_bytes"`
-	OriginFetchRespHeaderBytes uint64  `mapstructure:"origin_fetch_resp_header_bytes"`
-	OriginFetches              uint64  `mapstructure:"origin_fetches"`
-	OriginOffload              float64 `mapstructure:"origin_offload"`
-	OriginStatus1xx            uint64  `mapstructure:"origin_status_1xx"`
-	OriginStatus200            uint64  `mapstructure:"origin_status_200"`
-	OriginStatus204            uint64  `mapstructure:"origin_status_204"`
-	OriginStatus206            uint64  `mapstructure:"origin_status_206"`
-	OriginStatus2xx            uint64  `mapstructure:"origin_status_2xx"`
-	OriginStatus301            uint64  `mapstructure:"origin_status_301"`
-	OriginStatus302            uint64  `mapstructure:"origin_status_302"`
-	OriginStatus304            uint64  `mapstructure:"origin_status_304"`
-	OriginStatus3xx            uint64  `mapstructure:"origin_status_3xx"`
-	OriginStatus400            uint64  `mapstructure:"origin_status_400"`
-	OriginStatus401            uint64  `mapstructure:"origin_status_401"`
-	OriginStatus403            uint64  `mapstructure:"origin_status_403"`
-	OriginStatus404            uint64  `mapstructure:"origin_status_404"`
-	OriginStatus416            uint64  `mapstructure:"origin_status_416"`
-	OriginStatus429            uint64  `mapstructure:"origin_status_429"`
-	OriginStatus4xx            uint64  `mapstructure:"origin_status_4xx"`
-	OriginStatus500            uint64  `mapstructure:"origin_status_500"`
-	OriginStatus501            uint64  `mapstructure:"origin_status_501"`
-	OriginStatus502            uint64  `mapstructure:"origin_status_502"`
-	OriginStatus503            uint64  `mapstructure:"origin_status_503"`
-	OriginStatus504            uint64  `mapstructure:"origin_status_504"`
-	OriginStatus505            uint64  `mapstructure:"origin_status_505"`
-	OriginStatus5xx            uint64  `mapstructure:"origin_status_5xx"`
-	Requests                   uint64  `mapstructure:"requests"`
-	RespBodyBytes              uint64  `mapstructure:"resp_body_bytes"`
-	RespHeaderBytes            uint64  `mapstructure:"resp_header_bytes"`
-	Status1xx                  uint64  `mapstructure:"status_1xx"`
-	Status200                  uint64  `mapstructure:"status_200"`
-	Status204                  uint64  `mapstructure:"status_204"`
-	Status206                  uint64  `mapstructure:"status_206"`
-	Status2xx                  uint64  `mapstructure:"status_2xx"`
-	Status301                  uint64  `mapstructure:"status_301"`
-	Status302                  uint64  `mapstructure:"status_302"`
-	Status304                  uint64  `mapstructure:"status_304"`
-	Status3xx                  uint64  `mapstructure:"status_3xx"`
-	Status400                  uint64  `mapstructure:"status_400"`
-	Status401                  uint64  `mapstructure:"status_401"`
-	Status403                  uint64  `mapstructure:"status_403"`
-	Status404                  uint64  `mapstructure:"status_404"`
-	Status416                  uint64  `mapstructure:"status_416"`
-	Status429                  uint64  `mapstructure:"status_429"`
-	Status4xx                  uint64  `mapstructure:"status_4xx"`
-	Status500                  uint64  `mapstructure:"status_500"`
-	Status501                  uint64  `mapstructure:"status_501"`
-	Status502                  uint64  `mapstructure:"status_502"`
-	Status503                  uint64  `mapstructure:"status_503"`
-	Status504                  uint64  `mapstructure:"status_504"`
-	Status505                  uint64  `mapstructure:"status_505"`
-	Status5xx                  uint64  `mapstructure:"status_5xx"`
-	Timestamp                  uint64  `mapstructure:"timestamp"`
+	Bandwidth                  *uint64  `mapstructure:"bandwidth"`
+	BereqBodyBytes             *uint64  `mapstructure:"bereq_body_bytes"`
+	BereqHeaderBytes           *uint64  `mapstructure:"bereq_header_bytes"`
+	EdgeHitRatio               *float64 `mapstructure:"edge_hit_ratio"`
+	EdgeHitRequests            *uint64  `mapstructure:"edge_hit_requests"`
+	EdgeMissRequests           *uint64  `mapstructure:"edge_miss_requests"`
+	EdgeRequests               *uint64  `mapstructure:"edge_requests"`
+	EdgeRespBodyBytes          *uint64  `mapstructure:"edge_resp_body_bytes"`
+	EdgeRespHeaderBytes        *uint64  `mapstructure:"edge_resp_header_bytes"`
+	OriginFetchRespBodyBytes   *uint64  `mapstructure:"origin_fetch_resp_body_bytes"`
+	OriginFetchRespHeaderBytes *uint64  `mapstructure:"origin_fetch_resp_header_bytes"`
+	OriginFetches              *uint64  `mapstructure:"origin_fetches"`
+	OriginOffload              *float64 `mapstructure:"origin_offload"`
+	OriginStatus1xx            *uint64  `mapstructure:"origin_status_1xx"`
+	OriginStatus200            *uint64  `mapstructure:"origin_status_200"`
+	OriginStatus204            *uint64  `mapstructure:"origin_status_204"`
+	OriginStatus206            *uint64  `mapstructure:"origin_status_206"`
+	OriginStatus2xx            *uint64  `mapstructure:"origin_status_2xx"`
+	OriginStatus301            *uint64  `mapstructure:"origin_status_301"`
+	OriginStatus302            *uint64  `mapstructure:"origin_status_302"`
+	OriginStatus304            *uint64  `mapstructure:"origin_status_304"`
+	OriginStatus3xx            *uint64  `mapstructure:"origin_status_3xx"`
+	OriginStatus400            *uint64  `mapstructure:"origin_status_400"`
+	OriginStatus401            *uint64  `mapstructure:"origin_status_401"`
+	OriginStatus403            *uint64  `mapstructure:"origin_status_403"`
+	OriginStatus404            *uint64  `mapstructure:"origin_status_404"`
+	OriginStatus416            *uint64  `mapstructure:"origin_status_416"`
+	OriginStatus429            *uint64  `mapstructure:"origin_status_429"`
+	OriginStatus4xx            *uint64  `mapstructure:"origin_status_4xx"`
+	OriginStatus500            *uint64  `mapstructure:"origin_status_500"`
+	OriginStatus501            *uint64  `mapstructure:"origin_status_501"`
+	OriginStatus502            *uint64  `mapstructure:"origin_status_502"`
+	OriginStatus503            *uint64  `mapstructure:"origin_status_503"`
+	OriginStatus504            *uint64  `mapstructure:"origin_status_504"`
+	OriginStatus505            *uint64  `mapstructure:"origin_status_505"`
+	OriginStatus5xx            *uint64  `mapstructure:"origin_status_5xx"`
+	Requests                   *uint64  `mapstructure:"requests"`
+	RespBodyBytes              *uint64  `mapstructure:"resp_body_bytes"`
+	RespHeaderBytes            *uint64  `mapstructure:"resp_header_bytes"`
+	Status1xx                  *uint64  `mapstructure:"status_1xx"`
+	Status200                  *uint64  `mapstructure:"status_200"`
+	Status204                  *uint64  `mapstructure:"status_204"`
+	Status206                  *uint64  `mapstructure:"status_206"`
+	Status2xx                  *uint64  `mapstructure:"status_2xx"`
+	Status301                  *uint64  `mapstructure:"status_301"`
+	Status302                  *uint64  `mapstructure:"status_302"`
+	Status304                  *uint64  `mapstructure:"status_304"`
+	Status3xx                  *uint64  `mapstructure:"status_3xx"`
+	Status400                  *uint64  `mapstructure:"status_400"`
+	Status401                  *uint64  `mapstructure:"status_401"`
+	Status403                  *uint64  `mapstructure:"status_403"`
+	Status404                  *uint64  `mapstructure:"status_404"`
+	Status416                  *uint64  `mapstructure:"status_416"`
+	Status429                  *uint64  `mapstructure:"status_429"`
+	Status4xx                  *uint64  `mapstructure:"status_4xx"`
+	Status500                  *uint64  `mapstructure:"status_500"`
+	Status501                  *uint64  `mapstructure:"status_501"`
+	Status502                  *uint64  `mapstructure:"status_502"`
+	Status503                  *uint64  `mapstructure:"status_503"`
+	Status504                  *uint64  `mapstructure:"status_504"`
+	Status505                  *uint64  `mapstructure:"status_505"`
+	Status5xx                  *uint64  `mapstructure:"status_5xx"`
+	Timestamp                  *uint64  `mapstructure:"timestamp"`
 }
 
-// DomainMeta is the meta section returned for /metrics/domains/... responses
+// DomainMeta is the meta section returned for /metrics/domains/... responses.
 type DomainMeta struct {
-	Downsample string            `mapstructure:"downsample"`
-	End        string            `mapstructure:"end"`
+	Downsample *string           `mapstructure:"downsample"`
+	End        *string           `mapstructure:"end"`
 	Filters    map[string]string `mapstructure:"filters"`
-	GroupBy    string            `mapstructure:"group_by"`
-	Limit      int               `mapstructure:"limit"`
-	Metric     string            `mapstructure:"metric"`
-	NextCursor string            `mapstructure:"next_cursor"`
-	Sort       string            `mapstructure:"sort"`
-	Start      string            `mapstructure:"start"`
+	GroupBy    *string           `mapstructure:"group_by"`
+	Limit      *int              `mapstructure:"limit"`
+	Metric     *string           `mapstructure:"metric"`
+	NextCursor *string           `mapstructure:"next_cursor"`
+	Sort       *string           `mapstructure:"sort"`
+	Start      *string           `mapstructure:"start"`
 }
 
 // GetDomainMetricsInput is the input to a DomainMetrics request.
 type GetDomainMetricsInput struct {
 	// Cursor is the value from a previous response to retrieve the next page. To request the first page, this should be empty.
-	Cursor string
+	Cursor *string
 	// Datacenters limits query to one or more specific POPs.
 	Datacenters []string
 	// Domains limit query to one or more specific domains.
 	Domains []string
 	// Downsample is the duration of sample windows.
-	Downsample string
+	Downsample *string
 	// End is a valid ISO-8601-formatted date and time, or UNIX timestamp, indicating the exclusive end of the query time range. If not provided, a default is chosen based on the provided downsample value.
-	End time.Time
+	End *time.Time
 	// GroupBy is the dimensions to return in the query.
 	GroupBy []string
 	// Limit is the limit of returned data
-	Limit int
+	Limit *int
 	// Metrics is the metric to retrieve. Up to ten metrics are accepted.
 	Metrics []string
 	// Regions limits query to one or more specific geographic regions.
 	Regions []string
-	// ServiceID is an alphanumeric string identifying the service.
+	// ServiceID is an alphanumeric string identifying the service (required).
 	ServiceID string
 	// Start is a valid ISO-8601-formatted date and time, or UNIX timestamp, indicating the inclusive start of the query time range. If not provided, a default is chosen based on the provided downsample value.
-	Start time.Time
+	Start *time.Time
 }
 
 // GetDomainMetricsForService retrieves the specified resource.
@@ -151,33 +151,32 @@ func (c *Client) GetDomainMetricsForServiceJSON(i *GetDomainMetricsInput, dst an
 
 	p := "/metrics/domains/services/" + i.ServiceID
 
-	start := ""
-	if !i.Start.IsZero() {
-		start = strconv.FormatInt(i.Start.Unix(), 10)
-	}
-	end := ""
-	if !i.End.IsZero() {
-		end = strconv.FormatInt(i.End.Unix(), 10)
-	}
-	limit := ""
-	if i.Limit > 0 {
-		limit = strconv.Itoa(i.Limit)
-	}
-
-	r, err := c.Get(p, &RequestOptions{
+	ro := &RequestOptions{
 		Params: map[string]string{
-			"start":      start,
-			"end":        end,
-			"downsample": i.Downsample,
 			"group_by":   strings.Join(i.GroupBy, ","),
 			"metric":     strings.Join(i.Metrics, ","),
 			"domain":     strings.Join(i.Domains, ","),
 			"datacenter": strings.Join(i.Datacenters, ","),
 			"region":     strings.Join(i.Regions, ","),
-			"limit":      limit,
-			"cursor":     i.Cursor,
 		},
-	})
+	}
+	if i.Cursor != nil {
+		ro.Params["cursor"] = *i.Cursor
+	}
+	if i.Downsample != nil {
+		ro.Params["downsample"] = *i.Downsample
+	}
+	if i.End != nil {
+		ro.Params["end"] = strconv.FormatInt(i.End.Unix(), 10)
+	}
+	if i.Limit != nil {
+		ro.Params["limit"] = strconv.Itoa(*i.Limit)
+	}
+	if i.Start != nil {
+		ro.Params["start"] = strconv.FormatInt(i.Start.Unix(), 10)
+	}
+
+	r, err := c.Get(p, ro)
 	if err != nil {
 		return err
 	}

--- a/fastly/domain_inspector_test.go
+++ b/fastly/domain_inspector_test.go
@@ -17,16 +17,16 @@ func TestClient_GetDomainMetricsForService(t *testing.T) {
 	record(t, "domain_inspector/metrics_for_service", func(c *Client) {
 		_, err = c.GetDomainMetricsForService(&GetDomainMetricsInput{
 			ServiceID:   testServiceID,
-			Start:       start,
-			End:         end,
+			Start:       &start,
+			End:         &end,
 			Domains:     []string{"domain_1.com", "domain_2.com"},
 			Datacenters: []string{"SJC", "STP"},
 			Metrics:     []string{"resp_body_bytes", "status_2xx"},
 			GroupBy:     []string{"domain"},
-			Downsample:  "hour",
+			Downsample:  ToPointer("hour"),
 			Regions:     []string{"usa"},
-			Limit:       10,
-			Cursor:      "",
+			Limit:       ToPointer(10),
+			Cursor:      ToPointer(""),
 		})
 	})
 	if err != nil {

--- a/fastly/domain_test.go
+++ b/fastly/domain_test.go
@@ -25,7 +25,7 @@ func TestClient_Domains(t *testing.T) {
 	record(t, "domains/create", func(c *Client) {
 		d, err = c.CreateDomain(&CreateDomainInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer(domain1),
 			Comment:        ToPointer("comment"),
 		})
@@ -38,7 +38,7 @@ func TestClient_Domains(t *testing.T) {
 	record(t, "domains/create2", func(c *Client) {
 		d2, err = c.CreateDomain(&CreateDomainInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer(domain2),
 			Comment:        ToPointer("comment"),
 		})
@@ -52,13 +52,13 @@ func TestClient_Domains(t *testing.T) {
 		record(t, "domains/cleanup", func(c *Client) {
 			_ = c.DeleteDomain(&DeleteDomainInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           domain1,
 			})
 
 			_ = c.DeleteDomain(&DeleteDomainInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           domain3,
 			})
 		})
@@ -79,7 +79,7 @@ func TestClient_Domains(t *testing.T) {
 	record(t, "domains/list", func(c *Client) {
 		ds, err = c.ListDomains(&ListDomainsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -94,7 +94,7 @@ func TestClient_Domains(t *testing.T) {
 	record(t, "domains/get", func(c *Client) {
 		nd, err = c.GetDomain(&GetDomainInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           domain1,
 		})
 	})
@@ -113,7 +113,7 @@ func TestClient_Domains(t *testing.T) {
 	record(t, "domains/update", func(c *Client) {
 		ud, err = c.UpdateDomain(&UpdateDomainInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           domain1,
 			NewName:        ToPointer(domain3),
 		})
@@ -130,7 +130,7 @@ func TestClient_Domains(t *testing.T) {
 	record(t, "domains/validation", func(c *Client) {
 		vd, err = c.ValidateDomain(&ValidateDomainInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           domain3,
 		})
 	})
@@ -145,7 +145,7 @@ func TestClient_Domains(t *testing.T) {
 	record(t, "domains/validate-all", func(c *Client) {
 		vds, err = c.ValidateAllDomains(&ValidateAllDomainsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -164,7 +164,7 @@ func TestClient_Domains(t *testing.T) {
 	record(t, "domains/delete", func(c *Client) {
 		err = c.DeleteDomain(&DeleteDomainInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           domain3,
 		})
 	})

--- a/fastly/domain_test.go
+++ b/fastly/domain_test.go
@@ -13,7 +13,7 @@ func TestClient_Domains(t *testing.T) {
 		tv = testVersion(t, c)
 	})
 
-	// NOTE: Everytime you regenerate the fixtures you'll need to update the
+	// NOTE: Every time you regenerate the fixtures you'll need to update the
 	// domains as they'll potentially be reported as used depending on the
 	// service pre-existing.
 	domain1 := "integ-test-20221104.go-fastly-1.com"
@@ -64,14 +64,14 @@ func TestClient_Domains(t *testing.T) {
 		})
 	}()
 
-	if d.Name != domain1 {
-		t.Errorf("bad name: %q", d.Name)
+	if *d.Name != domain1 {
+		t.Errorf("bad name: %q", *d.Name)
 	}
-	if d.Comment != "comment" {
-		t.Errorf("bad comment: %q", d.Comment)
+	if *d.Comment != "comment" {
+		t.Errorf("bad comment: %q", *d.Comment)
 	}
-	if d2.Name != domain2 {
-		t.Errorf("bad name: %q", d.Name)
+	if *d2.Name != domain2 {
+		t.Errorf("bad name: %q", *d.Name)
 	}
 
 	// List
@@ -101,11 +101,11 @@ func TestClient_Domains(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if d.Name != nd.Name {
-		t.Errorf("bad name: %q (%q)", d.Name, nd.Name)
+	if *d.Name != *nd.Name {
+		t.Errorf("bad name: %q (%q)", *d.Name, *nd.Name)
 	}
-	if d.Comment != nd.Comment {
-		t.Errorf("bad comment: %q (%q)", d.Comment, nd.Comment)
+	if *d.Comment != *nd.Comment {
+		t.Errorf("bad comment: %q (%q)", *d.Comment, *nd.Comment)
 	}
 
 	// Update
@@ -121,8 +121,8 @@ func TestClient_Domains(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ud.Name != domain3 {
-		t.Errorf("bad name: %q", ud.Name)
+	if *ud.Name != domain3 {
+		t.Errorf("bad name: %q", *ud.Name)
 	}
 
 	// Validate
@@ -137,8 +137,8 @@ func TestClient_Domains(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if vd.Valid {
-		t.Errorf("valid domain unexpected: %q", vd.Metadata.Name)
+	if *vd.Valid {
+		t.Errorf("valid domain unexpected: %q", *vd.Metadata.Name)
 	}
 
 	var vds []*DomainValidationResult
@@ -155,8 +155,8 @@ func TestClient_Domains(t *testing.T) {
 		t.Errorf("invalid domains: %v", vds)
 	}
 	for _, d := range vds {
-		if d.Valid {
-			t.Errorf("valid domain unexpected: %q", d.Metadata.Name)
+		if *d.Valid {
+			t.Errorf("valid domain unexpected: %q", *d.Metadata.Name)
 		}
 	}
 

--- a/fastly/elasticsearch.go
+++ b/fastly/elasticsearch.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,43 +10,25 @@ import (
 type Elasticsearch struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Index             string     `mapstructure:"index"`
-	Name              string     `mapstructure:"name"`
-	Password          string     `mapstructure:"password"`
-	Pipeline          string     `mapstructure:"pipeline"`
-	Placement         string     `mapstructure:"placement"`
-	RequestMaxBytes   int        `mapstructure:"request_max_bytes"`
-	RequestMaxEntries int        `mapstructure:"request_max_entries"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TLSCACert         string     `mapstructure:"tls_ca_cert"`
-	TLSClientCert     string     `mapstructure:"tls_client_cert"`
-	TLSClientKey      string     `mapstructure:"tls_client_key"`
-	TLSHostname       string     `mapstructure:"tls_hostname"`
-	URL               string     `mapstructure:"url"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Index             *string    `mapstructure:"index"`
+	Name              *string    `mapstructure:"name"`
+	Password          *string    `mapstructure:"password"`
+	Pipeline          *string    `mapstructure:"pipeline"`
+	Placement         *string    `mapstructure:"placement"`
+	RequestMaxBytes   *int       `mapstructure:"request_max_bytes"`
+	RequestMaxEntries *int       `mapstructure:"request_max_entries"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TLSCACert         *string    `mapstructure:"tls_ca_cert"`
+	TLSClientCert     *string    `mapstructure:"tls_client_cert"`
+	TLSClientKey      *string    `mapstructure:"tls_client_key"`
+	TLSHostname       *string    `mapstructure:"tls_hostname"`
+	URL               *string    `mapstructure:"url"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	User              string     `mapstructure:"user"`
-}
-
-// elasticsearchByName is a sortable list of Elasticsearch logs.
-type elasticsearchByName []*Elasticsearch
-
-// Len implement the sortable interface.
-func (s elasticsearchByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s elasticsearchByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s elasticsearchByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	User              *string    `mapstructure:"user"`
 }
 
 // ListElasticsearchInput is used as input to the ListElasticsearch function.
@@ -78,7 +59,6 @@ func (c *Client) ListElasticsearch(i *ListElasticsearchInput) ([]*Elasticsearch,
 	if err := decodeBodyMap(resp.Body, &elasticsearch); err != nil {
 		return nil, err
 	}
-	sort.Stable(elasticsearchByName(elasticsearch))
 	return elasticsearch, nil
 }
 

--- a/fastly/elasticsearch_test.go
+++ b/fastly/elasticsearch_test.go
@@ -79,50 +79,50 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		})
 	}()
 
-	if es.Name != "test-elasticsearch" {
-		t.Errorf("bad name: %q", es.Name)
+	if *es.Name != "test-elasticsearch" {
+		t.Errorf("bad name: %q", *es.Name)
 	}
-	if es.Format != "format" {
-		t.Errorf("bad format: %q", es.Format)
+	if *es.Format != "format" {
+		t.Errorf("bad format: %q", *es.Format)
 	}
-	if es.Index != "#{%F}" {
-		t.Errorf("bad index: %q", es.Index)
+	if *es.Index != "#{%F}" {
+		t.Errorf("bad index: %q", *es.Index)
 	}
-	if es.URL != "https://example.com/" {
-		t.Errorf("bad url: %q", es.URL)
+	if *es.URL != "https://example.com/" {
+		t.Errorf("bad url: %q", *es.URL)
 	}
-	if es.Pipeline != "my_pipeline_id" {
-		t.Errorf("bad pipeline: %q", es.Pipeline)
+	if *es.Pipeline != "my_pipeline_id" {
+		t.Errorf("bad pipeline: %q", *es.Pipeline)
 	}
-	if es.User != "user" {
-		t.Errorf("bad user: %q", es.User)
+	if *es.User != "user" {
+		t.Errorf("bad user: %q", *es.User)
 	}
-	if es.Password != "password" {
-		t.Errorf("bad password: %q", es.Password)
+	if *es.Password != "password" {
+		t.Errorf("bad password: %q", *es.Password)
 	}
-	if es.RequestMaxEntries != 1 {
-		t.Errorf("bad request_max_entries: %q", es.RequestMaxEntries)
+	if *es.RequestMaxEntries != 1 {
+		t.Errorf("bad request_max_entries: %q", *es.RequestMaxEntries)
 	}
-	if es.RequestMaxBytes != 1000 {
-		t.Errorf("bad request_max_bytes: %q", es.RequestMaxBytes)
+	if *es.RequestMaxBytes != 1000 {
+		t.Errorf("bad request_max_bytes: %q", *es.RequestMaxBytes)
 	}
-	if es.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", es.Placement)
+	if *es.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *es.Placement)
 	}
-	if es.TLSCACert != caCert {
-		t.Errorf("bad tls_ca_cert: %q", es.TLSCACert)
+	if *es.TLSCACert != caCert {
+		t.Errorf("bad tls_ca_cert: %q", *es.TLSCACert)
 	}
-	if es.TLSHostname != "example.com" {
-		t.Errorf("bad tls_hostname: %q", es.TLSHostname)
+	if *es.TLSHostname != "example.com" {
+		t.Errorf("bad tls_hostname: %q", *es.TLSHostname)
 	}
-	if es.TLSClientCert != clientCert {
-		t.Errorf("bad tls_client_cert: %q", es.TLSClientCert)
+	if *es.TLSClientCert != clientCert {
+		t.Errorf("bad tls_client_cert: %q", *es.TLSClientCert)
 	}
-	if es.TLSClientKey != clientKey {
-		t.Errorf("bad tls_client_key: %q", es.TLSClientKey)
+	if *es.TLSClientKey != clientKey {
+		t.Errorf("bad tls_client_key: %q", *es.TLSClientKey)
 	}
-	if es.FormatVersion != 2 {
-		t.Errorf("bad format_version: %d", es.FormatVersion)
+	if *es.FormatVersion != 2 {
+		t.Errorf("bad format_version: %d", *es.FormatVersion)
 	}
 
 	// List
@@ -152,50 +152,50 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	if err != nil {
 		t.Fatal(err)
 	}
-	if es.Name != nes.Name {
-		t.Errorf("bad name: %q", es.Name)
+	if *es.Name != *nes.Name {
+		t.Errorf("bad name: %q", *es.Name)
 	}
-	if es.Format != nes.Format {
-		t.Errorf("bad format: %q", es.Format)
+	if *es.Format != *nes.Format {
+		t.Errorf("bad format: %q", *es.Format)
 	}
-	if es.Index != nes.Index {
-		t.Errorf("bad index: %q", es.Index)
+	if *es.Index != *nes.Index {
+		t.Errorf("bad index: %q", *es.Index)
 	}
-	if es.URL != nes.URL {
-		t.Errorf("bad url: %q", es.URL)
+	if *es.URL != *nes.URL {
+		t.Errorf("bad url: %q", *es.URL)
 	}
-	if es.Pipeline != nes.Pipeline {
-		t.Errorf("bad pipeline: %q", es.Pipeline)
+	if *es.Pipeline != *nes.Pipeline {
+		t.Errorf("bad pipeline: %q", *es.Pipeline)
 	}
-	if es.User != nes.User {
-		t.Errorf("bad user: %q", es.User)
+	if *es.User != *nes.User {
+		t.Errorf("bad user: %q", *es.User)
 	}
-	if es.Password != nes.Password {
-		t.Errorf("bad password: %q", es.Password)
+	if *es.Password != *nes.Password {
+		t.Errorf("bad password: %q", *es.Password)
 	}
-	if es.RequestMaxEntries != nes.RequestMaxEntries {
-		t.Errorf("bad request_max_entries: %q", es.RequestMaxEntries)
+	if *es.RequestMaxEntries != *nes.RequestMaxEntries {
+		t.Errorf("bad request_max_entries: %q", *es.RequestMaxEntries)
 	}
-	if es.RequestMaxBytes != nes.RequestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", es.RequestMaxBytes)
+	if *es.RequestMaxBytes != *nes.RequestMaxBytes {
+		t.Errorf("bad request_max_bytes: %q", *es.RequestMaxBytes)
 	}
-	if es.Placement != nes.Placement {
-		t.Errorf("bad placement: %q", es.Placement)
+	if *es.Placement != *nes.Placement {
+		t.Errorf("bad placement: %q", *es.Placement)
 	}
-	if es.TLSCACert != nes.TLSCACert {
-		t.Errorf("bad tls_ca_cert: %q", es.TLSCACert)
+	if *es.TLSCACert != *nes.TLSCACert {
+		t.Errorf("bad tls_ca_cert: %q", *es.TLSCACert)
 	}
-	if es.TLSHostname != nes.TLSHostname {
-		t.Errorf("bad tls_hostname: %q", es.TLSHostname)
+	if *es.TLSHostname != *nes.TLSHostname {
+		t.Errorf("bad tls_hostname: %q", *es.TLSHostname)
 	}
-	if es.TLSClientCert != nes.TLSClientCert {
-		t.Errorf("bad tls_client_cert: %q", es.TLSClientCert)
+	if *es.TLSClientCert != *nes.TLSClientCert {
+		t.Errorf("bad tls_client_cert: %q", *es.TLSClientCert)
 	}
-	if es.TLSClientKey != nes.TLSClientKey {
-		t.Errorf("bad tls_client_key: %q", es.TLSClientKey)
+	if *es.TLSClientKey != *nes.TLSClientKey {
+		t.Errorf("bad tls_client_key: %q", *es.TLSClientKey)
 	}
-	if es.FormatVersion != nes.FormatVersion {
-		t.Errorf("bad format_version: %d", es.FormatVersion)
+	if *es.FormatVersion != *nes.FormatVersion {
+		t.Errorf("bad format_version: %d", *es.FormatVersion)
 	}
 
 	// Update
@@ -212,11 +212,11 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ues.Name != "new-test-elasticsearch" {
-		t.Errorf("bad name: %q", ues.Name)
+	if *ues.Name != "new-test-elasticsearch" {
+		t.Errorf("bad name: %q", *ues.Name)
 	}
-	if ues.Pipeline != "my_new_pipeline_id" {
-		t.Errorf("bad pipeline: %q", ues.Pipeline)
+	if *ues.Pipeline != "my_new_pipeline_id" {
+		t.Errorf("bad pipeline: %q", *ues.Pipeline)
 	}
 
 	// Delete

--- a/fastly/elasticsearch_test.go
+++ b/fastly/elasticsearch_test.go
@@ -39,7 +39,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "elasticsearch/create", func(c *Client) {
 		es, err = c.CreateElasticsearch(&CreateElasticsearchInput{
 			ServiceID:         testServiceID,
-			ServiceVersion:    tv.Number,
+			ServiceVersion:    *tv.Number,
 			Name:              ToPointer("test-elasticsearch"),
 			Format:            ToPointer("format"),
 			Index:             ToPointer("#{%F}"),
@@ -66,14 +66,14 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		record(t, "elasticsearch/cleanup", func(c *Client) {
 			_ = c.DeleteElasticsearch(&DeleteElasticsearchInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-elasticsearch",
 			})
 
 			// ensure that renamed endpoint created in Update test is deleted
 			_ = c.DeleteElasticsearch(&DeleteElasticsearchInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-elasticsearch",
 			})
 		})
@@ -130,7 +130,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "elasticsearch/list", func(c *Client) {
 		ess, err = c.ListElasticsearch(&ListElasticsearchInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -145,7 +145,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "elasticsearch/get", func(c *Client) {
 		nes, err = c.GetElasticsearch(&GetElasticsearchInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-elasticsearch",
 		})
 	})
@@ -203,7 +203,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "elasticsearch/update", func(c *Client) {
 		ues, err = c.UpdateElasticsearch(&UpdateElasticsearchInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-elasticsearch",
 			NewName:        ToPointer("new-test-elasticsearch"),
 			Pipeline:       ToPointer("my_new_pipeline_id"),
@@ -223,7 +223,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "elasticsearch/delete", func(c *Client) {
 		err = c.DeleteElasticsearch(&DeleteElasticsearchInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-elasticsearch",
 		})
 	})

--- a/fastly/erl.go
+++ b/fastly/erl.go
@@ -5,44 +5,43 @@ package fastly
 
 import (
 	"fmt"
-	"sort"
 	"time"
 )
 
 // ERL models the response from the Fastly API.
 type ERL struct {
-	Action             ERLAction     `mapstructure:"action"`
-	ClientKey          []string      `mapstructure:"client_key"`
-	CreatedAt          *time.Time    `mapstructure:"created_at"`
-	DeletedAt          *time.Time    `mapstructure:"deleted_at"`
-	FeatureRevision    int           `mapstructure:"feature_revision"` // 1..
-	HTTPMethods        []string      `mapstructure:"http_methods"`
-	ID                 string        `mapstructure:"id"`
-	LoggerType         ERLLogger     `mapstructure:"logger_type"`
-	Name               string        `mapstructure:"name"`
-	PenaltyBoxDuration int           `mapstructure:"penalty_box_duration"` // 1..60
-	Response           *ERLResponse  `mapstructure:"response"`             // required if Action != Log
-	ResponseObjectName string        `mapstructure:"response_object_name"`
-	RpsLimit           int           `mapstructure:"rps_limit"` // 10..10000
-	ServiceID          string        `mapstructure:"service_id"`
-	UpdatedAt          *time.Time    `mapstructure:"updated_at"`
-	URIDictionaryName  string        `mapstructure:"uri_dictionary_name"`
-	Version            int           `mapstructure:"version"` // 1..
-	WindowSize         ERLWindowSize `mapstructure:"window_size"`
+	Action             *ERLAction     `mapstructure:"action"`
+	ClientKey          []*string      `mapstructure:"client_key"`
+	CreatedAt          *time.Time     `mapstructure:"created_at"`
+	DeletedAt          *time.Time     `mapstructure:"deleted_at"`
+	FeatureRevision    *int           `mapstructure:"feature_revision"` // 1..
+	HTTPMethods        []*string      `mapstructure:"http_methods"`
+	ID                 *string        `mapstructure:"id"`
+	LoggerType         *ERLLogger     `mapstructure:"logger_type"`
+	Name               *string        `mapstructure:"name"`
+	PenaltyBoxDuration *int           `mapstructure:"penalty_box_duration"` // 1..60
+	Response           *ERLResponse   `mapstructure:"response"`             // required if Action != Log
+	ResponseObjectName *string        `mapstructure:"response_object_name"`
+	RpsLimit           *int           `mapstructure:"rps_limit"` // 10..10000
+	ServiceID          *string        `mapstructure:"service_id"`
+	UpdatedAt          *time.Time     `mapstructure:"updated_at"`
+	URIDictionaryName  *string        `mapstructure:"uri_dictionary_name"`
+	Version            *int           `mapstructure:"version"` // 1..
+	WindowSize         *ERLWindowSize `mapstructure:"window_size"`
 }
 
 // ERLResponse models the response from the Fastly API.
 type ERLResponse struct {
-	ERLContent     string `mapstructure:"content,omitempty"`
-	ERLContentType string `mapstructure:"content_type,omitempty"`
-	ERLStatus      int    `mapstructure:"status,omitempty"`
+	ERLContent     *string `mapstructure:"content,omitempty"`
+	ERLContentType *string `mapstructure:"content_type,omitempty"`
+	ERLStatus      *int    `mapstructure:"status,omitempty"`
 }
 
 // ERLResponseType models the input to the Fastly API.
 type ERLResponseType struct {
-	ERLContent     string `url:"content,omitempty"`
-	ERLContentType string `url:"content_type,omitempty"`
-	ERLStatus      int    `url:"status,omitempty"`
+	ERLContent     *string `url:"content,omitempty"`
+	ERLContentType *string `url:"content_type,omitempty"`
+	ERLStatus      *int    `url:"status,omitempty"`
 }
 
 // ERLAction represents the action variants for when a rate limiter
@@ -182,24 +181,6 @@ var ERLWindowSizes = []ERLWindowSize{
 	ERLSize60,
 }
 
-// ERLsByName is a sortable list of ERLs
-type ERLsByName []*ERL
-
-// Len implement the sortable interface.
-func (s ERLsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s ERLsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s ERLsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
-}
-
 // ListERLsInput is used as input to the ListERLs function.
 type ListERLsInput struct {
 	// ServiceID is the ID of the service (required).
@@ -229,7 +210,6 @@ func (c *Client) ListERLs(i *ListERLsInput) ([]*ERL, error) {
 		return nil, err
 	}
 
-	sort.Stable(ERLsByName(erls))
 	return erls, nil
 }
 

--- a/fastly/erl_test.go
+++ b/fastly/erl_test.go
@@ -31,9 +31,9 @@ func TestClient_ERL(t *testing.T) {
 			},
 			PenaltyBoxDuration: ToPointer(30),
 			Response: &ERLResponseType{
-				ERLStatus:      429,
-				ERLContentType: "application/json",
-				ERLContent:     "Too many requests",
+				ERLStatus:      ToPointer(429),
+				ERLContentType: ToPointer("application/json"),
+				ERLContent:     ToPointer("Too many requests"),
 			},
 			RpsLimit:   ToPointer(20),
 			WindowSize: ToPointer(ERLWindowSize(10)),
@@ -47,29 +47,25 @@ func TestClient_ERL(t *testing.T) {
 	defer func() {
 		record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteERL(&DeleteERLInput{
-				ERLID: e.ID,
+				ERLID: *e.ID,
 			})
 		})
 	}()
 
-	if e.Name != "test_erl" {
-		t.Errorf("bad name: %q", e.Name)
+	if *e.Name != "test_erl" {
+		t.Errorf("bad name: %q", *e.Name)
 	}
-
-	if e.RpsLimit != 20 {
-		t.Errorf("wrong value: %q", e.RpsLimit)
+	if *e.RpsLimit != 20 {
+		t.Errorf("wrong value: %q", *e.RpsLimit)
 	}
-
-	if e.Response.ERLContent != "Too many requests" {
-		t.Errorf("want 'Too many requests', got %q", e.Response.ERLContent)
+	if *e.Response.ERLContent != "Too many requests" {
+		t.Errorf("want 'Too many requests', got %q", *e.Response.ERLContent)
 	}
-
-	if e.Response.ERLContentType != "application/json" {
-		t.Errorf("want 'application/json', got %q", e.Response.ERLContentType)
+	if *e.Response.ERLContentType != "application/json" {
+		t.Errorf("want 'application/json', got %q", *e.Response.ERLContentType)
 	}
-
-	if e.Response.ERLStatus != 429 {
-		t.Errorf("want 429, got %q", e.Response.ERLStatus)
+	if *e.Response.ERLStatus != 429 {
+		t.Errorf("want 429, got %q", *e.Response.ERLStatus)
 	}
 
 	// List
@@ -87,43 +83,43 @@ func TestClient_ERL(t *testing.T) {
 	if got < want {
 		t.Errorf("want %d, got %d", want, got)
 	}
-	if es[0].Name != "test_erl" {
-		t.Errorf("bad name: %q", es[0].Name)
+	if *es[0].Name != "test_erl" {
+		t.Errorf("bad name: %q", *es[0].Name)
 	}
 
 	// Get
 	var ge *ERL
 	record(t, fixtureBase+"get", func(c *Client) {
 		ge, err = c.GetERL(&GetERLInput{
-			ERLID: e.ID,
+			ERLID: *e.ID,
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if e.ID != ge.ID {
-		t.Errorf("bad ID: %q (%q)", e.ID, ge.ID)
+	if *e.ID != *ge.ID {
+		t.Errorf("bad ID: %q (%q)", *e.ID, *ge.ID)
 	}
 
 	// Update
 	var ua *ERL
 	record(t, fixtureBase+"update", func(c *Client) {
 		ua, err = c.UpdateERL(&UpdateERLInput{
-			ERLID: e.ID,
+			ERLID: *e.ID,
 			Name:  ToPointer("test_erl"),
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ua.Name != "test_erl" {
-		t.Errorf("Bad name after update %s", ua.Name)
+	if *ua.Name != "test_erl" {
+		t.Errorf("Bad name after update %s", *ua.Name)
 	}
 
 	// Delete
 	record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteERL(&DeleteERLInput{
-			ERLID: ge.ID,
+			ERLID: *ge.ID,
 		})
 	})
 	if err != nil {
@@ -159,17 +155,17 @@ func TestClient_ERL(t *testing.T) {
 	defer func() {
 		record(t, fixtureBase+"logger_cleanup", func(c *Client) {
 			_ = c.DeleteERL(&DeleteERLInput{
-				ERLID: elog.ID,
+				ERLID: *elog.ID,
 			})
 		})
 	}()
 
-	if elog.Name != "test_erl" {
-		t.Errorf("bad name: %q", elog.Name)
+	if *elog.Name != "test_erl" {
+		t.Errorf("bad name: %q", *elog.Name)
 	}
 
-	if elog.LoggerType != ERLLogAzureBlob {
-		t.Errorf("bad logger type: %q", elog.LoggerType)
+	if *elog.LoggerType != ERLLogAzureBlob {
+		t.Errorf("bad logger type: %q", *elog.LoggerType)
 	}
 }
 

--- a/fastly/erl_test.go
+++ b/fastly/erl_test.go
@@ -19,7 +19,7 @@ func TestClient_ERL(t *testing.T) {
 	record(t, fixtureBase+"create", func(c *Client) {
 		e, err = c.CreateERL(&CreateERLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           ToPointer("test_erl"),
 			Action:         ToPointer(ERLActionResponse),
 			ClientKey: &[]string{
@@ -73,7 +73,7 @@ func TestClient_ERL(t *testing.T) {
 	record(t, fixtureBase+"list", func(c *Client) {
 		es, err = c.ListERLs(&ListERLsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 		})
 	})
 	if err != nil {
@@ -131,7 +131,7 @@ func TestClient_ERL(t *testing.T) {
 	record(t, fixtureBase+"logger_create", func(c *Client) {
 		elog, err = c.CreateERL(&CreateERLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			Name:           ToPointer("test_erl"),
 			Action:         ToPointer(ERLActionLogOnly),
 			// IMPORTANT: API will 400 if LoggerType not set with log_only action.

--- a/fastly/example_remaining_test.go
+++ b/fastly/example_remaining_test.go
@@ -33,9 +33,9 @@ func ExampleClient_RateLimitRemaining() {
 
 	_, err = c.CreateDictionaryItem(&fastly.CreateDictionaryItemInput{
 		ServiceID:    sid,
-		DictionaryID: dict.ID,
-		ItemKey:      "test-dictionary-item",
-		ItemValue:    "value",
+		DictionaryID: *dict.ID,
+		ItemKey:      fastly.ToPointer("test-dictionary-item"),
+		ItemValue:    fastly.ToPointer("value"),
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -46,7 +46,7 @@ func ExampleClient_RateLimitRemaining() {
 	for i := 1; i < 10; i++ {
 		_, err := c.UpdateDictionaryItem(&fastly.UpdateDictionaryItemInput{
 			ServiceID:    sid,
-			DictionaryID: dict.ID,
+			DictionaryID: *dict.ID,
 			ItemKey:      "test-dictionary-item",
 			ItemValue:    fmt.Sprintf("value%d", i),
 		})

--- a/fastly/example_remaining_test.go
+++ b/fastly/example_remaining_test.go
@@ -24,7 +24,7 @@ func ExampleClient_RateLimitRemaining() {
 
 	dict, err := c.GetDictionary(&fastly.GetDictionaryInput{
 		ServiceID:      sid,
-		ServiceVersion: v.Number,
+		ServiceVersion: *v.Number,
 		Name:           dictName,
 	})
 	if err != nil {

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -210,9 +210,9 @@ func deleteTestDictionary(t *testing.T, dictionary *Dictionary, deleteFixture st
 
 	record(t, deleteFixture, func(client *Client) {
 		err = client.DeleteDictionary(&DeleteDictionaryInput{
-			ServiceID:      dictionary.ServiceID,
-			ServiceVersion: dictionary.ServiceVersion,
-			Name:           dictionary.Name,
+			ServiceID:      *dictionary.ServiceID,
+			ServiceVersion: *dictionary.ServiceVersion,
+			Name:           *dictionary.Name,
 		})
 	})
 	if err != nil {

--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -299,9 +299,9 @@ func deleteTestPool(t *testing.T, pool *Pool, deleteFixture string) {
 
 	record(t, deleteFixture, func(client *Client) {
 		err = client.DeletePool(&DeletePoolInput{
-			ServiceID:      pool.ServiceID,
-			ServiceVersion: pool.ServiceVersion,
-			Name:           pool.Name,
+			ServiceID:      *pool.ServiceID,
+			ServiceVersion: *pool.ServiceVersion,
+			Name:           *pool.Name,
 		})
 	})
 	if err != nil {

--- a/fastly/fixtures/origin_inspector/metrics_for_service.yaml
+++ b/fastly/fixtures/origin_inspector/metrics_for_service.yaml
@@ -1,13 +1,12 @@
----
 version: 1
 interactions:
   - request:
       body: ""
-      form: { }
+      form: {}
       headers:
         User-Agent:
           - FastlyGo/6.0.1 (+github.com/fastly/go-fastly; go1.17.2)
-      url: https://api.fastly.com/metrics/origins/services/7i6HN3TK9wS159v2gPAZ8A?cursor=&datacenter=LHR%2CJFK&downsample=day&end=1644796800&host=host01&metric=responses%2Cstatus_2xx&region=europe%2Cusa&start=1644624000
+      url: https://api.fastly.com/metrics/origins/services/7i6HN3TK9wS159v2gPAZ8A?cursor=&datacenter=LHR%2CJFK&downsample=day&end=1644796800&group_by=host&host=host01&metric=responses%2Cstatus_2xx&region=europe%2Cusa&start=1644624000
       method: GET
     response:
       body: |

--- a/fastly/ftp.go
+++ b/fastly/ftp.go
@@ -3,51 +3,32 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // FTP represents an FTP logging response from the Fastly API.
 type FTP struct {
-	Address           string     `mapstructure:"address"`
-	CompressionCodec  string     `mapstructure:"compression_codec"`
+	Address           *string    `mapstructure:"address"`
+	CompressionCodec  *string    `mapstructure:"compression_codec"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	GzipLevel         int        `mapstructure:"gzip_level"`
-	MessageType       string     `mapstructure:"message_type"`
-	Name              string     `mapstructure:"name"`
-	Password          string     `mapstructure:"password"`
-	Path              string     `mapstructure:"path"`
-	Period            int        `mapstructure:"period"`
-	Placement         string     `mapstructure:"placement"`
-	Port              int        `mapstructure:"port"`
-	PublicKey         string     `mapstructure:"public_key"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TimestampFormat   string     `mapstructure:"timestamp_format"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	GzipLevel         *int       `mapstructure:"gzip_level"`
+	MessageType       *string    `mapstructure:"message_type"`
+	Name              *string    `mapstructure:"name"`
+	Password          *string    `mapstructure:"password"`
+	Path              *string    `mapstructure:"path"`
+	Period            *int       `mapstructure:"period"`
+	Placement         *string    `mapstructure:"placement"`
+	Port              *int       `mapstructure:"port"`
+	PublicKey         *string    `mapstructure:"public_key"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TimestampFormat   *string    `mapstructure:"timestamp_format"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	Username          string     `mapstructure:"user"`
-}
-
-// ftpsByName is a sortable list of ftps.
-type ftpsByName []*FTP
-
-// Len implement the sortable interface.
-func (s ftpsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s ftpsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s ftpsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	Username          *string    `mapstructure:"user"`
 }
 
 // ListFTPsInput is used as input to the ListFTPs function.
@@ -78,7 +59,6 @@ func (c *Client) ListFTPs(i *ListFTPsInput) ([]*FTP, error) {
 	if err := decodeBodyMap(resp.Body, &ftps); err != nil {
 		return nil, err
 	}
-	sort.Stable(ftpsByName(ftps))
 	return ftps, nil
 }
 

--- a/fastly/ftp_test.go
+++ b/fastly/ftp_test.go
@@ -142,64 +142,62 @@ func TestClient_FTPs(t *testing.T) {
 		})
 	}()
 
-	if ftpCreateResp1.Name != "test-ftp" {
-		t.Errorf("bad name: %q", ftpCreateResp1.Name)
+	if *ftpCreateResp1.Name != "test-ftp" {
+		t.Errorf("bad name: %q", *ftpCreateResp1.Name)
 	}
-	if ftpCreateResp1.Address != "example.com" {
-		t.Errorf("bad address: %q", ftpCreateResp1.Address)
+	if *ftpCreateResp1.Address != "example.com" {
+		t.Errorf("bad address: %q", *ftpCreateResp1.Address)
 	}
-	if ftpCreateResp1.Port != 1234 {
-		t.Errorf("bad port: %q", ftpCreateResp1.Port)
+	if *ftpCreateResp1.Port != 1234 {
+		t.Errorf("bad port: %q", *ftpCreateResp1.Port)
 	}
-	if ftpCreateResp1.PublicKey != pgpPublicKey() {
-		t.Errorf("bad public_key: %q", ftpCreateResp1.PublicKey)
+	if *ftpCreateResp1.PublicKey != pgpPublicKey() {
+		t.Errorf("bad public_key: %q", *ftpCreateResp1.PublicKey)
 	}
-	if ftpCreateResp1.Username != "username" {
-		t.Errorf("bad username: %q", ftpCreateResp1.Username)
+	if *ftpCreateResp1.Username != "username" {
+		t.Errorf("bad username: %q", *ftpCreateResp1.Username)
 	}
-	if ftpCreateResp1.Password != "password" {
-		t.Errorf("bad password: %q", ftpCreateResp1.Password)
+	if *ftpCreateResp1.Password != "password" {
+		t.Errorf("bad password: %q", *ftpCreateResp1.Password)
 	}
-	if ftpCreateResp1.Path != "/dir" {
-		t.Errorf("bad path: %q", ftpCreateResp1.Path)
+	if *ftpCreateResp1.Path != "/dir" {
+		t.Errorf("bad path: %q", *ftpCreateResp1.Path)
 	}
-	if ftpCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", ftpCreateResp1.Period)
+	if *ftpCreateResp1.Period != 12 {
+		t.Errorf("bad period: %q", *ftpCreateResp1.Period)
 	}
-	if ftpCreateResp1.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", ftpCreateResp1.CompressionCodec)
+	if *ftpCreateResp1.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *ftpCreateResp1.CompressionCodec)
 	}
-	if ftpCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", ftpCreateResp1.GzipLevel)
+	if *ftpCreateResp1.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *ftpCreateResp1.GzipLevel)
 	}
-	if ftpCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", ftpCreateResp1.FormatVersion)
+	if *ftpCreateResp1.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *ftpCreateResp1.FormatVersion)
 	}
-	if ftpCreateResp1.Format != "format" {
-		t.Errorf("bad format: %q", ftpCreateResp1.Format)
+	if *ftpCreateResp1.Format != "format" {
+		t.Errorf("bad format: %q", *ftpCreateResp1.Format)
 	}
-	if ftpCreateResp1.TimestampFormat != "%Y" {
-		t.Errorf("bad timestamp_format: %q", ftpCreateResp1.TimestampFormat)
+	if *ftpCreateResp1.TimestampFormat != "%Y" {
+		t.Errorf("bad timestamp_format: %q", *ftpCreateResp1.TimestampFormat)
 	}
-	if ftpCreateResp1.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", ftpCreateResp1.Placement)
+	if *ftpCreateResp1.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *ftpCreateResp1.Placement)
 	}
-	if ftpCreateResp1.MessageType != "classic" {
-		t.Errorf("bad message type: %q", ftpCreateResp1.MessageType)
+	if *ftpCreateResp1.MessageType != "classic" {
+		t.Errorf("bad message type: %q", *ftpCreateResp1.MessageType)
 	}
-
-	if ftpCreateResp2.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", ftpCreateResp2.CompressionCodec)
+	if ftpCreateResp2.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *ftpCreateResp2.CompressionCodec)
 	}
-	if ftpCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", ftpCreateResp2.GzipLevel)
+	if *ftpCreateResp2.GzipLevel != 8 {
+		t.Errorf("bad gzip_level: %q", *ftpCreateResp2.GzipLevel)
 	}
-
-	if ftpCreateResp3.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", ftpCreateResp3.CompressionCodec)
+	if *ftpCreateResp3.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *ftpCreateResp3.CompressionCodec)
 	}
-	if ftpCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", ftpCreateResp3.GzipLevel)
+	if *ftpCreateResp3.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *ftpCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -229,50 +227,50 @@ func TestClient_FTPs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ftpCreateResp1.Name != ftpGetResp.Name {
-		t.Errorf("bad name: %q", ftpCreateResp1.Name)
+	if *ftpCreateResp1.Name != *ftpGetResp.Name {
+		t.Errorf("bad name: %q", *ftpCreateResp1.Name)
 	}
-	if ftpCreateResp1.Address != ftpGetResp.Address {
-		t.Errorf("bad address: %q", ftpCreateResp1.Address)
+	if *ftpCreateResp1.Address != *ftpGetResp.Address {
+		t.Errorf("bad address: %q", *ftpCreateResp1.Address)
 	}
-	if ftpCreateResp1.Port != ftpGetResp.Port {
-		t.Errorf("bad port: %q", ftpCreateResp1.Port)
+	if *ftpCreateResp1.Port != *ftpGetResp.Port {
+		t.Errorf("bad port: %q", *ftpCreateResp1.Port)
 	}
-	if ftpCreateResp1.PublicKey != ftpGetResp.PublicKey {
-		t.Errorf("bad public_key: %q", ftpCreateResp1.PublicKey)
+	if *ftpCreateResp1.PublicKey != *ftpGetResp.PublicKey {
+		t.Errorf("bad public_key: %q", *ftpCreateResp1.PublicKey)
 	}
-	if ftpCreateResp1.Username != ftpGetResp.Username {
-		t.Errorf("bad username: %q", ftpCreateResp1.Username)
+	if *ftpCreateResp1.Username != *ftpGetResp.Username {
+		t.Errorf("bad username: %q", *ftpCreateResp1.Username)
 	}
-	if ftpCreateResp1.Password != ftpGetResp.Password {
-		t.Errorf("bad password: %q", ftpCreateResp1.Password)
+	if *ftpCreateResp1.Password != *ftpGetResp.Password {
+		t.Errorf("bad password: %q", *ftpCreateResp1.Password)
 	}
-	if ftpCreateResp1.Path != ftpGetResp.Path {
-		t.Errorf("bad path: %q", ftpCreateResp1.Path)
+	if *ftpCreateResp1.Path != *ftpGetResp.Path {
+		t.Errorf("bad path: %q", *ftpCreateResp1.Path)
 	}
-	if ftpCreateResp1.Period != ftpGetResp.Period {
-		t.Errorf("bad period: %q", ftpCreateResp1.Period)
+	if *ftpCreateResp1.Period != *ftpGetResp.Period {
+		t.Errorf("bad period: %q", *ftpCreateResp1.Period)
 	}
-	if ftpCreateResp1.CompressionCodec != ftpGetResp.CompressionCodec {
-		t.Errorf("bad compression_codec: %q", ftpCreateResp1.CompressionCodec)
+	if *ftpCreateResp1.CompressionCodec != *ftpGetResp.CompressionCodec {
+		t.Errorf("bad compression_codec: %q", *ftpCreateResp1.CompressionCodec)
 	}
-	if ftpCreateResp1.GzipLevel != ftpGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", ftpCreateResp1.GzipLevel)
+	if *ftpCreateResp1.GzipLevel != *ftpGetResp.GzipLevel {
+		t.Errorf("bad gzip_level: %q", *ftpCreateResp1.GzipLevel)
 	}
-	if ftpCreateResp1.FormatVersion != ftpGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", ftpCreateResp1.FormatVersion)
+	if *ftpCreateResp1.FormatVersion != *ftpGetResp.FormatVersion {
+		t.Errorf("bad format_version: %q", *ftpCreateResp1.FormatVersion)
 	}
-	if ftpCreateResp1.Format != ftpGetResp.Format {
-		t.Errorf("bad format: %q", ftpCreateResp1.Format)
+	if *ftpCreateResp1.Format != *ftpGetResp.Format {
+		t.Errorf("bad format: %q", *ftpCreateResp1.Format)
 	}
-	if ftpCreateResp1.TimestampFormat != ftpGetResp.TimestampFormat {
-		t.Errorf("bad timestamp_format: %q", ftpCreateResp1.TimestampFormat)
+	if *ftpCreateResp1.TimestampFormat != *ftpGetResp.TimestampFormat {
+		t.Errorf("bad timestamp_format: %q", *ftpCreateResp1.TimestampFormat)
 	}
-	if ftpCreateResp1.Placement != ftpGetResp.Placement {
-		t.Errorf("bad placement: %q", ftpCreateResp1.Placement)
+	if *ftpCreateResp1.Placement != *ftpGetResp.Placement {
+		t.Errorf("bad placement: %q", *ftpCreateResp1.Placement)
 	}
-	if ftpCreateResp1.MessageType != ftpGetResp.MessageType {
-		t.Errorf("bad message type: %q", ftpCreateResp1.MessageType)
+	if *ftpCreateResp1.MessageType != *ftpGetResp.MessageType {
+		t.Errorf("bad message type: %q", *ftpCreateResp1.MessageType)
 	}
 
 	// Update
@@ -314,29 +312,26 @@ func TestClient_FTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ftpUpdateResp1.Name != "new-test-ftp" {
-		t.Errorf("bad name: %q", ftpUpdateResp1.Name)
+	if *ftpUpdateResp1.Name != "new-test-ftp" {
+		t.Errorf("bad name: %q", *ftpUpdateResp1.Name)
 	}
-
-	if ftpUpdateResp1.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", ftpUpdateResp1.CompressionCodec)
+	if *ftpUpdateResp1.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *ftpUpdateResp1.CompressionCodec)
 	}
-	if ftpUpdateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", ftpUpdateResp1.GzipLevel)
+	if ftpUpdateResp1.GzipLevel != nil {
+		t.Errorf("bad gzip_level: %q", *ftpUpdateResp1.GzipLevel)
 	}
-
-	if ftpUpdateResp2.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", ftpUpdateResp2.CompressionCodec)
+	if *ftpUpdateResp2.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *ftpUpdateResp2.CompressionCodec)
 	}
-	if ftpUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", ftpUpdateResp2.GzipLevel)
+	if *ftpUpdateResp2.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *ftpUpdateResp2.GzipLevel)
 	}
-
-	if ftpUpdateResp3.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", ftpUpdateResp3.CompressionCodec)
+	if ftpUpdateResp3.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *ftpUpdateResp3.CompressionCodec)
 	}
-	if ftpUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", ftpUpdateResp3.GzipLevel)
+	if *ftpUpdateResp3.GzipLevel != 9 {
+		t.Errorf("bad gzip_level: %q", *ftpUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/ftp_test.go
+++ b/fastly/ftp_test.go
@@ -17,7 +17,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/create", func(c *Client) {
 		ftpCreateResp1, err = c.CreateFTP(&CreateFTPInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-ftp"),
 			Address:          ToPointer("example.com"),
 			Port:             ToPointer(1234),
@@ -41,7 +41,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/create2", func(c *Client) {
 		ftpCreateResp2, err = c.CreateFTP(&CreateFTPInput{
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-ftp-2"),
 			Address:         ToPointer("example.com"),
 			Port:            ToPointer(1234),
@@ -65,7 +65,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/create3", func(c *Client) {
 		ftpCreateResp3, err = c.CreateFTP(&CreateFTPInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-ftp-3"),
 			Address:          ToPointer("example.com"),
 			Port:             ToPointer(1234),
@@ -91,7 +91,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/create4", func(c *Client) {
 		_, err = c.CreateFTP(&CreateFTPInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-ftp-4"),
 			Address:          ToPointer("example.com"),
 			Port:             ToPointer(1234),
@@ -118,25 +118,25 @@ func TestClient_FTPs(t *testing.T) {
 		record(t, "ftps/cleanup", func(c *Client) {
 			_ = c.DeleteFTP(&DeleteFTPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-ftp",
 			})
 
 			_ = c.DeleteFTP(&DeleteFTPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-ftp-2",
 			})
 
 			_ = c.DeleteFTP(&DeleteFTPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-ftp-3",
 			})
 
 			_ = c.DeleteFTP(&DeleteFTPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-ftp",
 			})
 		})
@@ -205,7 +205,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/list", func(c *Client) {
 		ftps, err = c.ListFTPs(&ListFTPsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -220,7 +220,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/get", func(c *Client) {
 		ftpGetResp, err = c.GetFTP(&GetFTPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-ftp",
 		})
 	})
@@ -278,7 +278,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/update", func(c *Client) {
 		ftpUpdateResp1, err = c.UpdateFTP(&UpdateFTPInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-ftp",
 			NewName:          ToPointer("new-test-ftp"),
 			CompressionCodec: ToPointer("zstd"),
@@ -291,7 +291,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/update2", func(c *Client) {
 		ftpUpdateResp2, err = c.UpdateFTP(&UpdateFTPInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-ftp-2",
 			CompressionCodec: ToPointer("zstd"),
 		})
@@ -303,7 +303,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/update3", func(c *Client) {
 		ftpUpdateResp3, err = c.UpdateFTP(&UpdateFTPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-ftp-3",
 			GzipLevel:      ToPointer(9),
 		})
@@ -338,7 +338,7 @@ func TestClient_FTPs(t *testing.T) {
 	record(t, "ftps/delete", func(c *Client) {
 		err = c.DeleteFTP(&DeleteFTPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-ftp",
 		})
 	})

--- a/fastly/gcs.go
+++ b/fastly/gcs.go
@@ -3,51 +3,32 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // GCS represents an GCS logging response from the Fastly API.
 type GCS struct {
-	AccountName       string     `mapstructure:"account_name"`
-	Bucket            string     `mapstructure:"bucket_name"`
-	CompressionCodec  string     `mapstructure:"compression_codec"`
+	AccountName       *string    `mapstructure:"account_name"`
+	Bucket            *string    `mapstructure:"bucket_name"`
+	CompressionCodec  *string    `mapstructure:"compression_codec"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	GzipLevel         int        `mapstructure:"gzip_level"`
-	MessageType       string     `mapstructure:"message_type"`
-	Name              string     `mapstructure:"name"`
-	Path              string     `mapstructure:"path"`
-	Period            int        `mapstructure:"period"`
-	Placement         string     `mapstructure:"placement"`
-	ProjectID         string     `mapstructure:"project_id"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	SecretKey         string     `mapstructure:"secret_key"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TimestampFormat   string     `mapstructure:"timestamp_format"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	GzipLevel         *int       `mapstructure:"gzip_level"`
+	MessageType       *string    `mapstructure:"message_type"`
+	Name              *string    `mapstructure:"name"`
+	Path              *string    `mapstructure:"path"`
+	Period            *int       `mapstructure:"period"`
+	Placement         *string    `mapstructure:"placement"`
+	ProjectID         *string    `mapstructure:"project_id"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	SecretKey         *string    `mapstructure:"secret_key"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TimestampFormat   *string    `mapstructure:"timestamp_format"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	User              string     `mapstructure:"user"`
-}
-
-// gcsesByName is a sortable list of gcses.
-type gcsesByName []*GCS
-
-// Len implement the sortable interface.
-func (s gcsesByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s gcsesByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s gcsesByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	User              *string    `mapstructure:"user"`
 }
 
 // ListGCSsInput is used as input to the ListGCSs function.
@@ -72,12 +53,12 @@ func (c *Client) ListGCSs(i *ListGCSsInput) ([]*GCS, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var gcses []*GCS
 	if err := decodeBodyMap(resp.Body, &gcses); err != nil {
 		return nil, err
 	}
-	sort.Stable(gcsesByName(gcses))
 	return gcses, nil
 }
 

--- a/fastly/gcs_test.go
+++ b/fastly/gcs_test.go
@@ -140,64 +140,62 @@ func TestClient_GCSs(t *testing.T) {
 		})
 	}()
 
-	if gcsCreateResp1.Name != "test-gcs" {
-		t.Errorf("bad name: %q", gcsCreateResp1.Name)
+	if *gcsCreateResp1.Name != "test-gcs" {
+		t.Errorf("bad name: %q", *gcsCreateResp1.Name)
 	}
-	if gcsCreateResp1.ProjectID != "logging-project" {
-		t.Errorf("bad project id: %q", gcsCreateResp1.ProjectID)
+	if *gcsCreateResp1.ProjectID != "logging-project" {
+		t.Errorf("bad project id: %q", *gcsCreateResp1.ProjectID)
 	}
-	if gcsCreateResp1.Bucket != "bucket" {
-		t.Errorf("bad bucket: %q", gcsCreateResp1.Bucket)
+	if *gcsCreateResp1.Bucket != "bucket" {
+		t.Errorf("bad bucket: %q", *gcsCreateResp1.Bucket)
 	}
-	if gcsCreateResp1.User != "user" {
-		t.Errorf("bad user: %q", gcsCreateResp1.User)
+	if *gcsCreateResp1.User != "user" {
+		t.Errorf("bad user: %q", *gcsCreateResp1.User)
 	}
-	if gcsCreateResp1.AccountName != "service-account" {
-		t.Errorf("bad service account name: %q", gcsCreateResp1.AccountName)
+	if *gcsCreateResp1.AccountName != "service-account" {
+		t.Errorf("bad service account name: %q", *gcsCreateResp1.AccountName)
 	}
-	if gcsCreateResp1.SecretKey != "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq\nTdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1\nNnqWYvHDyA5Ug+T8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA\neURUzFsqyymXMUGrqDPqrHsVWC2E3NTJEb4QlywtrwI13qbhlvTx6/9oRfUjytXJ\nRuUIE5xL8yhRCagNr5ZW250aa+wBwu5DSCk5fDNr0eDuZjw84WHDll+mHxBFGV+X\nKJ5jCOmGumGqjVWZesJpNN1My3M9bsY9layNJJ0eiDeHDEi/yXhhO/mNEXhvhq/R\nfN0Jh2A3AgMBAAECggEAef+CEL5aF6/aVs0yh7fiXkKSp1ECXkud8ztgpEn63KJF\nXM1EdnBt50fA2xSQUeGmeEXi6+cngf0nRb8FToAEgLoGoOEjSJuLrzP3I8U9Fe3m\nBRG2uZI2Ti/bD0eRGEc1oSDhCpsqnkTGK1bwcD4AKpwY+c08Izh/2BOoY6McDoqh\ndQ89jzTuMtD4cNlnPiIrY9HbxoNjshK2ax1OaeXyYKZFG1TxqMFv5gA/G5+S3Cwr\nVG4fkAxYi5vdIK3b8jUXrTM/kpoTl+d3dlQ7rRZYf7KyT31/HtJ/GNzxFI6upzO7\niDNrrUOyeOPjWXdzUh9budv3j+6UfbYK7uZIoebHIQKBgQDykYX1L/akGaOC2tfS\njzCWUzPxGFYVZQ7zD1PM6UyouuS1KLURDEGk9RxqVzTPh/pYd8Ivnz3vOVski5Zt\n19ozLGxdtDhn122DcnVpfCdYzHBdAzPCzORenFohX+MhiX5fEotTlVi7wfOmzTP5\nhUCMSd/17bJrV4XMLhkdrMRBFQKBgQDH5fwV7o+Ej/ZfcdGIa3mAFazToPDzxhHU\nnwADxaxpNGKRU03XCaiYkykarLYdG6Rk+7dXUv8eLy+6Dcq1SWQtfCWKEor++IIp\n1RwWmFHfYriHGkmxSkkEkLFvL8old9xM5YWbEXc4QIXvnfR4BZxdyJHVzIDdbI2i\nFgcn17U3GwKBgDd1njMY7ENIuWHJt16k7m7wRwfwkH4DxQ89ieNn0+cgE/p3fC6R\nptCYWg7WMXThmhNwDi3lMrvnWTdZ0uL6XyEkHwKtmdfkIV3UZZPglv5uf6JEgSkg\nv3YCOXk3+y5HyWTjUIejtc334kVY1XFPThrFKTeJSSnRsP2l7IgkYBqhAoGAYGsr\nM3z1FrDF2nWw5odIfKJ30UAw2LRyB0eGH0uqhLgyzvwKcK2E98sLqYUi9llN6zOK\n1IEA8xM5hxl97AFxY4sdJEMbbi55wim7uZ5Q51nbvbbNUsmM/Lm6C/JWI8pzpVeU\nIR7EjYp50AE1WOsD6CyFQ0W35pWkn0jWvL4L938CgYEAlax4dLE5+YCG5DeLT1/N\nin6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn+uNatKvlVyfPm6rdxeHCmER1FpR7Q\nA/aNVjPeViKT/R4nK9ytsa+s/1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ\nbv1KwcKoQbNVXwauH79JKc0=\n-----END PRIVATE KEY-----\n" {
-		t.Errorf("bad secret_key: %q", gcsCreateResp1.SecretKey)
+	if *gcsCreateResp1.SecretKey != "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq\nTdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1\nNnqWYvHDyA5Ug+T8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA\neURUzFsqyymXMUGrqDPqrHsVWC2E3NTJEb4QlywtrwI13qbhlvTx6/9oRfUjytXJ\nRuUIE5xL8yhRCagNr5ZW250aa+wBwu5DSCk5fDNr0eDuZjw84WHDll+mHxBFGV+X\nKJ5jCOmGumGqjVWZesJpNN1My3M9bsY9layNJJ0eiDeHDEi/yXhhO/mNEXhvhq/R\nfN0Jh2A3AgMBAAECggEAef+CEL5aF6/aVs0yh7fiXkKSp1ECXkud8ztgpEn63KJF\nXM1EdnBt50fA2xSQUeGmeEXi6+cngf0nRb8FToAEgLoGoOEjSJuLrzP3I8U9Fe3m\nBRG2uZI2Ti/bD0eRGEc1oSDhCpsqnkTGK1bwcD4AKpwY+c08Izh/2BOoY6McDoqh\ndQ89jzTuMtD4cNlnPiIrY9HbxoNjshK2ax1OaeXyYKZFG1TxqMFv5gA/G5+S3Cwr\nVG4fkAxYi5vdIK3b8jUXrTM/kpoTl+d3dlQ7rRZYf7KyT31/HtJ/GNzxFI6upzO7\niDNrrUOyeOPjWXdzUh9budv3j+6UfbYK7uZIoebHIQKBgQDykYX1L/akGaOC2tfS\njzCWUzPxGFYVZQ7zD1PM6UyouuS1KLURDEGk9RxqVzTPh/pYd8Ivnz3vOVski5Zt\n19ozLGxdtDhn122DcnVpfCdYzHBdAzPCzORenFohX+MhiX5fEotTlVi7wfOmzTP5\nhUCMSd/17bJrV4XMLhkdrMRBFQKBgQDH5fwV7o+Ej/ZfcdGIa3mAFazToPDzxhHU\nnwADxaxpNGKRU03XCaiYkykarLYdG6Rk+7dXUv8eLy+6Dcq1SWQtfCWKEor++IIp\n1RwWmFHfYriHGkmxSkkEkLFvL8old9xM5YWbEXc4QIXvnfR4BZxdyJHVzIDdbI2i\nFgcn17U3GwKBgDd1njMY7ENIuWHJt16k7m7wRwfwkH4DxQ89ieNn0+cgE/p3fC6R\nptCYWg7WMXThmhNwDi3lMrvnWTdZ0uL6XyEkHwKtmdfkIV3UZZPglv5uf6JEgSkg\nv3YCOXk3+y5HyWTjUIejtc334kVY1XFPThrFKTeJSSnRsP2l7IgkYBqhAoGAYGsr\nM3z1FrDF2nWw5odIfKJ30UAw2LRyB0eGH0uqhLgyzvwKcK2E98sLqYUi9llN6zOK\n1IEA8xM5hxl97AFxY4sdJEMbbi55wim7uZ5Q51nbvbbNUsmM/Lm6C/JWI8pzpVeU\nIR7EjYp50AE1WOsD6CyFQ0W35pWkn0jWvL4L938CgYEAlax4dLE5+YCG5DeLT1/N\nin6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn+uNatKvlVyfPm6rdxeHCmER1FpR7Q\nA/aNVjPeViKT/R4nK9ytsa+s/1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ\nbv1KwcKoQbNVXwauH79JKc0=\n-----END PRIVATE KEY-----\n" {
+		t.Errorf("bad secret_key: %q", *gcsCreateResp1.SecretKey)
 	}
-	if gcsCreateResp1.Path != "/path" {
-		t.Errorf("bad path: %q", gcsCreateResp1.Path)
+	if *gcsCreateResp1.Path != "/path" {
+		t.Errorf("bad path: %q", *gcsCreateResp1.Path)
 	}
-	if gcsCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", gcsCreateResp1.Period)
+	if *gcsCreateResp1.Period != 12 {
+		t.Errorf("bad period: %q", *gcsCreateResp1.Period)
 	}
-	if gcsCreateResp1.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", gcsCreateResp1.CompressionCodec)
+	if *gcsCreateResp1.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
-	if gcsCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", gcsCreateResp1.GzipLevel)
+	if *gcsCreateResp1.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
 	}
-	if gcsCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", gcsCreateResp1.FormatVersion)
+	if *gcsCreateResp1.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *gcsCreateResp1.FormatVersion)
 	}
-	if gcsCreateResp1.Format != "format" {
-		t.Errorf("bad format: %q", gcsCreateResp1.Format)
+	if *gcsCreateResp1.Format != "format" {
+		t.Errorf("bad format: %q", *gcsCreateResp1.Format)
 	}
-	if gcsCreateResp1.TimestampFormat != "%Y" {
-		t.Errorf("bad timestamp_format: %q", gcsCreateResp1.TimestampFormat)
+	if *gcsCreateResp1.TimestampFormat != "%Y" {
+		t.Errorf("bad timestamp_format: %q", *gcsCreateResp1.TimestampFormat)
 	}
-	if gcsCreateResp1.MessageType != "blank" {
-		t.Errorf("bad message_type: %q", gcsCreateResp1.MessageType)
+	if *gcsCreateResp1.MessageType != "blank" {
+		t.Errorf("bad message_type: %q", *gcsCreateResp1.MessageType)
 	}
-	if gcsCreateResp1.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", gcsCreateResp1.Placement)
+	if *gcsCreateResp1.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *gcsCreateResp1.Placement)
 	}
-
-	if gcsCreateResp2.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", gcsCreateResp1.CompressionCodec)
+	if gcsCreateResp2.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
-	if gcsCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", gcsCreateResp1.GzipLevel)
+	if *gcsCreateResp2.GzipLevel != 8 {
+		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
 	}
-
-	if gcsCreateResp3.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", gcsCreateResp1.CompressionCodec)
+	if *gcsCreateResp3.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
-	if gcsCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", gcsCreateResp1.GzipLevel)
+	if *gcsCreateResp3.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
 	}
 
 	// List
@@ -227,47 +225,47 @@ func TestClient_GCSs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gcsCreateResp1.Name != gcsGetResp.Name {
-		t.Errorf("bad name: %q", gcsCreateResp1.Name)
+	if *gcsCreateResp1.Name != *gcsGetResp.Name {
+		t.Errorf("bad name: %q", *gcsCreateResp1.Name)
 	}
-	if gcsCreateResp1.ProjectID != "logging-project" {
-		t.Errorf("bad project id: %q", gcsCreateResp1.ProjectID)
+	if *gcsCreateResp1.ProjectID != "logging-project" {
+		t.Errorf("bad project id: %q", *gcsCreateResp1.ProjectID)
 	}
-	if gcsCreateResp1.Bucket != gcsGetResp.Bucket {
-		t.Errorf("bad bucket: %q", gcsCreateResp1.Bucket)
+	if *gcsCreateResp1.Bucket != *gcsGetResp.Bucket {
+		t.Errorf("bad bucket: %q", *gcsCreateResp1.Bucket)
 	}
-	if gcsCreateResp1.User != gcsGetResp.User {
-		t.Errorf("bad user: %q", gcsCreateResp1.User)
+	if *gcsCreateResp1.User != *gcsGetResp.User {
+		t.Errorf("bad user: %q", *gcsCreateResp1.User)
 	}
-	if gcsCreateResp1.SecretKey != gcsGetResp.SecretKey {
-		t.Errorf("bad secret_key: %q", gcsCreateResp1.SecretKey)
+	if *gcsCreateResp1.SecretKey != *gcsGetResp.SecretKey {
+		t.Errorf("bad secret_key: %q", *gcsCreateResp1.SecretKey)
 	}
-	if gcsCreateResp1.Path != gcsGetResp.Path {
-		t.Errorf("bad path: %q", gcsCreateResp1.Path)
+	if *gcsCreateResp1.Path != *gcsGetResp.Path {
+		t.Errorf("bad path: %q", *gcsCreateResp1.Path)
 	}
-	if gcsCreateResp1.Period != gcsGetResp.Period {
-		t.Errorf("bad period: %q", gcsCreateResp1.Period)
+	if *gcsCreateResp1.Period != *gcsGetResp.Period {
+		t.Errorf("bad period: %q", *gcsCreateResp1.Period)
 	}
-	if gcsCreateResp1.CompressionCodec != gcsGetResp.CompressionCodec {
-		t.Errorf("bad compression_codec: %q", gcsCreateResp1.CompressionCodec)
+	if *gcsCreateResp1.CompressionCodec != *gcsGetResp.CompressionCodec {
+		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
-	if gcsCreateResp1.GzipLevel != gcsGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", gcsCreateResp1.GzipLevel)
+	if *gcsCreateResp1.GzipLevel != *gcsGetResp.GzipLevel {
+		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
 	}
-	if gcsCreateResp1.FormatVersion != gcsGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", gcsCreateResp1.FormatVersion)
+	if *gcsCreateResp1.FormatVersion != *gcsGetResp.FormatVersion {
+		t.Errorf("bad format_version: %q", *gcsCreateResp1.FormatVersion)
 	}
-	if gcsCreateResp1.Format != gcsGetResp.Format {
-		t.Errorf("bad format: %q", gcsCreateResp1.Format)
+	if *gcsCreateResp1.Format != *gcsGetResp.Format {
+		t.Errorf("bad format: %q", *gcsCreateResp1.Format)
 	}
-	if gcsCreateResp1.TimestampFormat != gcsGetResp.TimestampFormat {
-		t.Errorf("bad timestamp_format: %q", gcsCreateResp1.TimestampFormat)
+	if *gcsCreateResp1.TimestampFormat != *gcsGetResp.TimestampFormat {
+		t.Errorf("bad timestamp_format: %q", *gcsCreateResp1.TimestampFormat)
 	}
-	if gcsCreateResp1.MessageType != gcsGetResp.MessageType {
-		t.Errorf("bad message_type: %q", gcsCreateResp1.MessageType)
+	if *gcsCreateResp1.MessageType != *gcsGetResp.MessageType {
+		t.Errorf("bad message_type: %q", *gcsCreateResp1.MessageType)
 	}
-	if gcsCreateResp1.Placement != gcsGetResp.Placement {
-		t.Errorf("bad placement: %q", gcsCreateResp1.Placement)
+	if *gcsCreateResp1.Placement != *gcsGetResp.Placement {
+		t.Errorf("bad placement: %q", *gcsCreateResp1.Placement)
 	}
 
 	// Update
@@ -310,31 +308,29 @@ func TestClient_GCSs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if gcsUpdateResp1.Name != "new-test-gcs" {
-		t.Errorf("bad name: %q", gcsUpdateResp1.Name)
+	if *gcsUpdateResp1.Name != "new-test-gcs" {
+		t.Errorf("bad name: %q", *gcsUpdateResp1.Name)
 	}
-	if gcsUpdateResp1.MessageType != "classic" {
-		t.Errorf("bad message_type: %q", gcsUpdateResp1.MessageType)
+	if *gcsUpdateResp1.MessageType != "classic" {
+		t.Errorf("bad message_type: %q", *gcsUpdateResp1.MessageType)
 	}
-	if gcsUpdateResp1.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", gcsUpdateResp1.CompressionCodec)
+	if gcsUpdateResp1.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *gcsUpdateResp1.CompressionCodec)
 	}
-	if gcsUpdateResp1.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", gcsUpdateResp1.GzipLevel)
+	if *gcsUpdateResp1.GzipLevel != 9 {
+		t.Errorf("bad gzip_level: %q", *gcsUpdateResp1.GzipLevel)
 	}
-
-	if gcsUpdateResp2.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", gcsUpdateResp2.CompressionCodec)
+	if *gcsUpdateResp2.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *gcsUpdateResp2.CompressionCodec)
 	}
-	if gcsUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", gcsUpdateResp2.GzipLevel)
+	if *gcsUpdateResp2.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *gcsUpdateResp2.GzipLevel)
 	}
-
-	if gcsUpdateResp3.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", gcsUpdateResp3.CompressionCodec)
+	if gcsUpdateResp3.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *gcsUpdateResp3.CompressionCodec)
 	}
-	if gcsUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", gcsUpdateResp3.GzipLevel)
+	if *gcsUpdateResp3.GzipLevel != 9 {
+		t.Errorf("bad gzip_level: %q", *gcsUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/gcs_test.go
+++ b/fastly/gcs_test.go
@@ -18,7 +18,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/create", func(c *Client) {
 		gcsCreateResp1, err = c.CreateGCS(&CreateGCSInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-gcs"),
 			ProjectID:        ToPointer("logging-project"),
 			Bucket:           ToPointer("bucket"),
@@ -42,7 +42,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/create2", func(c *Client) {
 		gcsCreateResp2, err = c.CreateGCS(&CreateGCSInput{
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-gcs-2"),
 			ProjectID:       ToPointer("logging-project"),
 			Bucket:          ToPointer("bucket"),
@@ -65,7 +65,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/create3", func(c *Client) {
 		gcsCreateResp3, err = c.CreateGCS(&CreateGCSInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-gcs-3"),
 			ProjectID:        ToPointer("logging-project"),
 			Bucket:           ToPointer("bucket"),
@@ -90,7 +90,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/create4", func(c *Client) {
 		_, err = c.CreateGCS(&CreateGCSInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-gcs-4"),
 			ProjectID:        ToPointer("logging-project"),
 			Bucket:           ToPointer("bucket"),
@@ -116,25 +116,25 @@ func TestClient_GCSs(t *testing.T) {
 		record(t, "gcses/cleanup", func(c *Client) {
 			_ = c.DeleteGCS(&DeleteGCSInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-gcs",
 			})
 
 			_ = c.DeleteGCS(&DeleteGCSInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-gcs-2",
 			})
 
 			_ = c.DeleteGCS(&DeleteGCSInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-gcs-3",
 			})
 
 			_ = c.DeleteGCS(&DeleteGCSInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-gcs",
 			})
 		})
@@ -203,7 +203,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/list", func(c *Client) {
 		gcses, err = c.ListGCSs(&ListGCSsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -218,7 +218,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/get", func(c *Client) {
 		gcsGetResp, err = c.GetGCS(&GetGCSInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-gcs",
 		})
 	})
@@ -273,7 +273,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/update", func(c *Client) {
 		gcsUpdateResp1, err = c.UpdateGCS(&UpdateGCSInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-gcs",
 			NewName:        ToPointer("new-test-gcs"),
 			MessageType:    ToPointer("classic"),
@@ -287,7 +287,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/update2", func(c *Client) {
 		gcsUpdateResp2, err = c.UpdateGCS(&UpdateGCSInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-gcs-2",
 			CompressionCodec: ToPointer("zstd"),
 		})
@@ -299,7 +299,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/update3", func(c *Client) {
 		gcsUpdateResp3, err = c.UpdateGCS(&UpdateGCSInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-gcs-3",
 			GzipLevel:      ToPointer(9),
 		})
@@ -337,7 +337,7 @@ func TestClient_GCSs(t *testing.T) {
 	record(t, "gcses/delete", func(c *Client) {
 		err = c.DeleteGCS(&DeleteGCSInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-gcs",
 		})
 	})

--- a/fastly/gzip.go
+++ b/fastly/gzip.go
@@ -3,39 +3,20 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Gzip represents an Gzip logging response from the Fastly API.
 type Gzip struct {
-	CacheCondition string     `mapstructure:"cache_condition"`
-	ContentTypes   string     `mapstructure:"content_types"`
+	CacheCondition *string    `mapstructure:"cache_condition"`
+	ContentTypes   *string    `mapstructure:"content_types"`
 	CreatedAt      *time.Time `mapstructure:"created_at"`
 	DeletedAt      *time.Time `mapstructure:"deleted_at"`
-	Extensions     string     `mapstructure:"extensions"`
-	Name           string     `mapstructure:"name"`
-	ServiceID      string     `mapstructure:"service_id"`
-	ServiceVersion int        `mapstructure:"version"`
+	Extensions     *string    `mapstructure:"extensions"`
+	Name           *string    `mapstructure:"name"`
+	ServiceID      *string    `mapstructure:"service_id"`
+	ServiceVersion *int       `mapstructure:"version"`
 	UpdatedAt      *time.Time `mapstructure:"updated_at"`
-}
-
-// gzipsByName is a sortable list of gzips.
-type gzipsByName []*Gzip
-
-// Len implement the sortable interface.
-func (s gzipsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s gzipsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s gzipsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListGzipsInput is used as input to the ListGzips function.
@@ -66,7 +47,6 @@ func (c *Client) ListGzips(i *ListGzipsInput) ([]*Gzip, error) {
 	if err := decodeBodyMap(resp.Body, &gzips); err != nil {
 		return nil, err
 	}
-	sort.Stable(gzipsByName(gzips))
 	return gzips, nil
 }
 

--- a/fastly/gzip_test.go
+++ b/fastly/gzip_test.go
@@ -41,11 +41,11 @@ func TestClient_Gzips(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gzipomit.ContentTypes != "text/html application/x-javascript text/css application/javascript text/javascript application/json application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype application/x-font-ttf application/xml font/eot font/opentype font/otf image/svg+xml image/vnd.microsoft.icon text/plain text/xml" {
-		t.Errorf("bad content_types: %q", gzipomit.ContentTypes)
+	if *gzipomit.ContentTypes != "text/html application/x-javascript text/css application/javascript text/javascript application/json application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype application/x-font-ttf application/xml font/eot font/opentype font/otf image/svg+xml image/vnd.microsoft.icon text/plain text/xml" {
+		t.Errorf("bad content_types: %q", *gzipomit.ContentTypes)
 	}
-	if gzipomit.Extensions != "css js html eot ico otf ttf json" {
-		t.Errorf("bad extensions: %q", gzipomit.Extensions)
+	if *gzipomit.Extensions != "css js html eot ico otf ttf json" {
+		t.Errorf("bad extensions: %q", *gzipomit.Extensions)
 	}
 
 	// Ensure deleted
@@ -71,14 +71,14 @@ func TestClient_Gzips(t *testing.T) {
 		})
 	}()
 
-	if gzip.Name != "test-gzip" {
-		t.Errorf("bad name: %q", gzip.Name)
+	if *gzip.Name != "test-gzip" {
+		t.Errorf("bad name: %q", *gzip.Name)
 	}
-	if gzip.ContentTypes != "text/html text/css" {
-		t.Errorf("bad content_types: %q", gzip.ContentTypes)
+	if *gzip.ContentTypes != "text/html text/css" {
+		t.Errorf("bad content_types: %q", *gzip.ContentTypes)
 	}
-	if gzip.Extensions != "html css" {
-		t.Errorf("bad extensions: %q", gzip.Extensions)
+	if *gzip.Extensions != "html css" {
+		t.Errorf("bad extensions: %q", *gzip.Extensions)
 	}
 
 	// List
@@ -108,14 +108,14 @@ func TestClient_Gzips(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ngzip.Name != gzip.Name {
-		t.Errorf("bad name: %q", ngzip.Name)
+	if *ngzip.Name != *gzip.Name {
+		t.Errorf("bad name: %q", *ngzip.Name)
 	}
-	if ngzip.ContentTypes != gzip.ContentTypes {
-		t.Errorf("bad content_types: %q", ngzip.ContentTypes)
+	if *ngzip.ContentTypes != *gzip.ContentTypes {
+		t.Errorf("bad content_types: %q", *ngzip.ContentTypes)
 	}
-	if ngzip.Extensions != gzip.Extensions {
-		t.Errorf("bad extensions: %q", ngzip.Extensions)
+	if *ngzip.Extensions != *gzip.Extensions {
+		t.Errorf("bad extensions: %q", *ngzip.Extensions)
 	}
 
 	// Update
@@ -131,8 +131,8 @@ func TestClient_Gzips(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ugzip.Name != "new-test-gzip" {
-		t.Errorf("bad name: %q", ugzip.Name)
+	if *ugzip.Name != "new-test-gzip" {
+		t.Errorf("bad name: %q", *ugzip.Name)
 	}
 
 	// Delete

--- a/fastly/gzip_test.go
+++ b/fastly/gzip_test.go
@@ -18,7 +18,7 @@ func TestClient_Gzips(t *testing.T) {
 	record(t, "gzips/create", func(c *Client) {
 		gzip, err = c.CreateGzip(&CreateGzipInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-gzip"),
 			ContentTypes:   ToPointer("text/html text/css"),
 			Extensions:     ToPointer("html css"),
@@ -34,7 +34,7 @@ func TestClient_Gzips(t *testing.T) {
 	record(t, "gzips/create_omissions", func(c *Client) {
 		gzipomit, err = c.CreateGzip(&CreateGzipInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-gzip-omit"),
 		})
 	})
@@ -53,19 +53,19 @@ func TestClient_Gzips(t *testing.T) {
 		record(t, "gzips/cleanup", func(c *Client) {
 			_ = c.DeleteGzip(&DeleteGzipInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-gzip",
 			})
 
 			_ = c.DeleteGzip(&DeleteGzipInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-gzip-omit",
 			})
 
 			_ = c.DeleteGzip(&DeleteGzipInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-gzip",
 			})
 		})
@@ -86,7 +86,7 @@ func TestClient_Gzips(t *testing.T) {
 	record(t, "gzips/list", func(c *Client) {
 		gzips, err = c.ListGzips(&ListGzipsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -101,7 +101,7 @@ func TestClient_Gzips(t *testing.T) {
 	record(t, "gzips/get", func(c *Client) {
 		ngzip, err = c.GetGzip(&GetGzipInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-gzip",
 		})
 	})
@@ -123,7 +123,7 @@ func TestClient_Gzips(t *testing.T) {
 	record(t, "gzips/update", func(c *Client) {
 		ugzip, err = c.UpdateGzip(&UpdateGzipInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-gzip",
 			NewName:        ToPointer("new-test-gzip"),
 		})
@@ -139,7 +139,7 @@ func TestClient_Gzips(t *testing.T) {
 	record(t, "gzips/delete", func(c *Client) {
 		err = c.DeleteGzip(&DeleteGzipInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-gzip",
 		})
 	})

--- a/fastly/header.go
+++ b/fastly/header.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -29,12 +28,6 @@ const (
 // HeaderAction is a type of header action.
 type HeaderAction string
 
-// HeaderActionPtr returns pointer to HeaderAction.
-func HeaderActionPtr(t HeaderAction) *HeaderAction {
-	ha := HeaderAction(t)
-	return &ha
-}
-
 const (
 	// HeaderTypeRequest is a header type that performs on the request before
 	// lookups.
@@ -56,49 +49,25 @@ const (
 // HeaderType is a type of header.
 type HeaderType string
 
-// HeaderTypePtr returns pointer to HeaderType.
-func HeaderTypePtr(t HeaderType) *HeaderType {
-	ht := HeaderType(t)
-	return &ht
-}
-
 // Header represents a header response from the Fastly API.
 type Header struct {
-	Action            HeaderAction `mapstructure:"action"`
-	CacheCondition    string       `mapstructure:"cache_condition"`
-	CreatedAt         *time.Time   `mapstructure:"created_at"`
-	DeletedAt         *time.Time   `mapstructure:"deleted_at"`
-	Destination       string       `mapstructure:"dst"`
-	IgnoreIfSet       bool         `mapstructure:"ignore_if_set"`
-	Name              string       `mapstructure:"name"`
-	Priority          int          `mapstructure:"priority"`
-	Regex             string       `mapstructure:"regex"`
-	RequestCondition  string       `mapstructure:"request_condition"`
-	ResponseCondition string       `mapstructure:"response_condition"`
-	ServiceID         string       `mapstructure:"service_id"`
-	ServiceVersion    int          `mapstructure:"version"`
-	Source            string       `mapstructure:"src"`
-	Substitution      string       `mapstructure:"substitution"`
-	Type              HeaderType   `mapstructure:"type"`
-	UpdatedAt         *time.Time   `mapstructure:"updated_at"`
-}
-
-// headersByName is a sortable list of headers.
-type headersByName []*Header
-
-// Len implement the sortable interface.
-func (s headersByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s headersByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s headersByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	Action            *HeaderAction `mapstructure:"action"`
+	CacheCondition    *string       `mapstructure:"cache_condition"`
+	CreatedAt         *time.Time    `mapstructure:"created_at"`
+	DeletedAt         *time.Time    `mapstructure:"deleted_at"`
+	Destination       *string       `mapstructure:"dst"`
+	IgnoreIfSet       *bool         `mapstructure:"ignore_if_set"`
+	Name              *string       `mapstructure:"name"`
+	Priority          *int          `mapstructure:"priority"`
+	Regex             *string       `mapstructure:"regex"`
+	RequestCondition  *string       `mapstructure:"request_condition"`
+	ResponseCondition *string       `mapstructure:"response_condition"`
+	ServiceID         *string       `mapstructure:"service_id"`
+	ServiceVersion    *int          `mapstructure:"version"`
+	Source            *string       `mapstructure:"src"`
+	Substitution      *string       `mapstructure:"substitution"`
+	Type              *HeaderType   `mapstructure:"type"`
+	UpdatedAt         *time.Time    `mapstructure:"updated_at"`
 }
 
 // ListHeadersInput is used as input to the ListHeaders function.
@@ -128,7 +97,6 @@ func (c *Client) ListHeaders(i *ListHeadersInput) ([]*Header, error) {
 	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
-	sort.Stable(headersByName(bs))
 	return bs, nil
 }
 

--- a/fastly/header_test.go
+++ b/fastly/header_test.go
@@ -20,9 +20,9 @@ func TestClient_Headers(t *testing.T) {
 			ServiceID:      testServiceID,
 			ServiceVersion: tv.Number,
 			Name:           ToPointer("test-header"),
-			Action:         HeaderActionPtr(HeaderActionSet),
+			Action:         ToPointer(HeaderActionSet),
 			IgnoreIfSet:    ToPointer(Compatibool(false)),
-			Type:           HeaderTypePtr(HeaderTypeRequest),
+			Type:           ToPointer(HeaderTypeRequest),
 			Destination:    ToPointer("http.foo"),
 			Source:         ToPointer("client.ip"),
 			Regex:          ToPointer("foobar"),
@@ -51,32 +51,32 @@ func TestClient_Headers(t *testing.T) {
 		})
 	}()
 
-	if h.Name != "test-header" {
-		t.Errorf("bad name: %q", h.Name)
+	if *h.Name != "test-header" {
+		t.Errorf("bad name: %q", *h.Name)
 	}
-	if h.Action != HeaderActionSet {
-		t.Errorf("bad header_action_set: %q", h.Action)
+	if *h.Action != HeaderActionSet {
+		t.Errorf("bad header_action_set: %q", *h.Action)
 	}
-	if h.IgnoreIfSet {
-		t.Errorf("bad ignore_if_set: %t", h.IgnoreIfSet)
+	if *h.IgnoreIfSet {
+		t.Errorf("bad ignore_if_set: %t", *h.IgnoreIfSet)
 	}
-	if h.Type != HeaderTypeRequest {
-		t.Errorf("bad type: %q", h.Type)
+	if *h.Type != HeaderTypeRequest {
+		t.Errorf("bad type: %q", *h.Type)
 	}
-	if h.Destination != "http.foo" {
-		t.Errorf("bad destination: %q", h.Destination)
+	if *h.Destination != "http.foo" {
+		t.Errorf("bad destination: %q", *h.Destination)
 	}
-	if h.Source != "client.ip" {
-		t.Errorf("bad source: %q", h.Source)
+	if *h.Source != "client.ip" {
+		t.Errorf("bad source: %q", *h.Source)
 	}
-	if h.Regex != "foobar" {
-		t.Errorf("bad regex: %q", h.Regex)
+	if *h.Regex != "foobar" {
+		t.Errorf("bad regex: %q", *h.Regex)
 	}
-	if h.Substitution != "123" {
-		t.Errorf("bad substitution: %q", h.Substitution)
+	if *h.Substitution != "123" {
+		t.Errorf("bad substitution: %q", *h.Substitution)
 	}
-	if h.Priority != 50 {
-		t.Errorf("bad priority: %d", h.Priority)
+	if *h.Priority != 50 {
+		t.Errorf("bad priority: %d", *h.Priority)
 	}
 
 	// List
@@ -106,32 +106,32 @@ func TestClient_Headers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if h.Name != nh.Name {
-		t.Errorf("bad name: %q (%q)", h.Name, nh.Name)
+	if *h.Name != *nh.Name {
+		t.Errorf("bad name: %q (%q)", *h.Name, *nh.Name)
 	}
-	if h.Action != nh.Action {
-		t.Errorf("bad header_action_set: %q", h.Action)
+	if *h.Action != *nh.Action {
+		t.Errorf("bad header_action_set: %q", *h.Action)
 	}
-	if h.IgnoreIfSet != nh.IgnoreIfSet {
-		t.Errorf("bad ignore_if_set: %t", h.IgnoreIfSet)
+	if *h.IgnoreIfSet != *nh.IgnoreIfSet {
+		t.Errorf("bad ignore_if_set: %t", *h.IgnoreIfSet)
 	}
-	if h.Type != nh.Type {
-		t.Errorf("bad type: %q", h.Type)
+	if *h.Type != *nh.Type {
+		t.Errorf("bad type: %q", *h.Type)
 	}
-	if h.Destination != nh.Destination {
-		t.Errorf("bad destination: %q", h.Destination)
+	if *h.Destination != *nh.Destination {
+		t.Errorf("bad destination: %q", *h.Destination)
 	}
-	if h.Source != nh.Source {
-		t.Errorf("bad source: %q", h.Source)
+	if *h.Source != *nh.Source {
+		t.Errorf("bad source: %q", *h.Source)
 	}
-	if h.Regex != nh.Regex {
-		t.Errorf("bad regex: %q", h.Regex)
+	if *h.Regex != *nh.Regex {
+		t.Errorf("bad regex: %q", *h.Regex)
 	}
-	if h.Substitution != nh.Substitution {
-		t.Errorf("bad substitution: %q", h.Substitution)
+	if *h.Substitution != *nh.Substitution {
+		t.Errorf("bad substitution: %q", *h.Substitution)
 	}
-	if h.Priority != nh.Priority {
-		t.Errorf("bad priority: %d", h.Priority)
+	if *h.Priority != *nh.Priority {
+		t.Errorf("bad priority: %d", *h.Priority)
 	}
 
 	// Update
@@ -142,15 +142,15 @@ func TestClient_Headers(t *testing.T) {
 			ServiceVersion: tv.Number,
 			Name:           "test-header",
 			NewName:        ToPointer("new-test-header"),
-			Action:         HeaderActionPtr(HeaderActionAppend),
-			Type:           HeaderTypePtr(HeaderTypeFetch),
+			Action:         ToPointer(HeaderActionAppend),
+			Type:           ToPointer(HeaderTypeFetch),
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uh.Name != "new-test-header" {
-		t.Errorf("bad name: %q", uh.Name)
+	if *uh.Name != "new-test-header" {
+		t.Errorf("bad name: %q", *uh.Name)
 	}
 
 	// Delete

--- a/fastly/header_test.go
+++ b/fastly/header_test.go
@@ -18,7 +18,7 @@ func TestClient_Headers(t *testing.T) {
 	record(t, "headers/create", func(c *Client) {
 		h, err = c.CreateHeader(&CreateHeaderInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-header"),
 			Action:         ToPointer(HeaderActionSet),
 			IgnoreIfSet:    ToPointer(Compatibool(false)),
@@ -39,13 +39,13 @@ func TestClient_Headers(t *testing.T) {
 		record(t, "headers/cleanup", func(c *Client) {
 			_ = c.DeleteHeader(&DeleteHeaderInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-header",
 			})
 
 			_ = c.DeleteHeader(&DeleteHeaderInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-header",
 			})
 		})
@@ -84,7 +84,7 @@ func TestClient_Headers(t *testing.T) {
 	record(t, "headers/list", func(c *Client) {
 		hs, err = c.ListHeaders(&ListHeadersInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -99,7 +99,7 @@ func TestClient_Headers(t *testing.T) {
 	record(t, "headers/get", func(c *Client) {
 		nh, err = c.GetHeader(&GetHeaderInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-header",
 		})
 	})
@@ -139,7 +139,7 @@ func TestClient_Headers(t *testing.T) {
 	record(t, "headers/update", func(c *Client) {
 		uh, err = c.UpdateHeader(&UpdateHeaderInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-header",
 			NewName:        ToPointer("new-test-header"),
 			Action:         ToPointer(HeaderActionAppend),
@@ -157,7 +157,7 @@ func TestClient_Headers(t *testing.T) {
 	record(t, "headers/delete", func(c *Client) {
 		err = c.DeleteHeader(&DeleteHeaderInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-header",
 		})
 	})

--- a/fastly/health_check.go
+++ b/fastly/health_check.go
@@ -3,48 +3,29 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // HealthCheck represents a health check response from the Fastly API.
 type HealthCheck struct {
-	CheckInterval    int        `mapstructure:"check_interval"`
-	Comment          string     `mapstructure:"comment"`
+	CheckInterval    *int       `mapstructure:"check_interval"`
+	Comment          *string    `mapstructure:"comment"`
 	CreatedAt        *time.Time `mapstructure:"created_at"`
 	DeletedAt        *time.Time `mapstructure:"deleted_at"`
-	ExpectedResponse int        `mapstructure:"expected_response"`
-	HTTPVersion      string     `mapstructure:"http_version"`
+	ExpectedResponse *int       `mapstructure:"expected_response"`
+	HTTPVersion      *string    `mapstructure:"http_version"`
 	Headers          []string   `mapstructure:"headers"`
-	Host             string     `mapstructure:"host"`
-	Initial          int        `mapstructure:"initial"`
-	Method           string     `mapstructure:"method"`
-	Name             string     `mapstructure:"name"`
-	Path             string     `mapstructure:"path"`
-	ServiceID        string     `mapstructure:"service_id"`
-	ServiceVersion   int        `mapstructure:"version"`
-	Threshold        int        `mapstructure:"threshold"`
-	Timeout          int        `mapstructure:"timeout"`
+	Host             *string    `mapstructure:"host"`
+	Initial          *int       `mapstructure:"initial"`
+	Method           *string    `mapstructure:"method"`
+	Name             *string    `mapstructure:"name"`
+	Path             *string    `mapstructure:"path"`
+	ServiceID        *string    `mapstructure:"service_id"`
+	ServiceVersion   *int       `mapstructure:"version"`
+	Threshold        *int       `mapstructure:"threshold"`
+	Timeout          *int       `mapstructure:"timeout"`
 	UpdatedAt        *time.Time `mapstructure:"updated_at"`
-	Window           int        `mapstructure:"window"`
-}
-
-// healthChecksByName is a sortable list of health checks.
-type healthChecksByName []*HealthCheck
-
-// Len implement the sortable interface.
-func (s healthChecksByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s healthChecksByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s healthChecksByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	Window           *int       `mapstructure:"window"`
 }
 
 // ListHealthChecksInput is used as input to the ListHealthChecks function.
@@ -74,7 +55,6 @@ func (c *Client) ListHealthChecks(i *ListHealthChecksInput) ([]*HealthCheck, err
 	if err := decodeBodyMap(resp.Body, &hcs); err != nil {
 		return nil, err
 	}
-	sort.Stable(healthChecksByName(hcs))
 	return hcs, nil
 }
 

--- a/fastly/health_check_test.go
+++ b/fastly/health_check_test.go
@@ -18,7 +18,7 @@ func TestClient_HealthChecks(t *testing.T) {
 	record(t, "health_checks/create", func(c *Client) {
 		hc, err = c.CreateHealthCheck(&CreateHealthCheckInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-healthcheck"),
 			Method:         ToPointer("HEAD"),
 			Headers: &[]string{
@@ -45,13 +45,13 @@ func TestClient_HealthChecks(t *testing.T) {
 		record(t, "health_checks/cleanup", func(c *Client) {
 			_ = c.DeleteHealthCheck(&DeleteHealthCheckInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-healthcheck",
 			})
 
 			_ = c.DeleteHealthCheck(&DeleteHealthCheckInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-healthcheck",
 			})
 		})
@@ -99,7 +99,7 @@ func TestClient_HealthChecks(t *testing.T) {
 	record(t, "health_checks/list", func(c *Client) {
 		hcs, err = c.ListHealthChecks(&ListHealthChecksInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -114,7 +114,7 @@ func TestClient_HealthChecks(t *testing.T) {
 	record(t, "health_checks/get", func(c *Client) {
 		nhc, err = c.GetHealthCheck(&GetHealthCheckInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-healthcheck",
 		})
 	})
@@ -166,7 +166,7 @@ func TestClient_HealthChecks(t *testing.T) {
 	record(t, "health_checks/update", func(c *Client) {
 		uhc, err = c.UpdateHealthCheck(&UpdateHealthCheckInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-healthcheck",
 			NewName:        ToPointer("new-test-healthcheck"),
 			Headers:        &[]string{"Beep: Boop"},
@@ -186,7 +186,7 @@ func TestClient_HealthChecks(t *testing.T) {
 	record(t, "health_checks/delete", func(c *Client) {
 		err = c.DeleteHealthCheck(&DeleteHealthCheckInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-healthcheck",
 		})
 	})

--- a/fastly/health_check_test.go
+++ b/fastly/health_check_test.go
@@ -57,38 +57,38 @@ func TestClient_HealthChecks(t *testing.T) {
 		})
 	}()
 
-	if hc.Name != "test-healthcheck" {
-		t.Errorf("bad name: %q", hc.Name)
+	if *hc.Name != "test-healthcheck" {
+		t.Errorf("bad name: %q", *hc.Name)
 	}
-	if hc.Method != "HEAD" {
-		t.Errorf("bad address: %q", hc.Method)
+	if *hc.Method != "HEAD" {
+		t.Errorf("bad address: %q", *hc.Method)
 	}
-	if hc.Host != "example.com" {
-		t.Errorf("bad host: %q", hc.Host)
+	if *hc.Host != "example.com" {
+		t.Errorf("bad host: %q", *hc.Host)
 	}
-	if hc.Path != "/foo" {
-		t.Errorf("bad path: %q", hc.Path)
+	if *hc.Path != "/foo" {
+		t.Errorf("bad path: %q", *hc.Path)
 	}
-	if hc.HTTPVersion != "1.1" {
-		t.Errorf("bad http_version: %q", hc.HTTPVersion)
+	if *hc.HTTPVersion != "1.1" {
+		t.Errorf("bad http_version: %q", *hc.HTTPVersion)
 	}
-	if hc.Timeout != 1500 {
-		t.Errorf("bad timeout: %q", hc.Timeout)
+	if *hc.Timeout != 1500 {
+		t.Errorf("bad timeout: %q", *hc.Timeout)
 	}
-	if hc.CheckInterval != 2500 {
-		t.Errorf("bad check_interval: %q", hc.CheckInterval)
+	if *hc.CheckInterval != 2500 {
+		t.Errorf("bad check_interval: %q", *hc.CheckInterval)
 	}
-	if hc.ExpectedResponse != 200 {
-		t.Errorf("bad timeout: %q", hc.ExpectedResponse)
+	if *hc.ExpectedResponse != 200 {
+		t.Errorf("bad timeout: %q", *hc.ExpectedResponse)
 	}
-	if hc.Window != 5000 {
-		t.Errorf("bad window: %q", hc.Window)
+	if *hc.Window != 5000 {
+		t.Errorf("bad window: %q", *hc.Window)
 	}
-	if hc.Threshold != 10 {
-		t.Errorf("bad threshold: %q", hc.Threshold)
+	if *hc.Threshold != 10 {
+		t.Errorf("bad threshold: %q", *hc.Threshold)
 	}
-	if hc.Initial != 10 {
-		t.Errorf("bad initial: %q", hc.Initial)
+	if *hc.Initial != 10 {
+		t.Errorf("bad initial: %q", *hc.Initial)
 	}
 	if len(hc.Headers) != 2 {
 		t.Errorf("bad headers: %q", hc.Headers)
@@ -121,38 +121,38 @@ func TestClient_HealthChecks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hc.Name != nhc.Name {
-		t.Errorf("bad name: %q (%q)", hc.Name, nhc.Name)
+	if *hc.Name != *nhc.Name {
+		t.Errorf("bad name: %q (%q)", *hc.Name, *nhc.Name)
 	}
-	if hc.Method != nhc.Method {
-		t.Errorf("bad address: %q", hc.Method)
+	if *hc.Method != *nhc.Method {
+		t.Errorf("bad address: %q", *hc.Method)
 	}
-	if hc.Host != nhc.Host {
-		t.Errorf("bad host: %q", hc.Host)
+	if *hc.Host != *nhc.Host {
+		t.Errorf("bad host: %q", *hc.Host)
 	}
-	if hc.Path != nhc.Path {
-		t.Errorf("bad path: %q", hc.Path)
+	if *hc.Path != *nhc.Path {
+		t.Errorf("bad path: %q", *hc.Path)
 	}
-	if hc.HTTPVersion != nhc.HTTPVersion {
-		t.Errorf("bad http_version: %q", hc.HTTPVersion)
+	if *hc.HTTPVersion != *nhc.HTTPVersion {
+		t.Errorf("bad http_version: %q", *hc.HTTPVersion)
 	}
-	if hc.Timeout != nhc.Timeout {
-		t.Errorf("bad timeout: %q", hc.Timeout)
+	if *hc.Timeout != *nhc.Timeout {
+		t.Errorf("bad timeout: %q", *hc.Timeout)
 	}
-	if hc.CheckInterval != nhc.CheckInterval {
-		t.Errorf("bad check_interval: %q", hc.CheckInterval)
+	if *hc.CheckInterval != *nhc.CheckInterval {
+		t.Errorf("bad check_interval: %q", *hc.CheckInterval)
 	}
-	if hc.ExpectedResponse != nhc.ExpectedResponse {
-		t.Errorf("bad timeout: %q", hc.ExpectedResponse)
+	if *hc.ExpectedResponse != *nhc.ExpectedResponse {
+		t.Errorf("bad timeout: %q", *hc.ExpectedResponse)
 	}
-	if hc.Window != nhc.Window {
-		t.Errorf("bad window: %q", hc.Window)
+	if *hc.Window != *nhc.Window {
+		t.Errorf("bad window: %q", *hc.Window)
 	}
-	if hc.Threshold != nhc.Threshold {
-		t.Errorf("bad threshold: %q", hc.Threshold)
+	if *hc.Threshold != *nhc.Threshold {
+		t.Errorf("bad threshold: %q", *hc.Threshold)
 	}
-	if hc.Initial != nhc.Initial {
-		t.Errorf("bad initial: %q", hc.Initial)
+	if *hc.Initial != *nhc.Initial {
+		t.Errorf("bad initial: %q", *hc.Initial)
 	}
 	if len(nhc.Headers) != 2 {
 		t.Errorf("bad headers: %q", nhc.Headers)
@@ -175,8 +175,8 @@ func TestClient_HealthChecks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uhc.Name != "new-test-healthcheck" {
-		t.Errorf("bad update name: %q", uhc.Name)
+	if *uhc.Name != "new-test-healthcheck" {
+		t.Errorf("bad update name: %q", *uhc.Name)
 	}
 	if len(uhc.Headers) != 1 {
 		t.Errorf("bad headers: %q", uhc.Headers)

--- a/fastly/heroku.go
+++ b/fastly/heroku.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,34 +10,16 @@ import (
 type Heroku struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	Token             string     `mapstructure:"token"`
-	URL               string     `mapstructure:"url"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	Token             *string    `mapstructure:"token"`
+	URL               *string    `mapstructure:"url"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// herokusByName is a sortable list of herokus.
-type herokusByName []*Heroku
-
-// Len implement the sortable interface.
-func (h herokusByName) Len() int {
-	return len(h)
-}
-
-// Swap implement the sortable interface.
-func (h herokusByName) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-}
-
-// Less implement the sortable interface.
-func (h herokusByName) Less(i, j int) bool {
-	return h[i].Name < h[j].Name
 }
 
 // ListHerokusInput is used as input to the ListHerokus function.
@@ -68,7 +49,6 @@ func (c *Client) ListHerokus(i *ListHerokusInput) ([]*Heroku, error) {
 	if err := decodeBodyMap(resp.Body, &hs); err != nil {
 		return nil, err
 	}
-	sort.Stable(herokusByName(hs))
 	return hs, nil
 }
 

--- a/fastly/heroku_test.go
+++ b/fastly/heroku_test.go
@@ -48,23 +48,23 @@ func TestClient_Herokus(t *testing.T) {
 		})
 	}()
 
-	if h.Name != "test-heroku" {
-		t.Errorf("bad name: %q", h.Name)
+	if *h.Name != "test-heroku" {
+		t.Errorf("bad name: %q", *h.Name)
 	}
-	if h.Format != "%h %l %u %t \"%r\" %>s %b" {
-		t.Errorf("bad format: %q", h.Format)
+	if *h.Format != "%h %l %u %t \"%r\" %>s %b" {
+		t.Errorf("bad format: %q", *h.Format)
 	}
-	if h.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", h.FormatVersion)
+	if *h.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *h.FormatVersion)
 	}
-	if h.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", h.Placement)
+	if *h.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *h.Placement)
 	}
-	if h.Token != "super-secure-token" {
-		t.Errorf("bad token: %q", h.Token)
+	if *h.Token != "super-secure-token" {
+		t.Errorf("bad token: %q", *h.Token)
 	}
-	if h.URL != "https://1.us.logplex.io/logs" {
-		t.Errorf("bad url: %q", h.URL)
+	if *h.URL != "https://1.us.logplex.io/logs" {
+		t.Errorf("bad url: %q", *h.URL)
 	}
 
 	// List
@@ -94,23 +94,23 @@ func TestClient_Herokus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if h.Name != nh.Name {
-		t.Errorf("bad name: %q", h.Name)
+	if *h.Name != *nh.Name {
+		t.Errorf("bad name: %q", *h.Name)
 	}
-	if h.Format != nh.Format {
-		t.Errorf("bad format: %q", h.Format)
+	if *h.Format != *nh.Format {
+		t.Errorf("bad format: %q", *h.Format)
 	}
-	if h.FormatVersion != nh.FormatVersion {
-		t.Errorf("bad format_version: %q", h.FormatVersion)
+	if *h.FormatVersion != *nh.FormatVersion {
+		t.Errorf("bad format_version: %q", *h.FormatVersion)
 	}
-	if h.Placement != nh.Placement {
-		t.Errorf("bad placement: %q", h.Placement)
+	if *h.Placement != *nh.Placement {
+		t.Errorf("bad placement: %q", *h.Placement)
 	}
-	if h.Token != nh.Token {
-		t.Errorf("bad token: %q", h.Token)
+	if *h.Token != *nh.Token {
+		t.Errorf("bad token: %q", *h.Token)
 	}
-	if h.URL != nh.URL {
-		t.Errorf("bad url: %q", h.URL)
+	if *h.URL != *nh.URL {
+		t.Errorf("bad url: %q", *h.URL)
 	}
 
 	// Update
@@ -127,11 +127,11 @@ func TestClient_Herokus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uh.Name != "new-test-heroku" {
-		t.Errorf("bad name: %q", uh.Name)
+	if *uh.Name != "new-test-heroku" {
+		t.Errorf("bad name: %q", *uh.Name)
 	}
-	if uh.Token != "new-token" {
-		t.Errorf("bad token: %q", uh.Token)
+	if *uh.Token != "new-token" {
+		t.Errorf("bad token: %q", *uh.Token)
 	}
 
 	// Delete

--- a/fastly/heroku_test.go
+++ b/fastly/heroku_test.go
@@ -18,7 +18,7 @@ func TestClient_Herokus(t *testing.T) {
 	record(t, "herokus/create", func(c *Client) {
 		h, err = c.CreateHeroku(&CreateHerokuInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-heroku"),
 			Format:         ToPointer("%h %l %u %t \"%r\" %>s %b"),
 			FormatVersion:  ToPointer(2),
@@ -36,13 +36,13 @@ func TestClient_Herokus(t *testing.T) {
 		record(t, "herokus/cleanup", func(c *Client) {
 			_ = c.DeleteHeroku(&DeleteHerokuInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-heroku",
 			})
 
 			_ = c.DeleteHeroku(&DeleteHerokuInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-heroku",
 			})
 		})
@@ -72,7 +72,7 @@ func TestClient_Herokus(t *testing.T) {
 	record(t, "herokus/list", func(c *Client) {
 		hs, err = c.ListHerokus(&ListHerokusInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func TestClient_Herokus(t *testing.T) {
 	record(t, "herokus/get", func(c *Client) {
 		nh, err = c.GetHeroku(&GetHerokuInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-heroku",
 		})
 	})
@@ -118,7 +118,7 @@ func TestClient_Herokus(t *testing.T) {
 	record(t, "herokus/update", func(c *Client) {
 		uh, err = c.UpdateHeroku(&UpdateHerokuInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-heroku",
 			NewName:        ToPointer("new-test-heroku"),
 			Token:          ToPointer("new-token"),
@@ -138,7 +138,7 @@ func TestClient_Herokus(t *testing.T) {
 	record(t, "herokus/delete", func(c *Client) {
 		err = c.DeleteHeroku(&DeleteHerokuInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-heroku",
 		})
 	})

--- a/fastly/honeycomb.go
+++ b/fastly/honeycomb.go
@@ -3,42 +3,23 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Honeycomb represents a honeycomb response from the Fastly API.
 type Honeycomb struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
-	Dataset           string     `mapstructure:"dataset"`
+	Dataset           *string    `mapstructure:"dataset"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	Token             string     `mapstructure:"token"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	Token             *string    `mapstructure:"token"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// honeycombsByName is a sortable list of honeycombs.
-type honeycombsByName []*Honeycomb
-
-// Len implement the sortable interface.
-func (h honeycombsByName) Len() int {
-	return len(h)
-}
-
-// Swap implement the sortable interface.
-func (h honeycombsByName) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-}
-
-// Less implement the sortable interface.
-func (h honeycombsByName) Less(i, j int) bool {
-	return h[i].Name < h[j].Name
 }
 
 // ListHoneycombsInput is used as input to the ListHoneycombs function.
@@ -69,7 +50,6 @@ func (c *Client) ListHoneycombs(i *ListHoneycombsInput) ([]*Honeycomb, error) {
 	if err := decodeBodyMap(resp.Body, &hs); err != nil {
 		return nil, err
 	}
-	sort.Stable(honeycombsByName(hs))
 	return hs, nil
 }
 

--- a/fastly/honeycomb_test.go
+++ b/fastly/honeycomb_test.go
@@ -18,7 +18,7 @@ func TestClient_Honeycombs(t *testing.T) {
 	record(t, "honeycombs/create", func(c *Client) {
 		h, err = c.CreateHoneycomb(&CreateHoneycombInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-honeycomb"),
 			Format:         ToPointer("%h %l %u %t \"%r\" %>s %b"),
 			FormatVersion:  ToPointer(2),
@@ -36,13 +36,13 @@ func TestClient_Honeycombs(t *testing.T) {
 		record(t, "honeycombs/cleanup", func(c *Client) {
 			_ = c.DeleteHoneycomb(&DeleteHoneycombInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-honeycomb",
 			})
 
 			_ = c.DeleteHoneycomb(&DeleteHoneycombInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-honeycomb",
 			})
 		})
@@ -72,7 +72,7 @@ func TestClient_Honeycombs(t *testing.T) {
 	record(t, "honeycombs/list", func(c *Client) {
 		hs, err = c.ListHoneycombs(&ListHoneycombsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func TestClient_Honeycombs(t *testing.T) {
 	record(t, "honeycombs/get", func(c *Client) {
 		nh, err = c.GetHoneycomb(&GetHoneycombInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-honeycomb",
 		})
 	})
@@ -118,7 +118,7 @@ func TestClient_Honeycombs(t *testing.T) {
 	record(t, "honeycombs/update", func(c *Client) {
 		us, err = c.UpdateHoneycomb(&UpdateHoneycombInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-honeycomb",
 			NewName:        ToPointer("new-test-honeycomb"),
 			Token:          ToPointer("new-token"),
@@ -142,7 +142,7 @@ func TestClient_Honeycombs(t *testing.T) {
 	record(t, "honeycombs/delete", func(c *Client) {
 		err = c.DeleteHoneycomb(&DeleteHoneycombInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-honeycomb",
 		})
 	})

--- a/fastly/honeycomb_test.go
+++ b/fastly/honeycomb_test.go
@@ -48,23 +48,23 @@ func TestClient_Honeycombs(t *testing.T) {
 		})
 	}()
 
-	if h.Name != "test-honeycomb" {
-		t.Errorf("bad name: %q", h.Name)
+	if *h.Name != "test-honeycomb" {
+		t.Errorf("bad name: %q", *h.Name)
 	}
-	if h.Format != "%h %l %u %t \"%r\" %>s %b" {
-		t.Errorf("bad format: %q", h.Format)
+	if *h.Format != "%h %l %u %t \"%r\" %>s %b" {
+		t.Errorf("bad format: %q", *h.Format)
 	}
-	if h.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", h.FormatVersion)
+	if *h.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *h.FormatVersion)
 	}
-	if h.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", h.Placement)
+	if *h.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *h.Placement)
 	}
-	if h.Token != "super-secure-token" {
-		t.Errorf("bad token: %q", h.Token)
+	if *h.Token != "super-secure-token" {
+		t.Errorf("bad token: %q", *h.Token)
 	}
-	if h.Dataset != "testDataset" {
-		t.Errorf("bad dataset: %q", h.Dataset)
+	if *h.Dataset != "testDataset" {
+		t.Errorf("bad dataset: %q", *h.Dataset)
 	}
 
 	// List
@@ -94,23 +94,23 @@ func TestClient_Honeycombs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if h.Name != nh.Name {
-		t.Errorf("bad name: %q", h.Name)
+	if *h.Name != *nh.Name {
+		t.Errorf("bad name: %q", *h.Name)
 	}
-	if h.Format != nh.Format {
-		t.Errorf("bad format: %q", h.Format)
+	if *h.Format != *nh.Format {
+		t.Errorf("bad format: %q", *h.Format)
 	}
-	if h.FormatVersion != nh.FormatVersion {
-		t.Errorf("bad format_version: %q", h.FormatVersion)
+	if *h.FormatVersion != *nh.FormatVersion {
+		t.Errorf("bad format_version: %q", *h.FormatVersion)
 	}
-	if h.Placement != nh.Placement {
-		t.Errorf("bad placement: %q", h.Placement)
+	if *h.Placement != *nh.Placement {
+		t.Errorf("bad placement: %q", *h.Placement)
 	}
-	if h.Token != nh.Token {
-		t.Errorf("bad token: %q", h.Token)
+	if *h.Token != *nh.Token {
+		t.Errorf("bad token: %q", *h.Token)
 	}
-	if h.Dataset != nh.Dataset {
-		t.Errorf("bad dataset: %q", h.Dataset)
+	if *h.Dataset != *nh.Dataset {
+		t.Errorf("bad dataset: %q", *h.Dataset)
 	}
 
 	// Update
@@ -128,14 +128,14 @@ func TestClient_Honeycombs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if us.Name != "new-test-honeycomb" {
-		t.Errorf("bad name: %q", us.Name)
+	if *us.Name != "new-test-honeycomb" {
+		t.Errorf("bad name: %q", *us.Name)
 	}
-	if us.Token != "new-token" {
-		t.Errorf("bad token: %q", us.Token)
+	if *us.Token != "new-token" {
+		t.Errorf("bad token: %q", *us.Token)
 	}
-	if us.Dataset != "newDataset" {
-		t.Errorf("bad dataset: %q", us.Dataset)
+	if *us.Dataset != "newDataset" {
+		t.Errorf("bad dataset: %q", *us.Dataset)
 	}
 
 	// Delete

--- a/fastly/http3.go
+++ b/fastly/http3.go
@@ -9,9 +9,9 @@ import (
 type HTTP3 struct {
 	CreatedAt       *time.Time `mapstructure:"created_at" json:"created_at"`
 	DeletedAt       *time.Time `mapstructure:"deleted_at" json:"deleted_at"`
-	FeatureRevision int        `mapstructure:"feature_revision" json:"feature_revision"`
-	ServiceID       string     `mapstructure:"service_id" json:"service_id"`
-	ServiceVersion  int        `mapstructure:"version" json:"version"`
+	FeatureRevision *int       `mapstructure:"feature_revision" json:"feature_revision"`
+	ServiceID       *string    `mapstructure:"service_id" json:"service_id"`
+	ServiceVersion  *int       `mapstructure:"version" json:"version"`
 	UpdatedAt       *time.Time `mapstructure:"updated_at" json:"updated_at"`
 }
 

--- a/fastly/http3_test.go
+++ b/fastly/http3_test.go
@@ -26,8 +26,8 @@ func TestClient_HTTP3(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if h.FeatureRevision != 1 {
-		t.Errorf("bad feature_revision: %d", h.FeatureRevision)
+	if *h.FeatureRevision != 1 {
+		t.Errorf("bad feature_revision: %d", *h.FeatureRevision)
 	}
 
 	// Get HTTP3 status
@@ -42,8 +42,8 @@ func TestClient_HTTP3(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if gh.FeatureRevision != 1 {
-		t.Errorf("bad feature_revision: %d", gh.FeatureRevision)
+	if *gh.FeatureRevision != 1 {
+		t.Errorf("bad feature_revision: %d", *gh.FeatureRevision)
 	}
 
 	// Disable HTTP3

--- a/fastly/http3_test.go
+++ b/fastly/http3_test.go
@@ -19,7 +19,7 @@ func TestClient_HTTP3(t *testing.T) {
 		h, err = c.EnableHTTP3(&EnableHTTP3Input{
 			FeatureRevision: ToPointer(1),
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 		})
 	})
 	if err != nil {
@@ -35,7 +35,7 @@ func TestClient_HTTP3(t *testing.T) {
 	record(t, "http3/get", func(c *Client) {
 		gh, err = c.GetHTTP3(&GetHTTP3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -50,7 +50,7 @@ func TestClient_HTTP3(t *testing.T) {
 	record(t, "http3/disable", func(c *Client) {
 		err = c.DisableHTTP3(&DisableHTTP3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -61,7 +61,7 @@ func TestClient_HTTP3(t *testing.T) {
 	record(t, "http3/get-disabled", func(c *Client) {
 		gh, err = c.GetHTTP3(&GetHTTP3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 

--- a/fastly/https.go
+++ b/fastly/https.go
@@ -3,53 +3,34 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // HTTPS represents an HTTPS Logging response from the Fastly API.
 type HTTPS struct {
-	ContentType       string     `mapstructure:"content_type"`
+	ContentType       *string    `mapstructure:"content_type"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	HeaderName        string     `mapstructure:"header_name"`
-	HeaderValue       string     `mapstructure:"header_value"`
-	JSONFormat        string     `mapstructure:"json_format"`
-	MessageType       string     `mapstructure:"message_type"`
-	Method            string     `mapstructure:"method"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	RequestMaxBytes   int        `mapstructure:"request_max_bytes"`
-	RequestMaxEntries int        `mapstructure:"request_max_entries"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TLSCACert         string     `mapstructure:"tls_ca_cert"`
-	TLSClientCert     string     `mapstructure:"tls_client_cert"`
-	TLSClientKey      string     `mapstructure:"tls_client_key"`
-	TLSHostname       string     `mapstructure:"tls_hostname"`
-	URL               string     `mapstructure:"url"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	HeaderName        *string    `mapstructure:"header_name"`
+	HeaderValue       *string    `mapstructure:"header_value"`
+	JSONFormat        *string    `mapstructure:"json_format"`
+	MessageType       *string    `mapstructure:"message_type"`
+	Method            *string    `mapstructure:"method"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	RequestMaxBytes   *int       `mapstructure:"request_max_bytes"`
+	RequestMaxEntries *int       `mapstructure:"request_max_entries"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TLSCACert         *string    `mapstructure:"tls_ca_cert"`
+	TLSClientCert     *string    `mapstructure:"tls_client_cert"`
+	TLSClientKey      *string    `mapstructure:"tls_client_key"`
+	TLSHostname       *string    `mapstructure:"tls_hostname"`
+	URL               *string    `mapstructure:"url"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// httpsByName is a sortable list of HTTPS logs.
-type httpsByName []*HTTPS
-
-// Len implement the sortable interface.
-func (s httpsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s httpsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s httpsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListHTTPSInput is used as input to the ListHTTPS function.
@@ -80,7 +61,6 @@ func (c *Client) ListHTTPS(i *ListHTTPSInput) ([]*HTTPS, error) {
 	if err := decodeBodyMap(resp.Body, &https); err != nil {
 		return nil, err
 	}
-	sort.Stable(httpsByName(https))
 	return https, nil
 }
 

--- a/fastly/https_test.go
+++ b/fastly/https_test.go
@@ -81,56 +81,56 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		})
 	}()
 
-	if h.Name != "test-https" {
-		t.Errorf("bad name: %q", h.Name)
+	if *h.Name != "test-https" {
+		t.Errorf("bad name: %q", *h.Name)
 	}
-	if h.Format != "format" {
-		t.Errorf("bad format: %q", h.Format)
+	if *h.Format != "format" {
+		t.Errorf("bad format: %q", *h.Format)
 	}
-	if h.URL != "https://example.com/" {
-		t.Errorf("bad url: %q", h.URL)
+	if *h.URL != "https://example.com/" {
+		t.Errorf("bad url: %q", *h.URL)
 	}
-	if h.RequestMaxEntries != 1 {
-		t.Errorf("bad request_max_entries: %q", h.RequestMaxEntries)
+	if *h.RequestMaxEntries != 1 {
+		t.Errorf("bad request_max_entries: %q", *h.RequestMaxEntries)
 	}
-	if h.RequestMaxBytes != 1000 {
-		t.Errorf("bad request_max_bytes: %q", h.RequestMaxBytes)
+	if *h.RequestMaxBytes != 1000 {
+		t.Errorf("bad request_max_bytes: %q", *h.RequestMaxBytes)
 	}
-	if h.ContentType != "application/json" {
-		t.Errorf("bad content_type: %q", h.ContentType)
+	if *h.ContentType != "application/json" {
+		t.Errorf("bad content_type: %q", *h.ContentType)
 	}
-	if h.HeaderName != "X-Example-Header" {
-		t.Errorf("bad header_name: %q", h.HeaderName)
+	if *h.HeaderName != "X-Example-Header" {
+		t.Errorf("bad *h.ader_name: %q", *h.HeaderName)
 	}
-	if h.HeaderValue != "ExampleValue" {
-		t.Errorf("bad header_value: %q", h.HeaderValue)
+	if *h.HeaderValue != "ExampleValue" {
+		t.Errorf("bad *h.ader_value: %q", *h.HeaderValue)
 	}
-	if h.Method != "PUT" {
-		t.Errorf("bad method: %q", h.Method)
+	if *h.Method != "PUT" {
+		t.Errorf("bad met*h.d: %q", *h.Method)
 	}
-	if h.JSONFormat != "2" {
-		t.Errorf("bad json_format: %q", h.JSONFormat)
+	if *h.JSONFormat != "2" {
+		t.Errorf("bad json_format: %q", *h.JSONFormat)
 	}
-	if h.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", h.Placement)
+	if *h.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *h.Placement)
 	}
-	if h.TLSCACert != caCert {
-		t.Errorf("bad tls_ca_cert: %q", h.TLSCACert)
+	if *h.TLSCACert != caCert {
+		t.Errorf("bad tls_ca_cert: %q", *h.TLSCACert)
 	}
-	if h.TLSHostname != "example.com" {
-		t.Errorf("bad tls_hostname: %q", h.TLSHostname)
+	if *h.TLSHostname != "example.com" {
+		t.Errorf("bad tls_*h.stname: %q", *h.TLSHostname)
 	}
-	if h.TLSClientCert != clientCert {
-		t.Errorf("bad tls_client_cert: %q", h.TLSClientCert)
+	if *h.TLSClientCert != clientCert {
+		t.Errorf("bad tls_client_cert: %q", *h.TLSClientCert)
 	}
-	if h.TLSClientKey != clientKey {
-		t.Errorf("bad tls_client_key: %q", h.TLSClientKey)
+	if *h.TLSClientKey != clientKey {
+		t.Errorf("bad tls_client_key: %q", *h.TLSClientKey)
 	}
-	if h.MessageType != "blank" {
-		t.Errorf("bad message_type: %s", h.MessageType)
+	if *h.MessageType != "blank" {
+		t.Errorf("bad message_type: %s", *h.MessageType)
 	}
-	if h.FormatVersion != 2 {
-		t.Errorf("bad format_version: %d", h.FormatVersion)
+	if *h.FormatVersion != 2 {
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 
 	// List
@@ -160,56 +160,56 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	if err != nil {
 		t.Fatal(err)
 	}
-	if h.Name != nh.Name {
-		t.Errorf("bad name: %q", h.Name)
+	if *h.Name != *nh.Name {
+		t.Errorf("bad name: %q", *h.Name)
 	}
-	if h.Format != nh.Format {
-		t.Errorf("bad format: %q", h.Format)
+	if *h.Format != *nh.Format {
+		t.Errorf("bad format: %q", *h.Format)
 	}
-	if h.URL != nh.URL {
-		t.Errorf("bad url: %q", h.URL)
+	if *h.URL != *nh.URL {
+		t.Errorf("bad url: %q", *h.URL)
 	}
-	if h.RequestMaxEntries != nh.RequestMaxEntries {
-		t.Errorf("bad request_max_entries: %q", h.RequestMaxEntries)
+	if *h.RequestMaxEntries != *nh.RequestMaxEntries {
+		t.Errorf("bad request_max_entries: %q", *h.RequestMaxEntries)
 	}
-	if h.RequestMaxBytes != nh.RequestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", h.RequestMaxBytes)
+	if *h.RequestMaxBytes != *nh.RequestMaxBytes {
+		t.Errorf("bad request_max_bytes: %q", *h.RequestMaxBytes)
 	}
-	if h.ContentType != nh.ContentType {
-		t.Errorf("bad content_type: %q", h.ContentType)
+	if *h.ContentType != *nh.ContentType {
+		t.Errorf("bad content_type: %q", *h.ContentType)
 	}
-	if h.HeaderName != nh.HeaderName {
-		t.Errorf("bad header_name: %q", h.HeaderName)
+	if *h.HeaderName != *nh.HeaderName {
+		t.Errorf("bad *h.ader_name: %q", *h.HeaderName)
 	}
-	if h.HeaderValue != nh.HeaderValue {
-		t.Errorf("bad header_value: %q", h.HeaderValue)
+	if *h.HeaderValue != *nh.HeaderValue {
+		t.Errorf("bad *h.ader_value: %q", *h.HeaderValue)
 	}
-	if h.Method != nh.Method {
-		t.Errorf("bad method: %q", h.Method)
+	if *h.Method != *nh.Method {
+		t.Errorf("bad met*h.d: %q", *h.Method)
 	}
-	if h.JSONFormat != nh.JSONFormat {
-		t.Errorf("bad json_format: %q", h.JSONFormat)
+	if *h.JSONFormat != *nh.JSONFormat {
+		t.Errorf("bad json_format: %q", *h.JSONFormat)
 	}
-	if h.Placement != nh.Placement {
-		t.Errorf("bad placement: %q", h.Placement)
+	if *h.Placement != *nh.Placement {
+		t.Errorf("bad placement: %q", *h.Placement)
 	}
-	if h.TLSCACert != nh.TLSCACert {
-		t.Errorf("bad tls_ca_cert: %q", h.TLSCACert)
+	if *h.TLSCACert != *nh.TLSCACert {
+		t.Errorf("bad tls_ca_cert: %q", *h.TLSCACert)
 	}
-	if h.TLSHostname != nh.TLSHostname {
-		t.Errorf("bad tls_hostname: %q", h.TLSHostname)
+	if *h.TLSHostname != *nh.TLSHostname {
+		t.Errorf("bad tls_*h.stname: %q", *h.TLSHostname)
 	}
-	if h.TLSClientCert != nh.TLSClientCert {
-		t.Errorf("bad tls_client_cert: %q", h.TLSClientCert)
+	if *h.TLSClientCert != *nh.TLSClientCert {
+		t.Errorf("bad tls_client_cert: %q", *h.TLSClientCert)
 	}
-	if h.TLSClientKey != nh.TLSClientKey {
-		t.Errorf("bad tls_client_key: %q", h.TLSClientKey)
+	if *h.TLSClientKey != *nh.TLSClientKey {
+		t.Errorf("bad tls_client_key: %q", *h.TLSClientKey)
 	}
-	if h.MessageType != nh.MessageType {
-		t.Errorf("bad message_type: %s", h.MessageType)
+	if *h.MessageType != *nh.MessageType {
+		t.Errorf("bad message_type: %s", *h.MessageType)
 	}
-	if h.FormatVersion != nh.FormatVersion {
-		t.Errorf("bad format_version: %d", h.FormatVersion)
+	if *h.FormatVersion != *nh.FormatVersion {
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 
 	// Update
@@ -226,11 +226,11 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uh.Name != "new-test-https" {
-		t.Errorf("bad name: %q", uh.Name)
+	if *uh.Name != "new-test-https" {
+		t.Errorf("bad name: %q", *uh.Name)
 	}
-	if uh.Method != "POST" {
-		t.Errorf("bad method: %q", uh.Method)
+	if *uh.Method != "POST" {
+		t.Errorf("bad method: %q", *uh.Method)
 	}
 
 	// Delete

--- a/fastly/https_test.go
+++ b/fastly/https_test.go
@@ -39,7 +39,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "https/create", func(c *Client) {
 		h, err = c.CreateHTTPS(&CreateHTTPSInput{
 			ServiceID:         testServiceID,
-			ServiceVersion:    tv.Number,
+			ServiceVersion:    *tv.Number,
 			Name:              ToPointer("test-https"),
 			Format:            ToPointer("format"),
 			URL:               ToPointer("https://example.com/"),
@@ -68,14 +68,14 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		record(t, "https/cleanup", func(c *Client) {
 			_ = c.DeleteHTTPS(&DeleteHTTPSInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-https",
 			})
 
 			// ensure that renamed endpoint created in Update test is deleted
 			_ = c.DeleteHTTPS(&DeleteHTTPSInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-https",
 			})
 		})
@@ -138,7 +138,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "https/list", func(c *Client) {
 		hs, err = c.ListHTTPS(&ListHTTPSInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -153,7 +153,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "https/get", func(c *Client) {
 		nh, err = c.GetHTTPS(&GetHTTPSInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-https",
 		})
 	})
@@ -217,7 +217,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "https/update", func(c *Client) {
 		uh, err = c.UpdateHTTPS(&UpdateHTTPSInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-https",
 			NewName:        ToPointer("new-test-https"),
 			Method:         ToPointer("POST"),
@@ -237,7 +237,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "https/delete", func(c *Client) {
 		err = c.DeleteHTTPS(&DeleteHTTPSInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-https",
 		})
 	})

--- a/fastly/ip.go
+++ b/fastly/ip.go
@@ -1,6 +1,6 @@
 package fastly
 
-// IPAddrs is a sortable list of IP addresses returned by the Fastly API.
+// IPAddrs is a list of IP addresses returned by the Fastly API.
 type IPAddrs []string
 
 // AllIPs returns the lists of public IPv4 and IPv6 addresses for Fastly's network.

--- a/fastly/kafka.go
+++ b/fastly/kafka.go
@@ -3,54 +3,35 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Kafka represents a kafka response from the Fastly API.
 type Kafka struct {
-	AuthMethod        string     `mapstructure:"auth_method"`
-	Brokers           string     `mapstructure:"brokers"`
-	CompressionCodec  string     `mapstructure:"compression_codec"`
+	AuthMethod        *string    `mapstructure:"auth_method"`
+	Brokers           *string    `mapstructure:"brokers"`
+	CompressionCodec  *string    `mapstructure:"compression_codec"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	ParseLogKeyvals   bool       `mapstructure:"parse_log_keyvals"`
-	Password          string     `mapstructure:"password"`
-	Placement         string     `mapstructure:"placement"`
-	RequestMaxBytes   int        `mapstructure:"request_max_bytes"`
-	RequiredACKs      string     `mapstructure:"required_acks"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TLSCACert         string     `mapstructure:"tls_ca_cert"`
-	TLSClientCert     string     `mapstructure:"tls_client_cert"`
-	TLSClientKey      string     `mapstructure:"tls_client_key"`
-	TLSHostname       string     `mapstructure:"tls_hostname"`
-	Topic             string     `mapstructure:"topic"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	ParseLogKeyvals   *bool      `mapstructure:"parse_log_keyvals"`
+	Password          *string    `mapstructure:"password"`
+	Placement         *string    `mapstructure:"placement"`
+	RequestMaxBytes   *int       `mapstructure:"request_max_bytes"`
+	RequiredACKs      *string    `mapstructure:"required_acks"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TLSCACert         *string    `mapstructure:"tls_ca_cert"`
+	TLSClientCert     *string    `mapstructure:"tls_client_cert"`
+	TLSClientKey      *string    `mapstructure:"tls_client_key"`
+	TLSHostname       *string    `mapstructure:"tls_hostname"`
+	Topic             *string    `mapstructure:"topic"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	UseTLS            bool       `mapstructure:"use_tls"`
-	User              string     `mapstructure:"user"`
-}
-
-// kafkaByName is a sortable list of kafkas.
-type kafkasByName []*Kafka
-
-// Len implements the sortable interface.
-func (s kafkasByName) Len() int {
-	return len(s)
-}
-
-// Swap implements the sortable interface.
-func (s kafkasByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implements the sortable interface.
-func (s kafkasByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	UseTLS            *bool      `mapstructure:"use_tls"`
+	User              *string    `mapstructure:"user"`
 }
 
 // ListKafkasInput is used as input to the ListKafkas function.
@@ -81,7 +62,6 @@ func (c *Client) ListKafkas(i *ListKafkasInput) ([]*Kafka, error) {
 	if err := decodeBodyMap(resp.Body, &k); err != nil {
 		return nil, err
 	}
-	sort.Stable(kafkasByName(k))
 	return k, nil
 }
 

--- a/fastly/kafka_test.go
+++ b/fastly/kafka_test.go
@@ -36,7 +36,7 @@ func TestClient_Kafkas(t *testing.T) {
 			RequestMaxBytes:  ToPointer(requestMaxBytes),
 			RequiredACKs:     ToPointer("-1"),
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			TLSCACert:        ToPointer(caCert),
 			TLSClientCert:    ToPointer(clientCert),
 			TLSClientKey:     ToPointer(clientKey),
@@ -55,13 +55,13 @@ func TestClient_Kafkas(t *testing.T) {
 		record(t, "kafkas/cleanup", func(c *Client) {
 			_ = c.DeleteKafka(&DeleteKafkaInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-kafka",
 			})
 
 			_ = c.DeleteKafka(&DeleteKafkaInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-kafka",
 			})
 		})
@@ -127,7 +127,7 @@ func TestClient_Kafkas(t *testing.T) {
 	record(t, "kafkas/list", func(c *Client) {
 		ks, err = c.ListKafkas(&ListKafkasInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -142,7 +142,7 @@ func TestClient_Kafkas(t *testing.T) {
 	record(t, "kafkas/get", func(c *Client) {
 		nk, err = c.GetKafka(&GetKafkaInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-kafka",
 		})
 	})
@@ -209,7 +209,7 @@ func TestClient_Kafkas(t *testing.T) {
 	record(t, "kafkas/update", func(c *Client) {
 		uk, err = c.UpdateKafka(&UpdateKafkaInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-kafka",
 			NewName:        ToPointer("new-test-kafka"),
 			Topic:          ToPointer("new-kafka-topic"),
@@ -229,7 +229,7 @@ func TestClient_Kafkas(t *testing.T) {
 	record(t, "kafkas/delete", func(c *Client) {
 		err = c.DeleteKafka(&DeleteKafkaInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-kafka",
 		})
 	})

--- a/fastly/kafka_test.go
+++ b/fastly/kafka_test.go
@@ -67,59 +67,59 @@ func TestClient_Kafkas(t *testing.T) {
 		})
 	}()
 
-	if k.Name != "test-kafka" {
-		t.Errorf("bad name: %q", k.Name)
+	if *k.Name != "test-kafka" {
+		t.Errorf("bad name: %q", *k.Name)
 	}
-	if k.Brokers != "192.168.1.1,192.168.1.2" {
-		t.Errorf("bad url: %q", k.Brokers)
+	if *k.Brokers != "192.168.1.1,192.168.1.2" {
+		t.Errorf("bad url: %q", *k.Brokers)
 	}
-	if k.Topic != "kafka-topic" {
-		t.Errorf("bad topic: %q", k.Topic)
+	if *k.Topic != "kafka-topic" {
+		t.Errorf("bad topic: %q", *k.Topic)
 	}
-	if k.RequiredACKs != "-1" {
-		t.Errorf("bad required_acks: %q", k.RequiredACKs)
+	if *k.RequiredACKs != "-1" {
+		t.Errorf("bad required_acks: %q", *k.RequiredACKs)
 	}
-	if !k.UseTLS {
-		t.Errorf("bad use_tls: %t", k.UseTLS)
+	if !*k.UseTLS {
+		t.Errorf("bad use_tls: %t", *k.UseTLS)
 	}
-	if k.CompressionCodec != "lz4" {
-		t.Errorf("bad compression_codec: %q", k.CompressionCodec)
+	if *k.CompressionCodec != "lz4" {
+		t.Errorf("bad compression_codec: %q", *k.CompressionCodec)
 	}
-	if k.Format != "%h %l %u %t \"%r\" %>s %b" {
-		t.Errorf("bad format: %q", k.Format)
+	if *k.Format != "%h %l %u %t \"%r\" %>s %b" {
+		t.Errorf("bad format: %q", *k.Format)
 	}
-	if k.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", k.FormatVersion)
+	if *k.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *k.FormatVersion)
 	}
-	if k.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", k.Placement)
+	if *k.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *k.Placement)
 	}
-	if k.TLSCACert != caCert {
-		t.Errorf("bad tls_ca_cert: %q", k.TLSCACert)
+	if *k.TLSCACert != caCert {
+		t.Errorf("bad tls_ca_cert: %q", *k.TLSCACert)
 	}
-	if k.TLSHostname != "example.com" {
-		t.Errorf("bad tls_hostname: %q", k.TLSHostname)
+	if *k.TLSHostname != "example.com" {
+		t.Errorf("bad tls_hostname: %q", *k.TLSHostname)
 	}
-	if k.TLSClientCert != clientCert {
-		t.Errorf("bad tls_client_cert: %q", k.TLSClientCert)
+	if *k.TLSClientCert != clientCert {
+		t.Errorf("bad tls_client_cert: %q", *k.TLSClientCert)
 	}
-	if k.TLSClientKey != clientKey {
-		t.Errorf("bad tls_client_key: %q", k.TLSClientKey)
+	if *k.TLSClientKey != clientKey {
+		t.Errorf("bad tls_client_key: %q", *k.TLSClientKey)
 	}
-	if !k.ParseLogKeyvals {
-		t.Errorf("bad parse_log_keyvals: %t", k.ParseLogKeyvals)
+	if !*k.ParseLogKeyvals {
+		t.Errorf("bad parse_log_keyvals: %t", *k.ParseLogKeyvals)
 	}
-	if k.RequestMaxBytes != requestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", k.RequestMaxBytes)
+	if *k.RequestMaxBytes != requestMaxBytes {
+		t.Errorf("bad request_max_bytes: %q", *k.RequestMaxBytes)
 	}
-	if k.AuthMethod != "scram-sha-512" {
-		t.Errorf("bad auth_method: %q", k.AuthMethod)
+	if *k.AuthMethod != "scram-sha-512" {
+		t.Errorf("bad auth_method: %q", *k.AuthMethod)
 	}
-	if k.User != "foobar" {
-		t.Errorf("bad user: %q", k.User)
+	if *k.User != "foobar" {
+		t.Errorf("bad user: %q", *k.User)
 	}
-	if k.Password != "deadbeef" {
-		t.Errorf("bad password: %q", k.Password)
+	if *k.Password != "deadbeef" {
+		t.Errorf("bad password: %q", *k.Password)
 	}
 
 	// List
@@ -149,59 +149,59 @@ func TestClient_Kafkas(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if k.Name != nk.Name {
-		t.Errorf("bad name: %q", k.Name)
+	if *k.Name != *nk.Name {
+		t.Errorf("bad name: %q", *k.Name)
 	}
-	if k.Brokers != nk.Brokers {
-		t.Errorf("bad url: %q", k.Brokers)
+	if *k.Brokers != *nk.Brokers {
+		t.Errorf("bad url: %q", *k.Brokers)
 	}
-	if k.Topic != nk.Topic {
-		t.Errorf("bad topic: %q", k.Topic)
+	if *k.Topic != *nk.Topic {
+		t.Errorf("bad topic: %q", *k.Topic)
 	}
-	if k.RequiredACKs != nk.RequiredACKs {
-		t.Errorf("bad required_acks: %q", k.RequiredACKs)
+	if *k.RequiredACKs != *nk.RequiredACKs {
+		t.Errorf("bad required_acks: %q", *k.RequiredACKs)
 	}
-	if k.UseTLS != nk.UseTLS {
-		t.Errorf("bad use_tls: %t", k.UseTLS)
+	if *k.UseTLS != *nk.UseTLS {
+		t.Errorf("bad use_tls: %t", *k.UseTLS)
 	}
-	if k.CompressionCodec != nk.CompressionCodec {
-		t.Errorf("bad compression_codec: %q", k.CompressionCodec)
+	if *k.CompressionCodec != *nk.CompressionCodec {
+		t.Errorf("bad compression_codec: %q", *k.CompressionCodec)
 	}
-	if k.Format != nk.Format {
-		t.Errorf("bad format: %q", k.Format)
+	if *k.Format != *nk.Format {
+		t.Errorf("bad format: %q", *k.Format)
 	}
-	if k.FormatVersion != nk.FormatVersion {
-		t.Errorf("bad format_version: %q", k.FormatVersion)
+	if *k.FormatVersion != *nk.FormatVersion {
+		t.Errorf("bad format_version: %q", *k.FormatVersion)
 	}
-	if k.Placement != nk.Placement {
-		t.Errorf("bad placement: %q", k.Placement)
+	if *k.Placement != *nk.Placement {
+		t.Errorf("bad placement: %q", *k.Placement)
 	}
-	if k.TLSCACert != nk.TLSCACert {
-		t.Errorf("bad tls_ca_cert: %q", k.TLSCACert)
+	if *k.TLSCACert != *nk.TLSCACert {
+		t.Errorf("bad tls_ca_cert: %q", *k.TLSCACert)
 	}
-	if k.TLSHostname != nk.TLSHostname {
-		t.Errorf("bad tls_hostname: %q", k.TLSHostname)
+	if *k.TLSHostname != *nk.TLSHostname {
+		t.Errorf("bad tls_hostname: %q", *k.TLSHostname)
 	}
-	if k.TLSClientCert != nk.TLSClientCert {
-		t.Errorf("bad tls_client_cert: %q", k.TLSClientCert)
+	if *k.TLSClientCert != *nk.TLSClientCert {
+		t.Errorf("bad tls_client_cert: %q", *k.TLSClientCert)
 	}
-	if k.TLSClientKey != nk.TLSClientKey {
-		t.Errorf("bad tls_client_key: %q", k.TLSClientKey)
+	if *k.TLSClientKey != *nk.TLSClientKey {
+		t.Errorf("bad tls_client_key: %q", *k.TLSClientKey)
 	}
-	if !k.ParseLogKeyvals {
-		t.Errorf("bad parse_log_keyvals: %t", k.ParseLogKeyvals)
+	if !*k.ParseLogKeyvals {
+		t.Errorf("bad parse_log_keyvals: %t", *k.ParseLogKeyvals)
 	}
-	if k.RequestMaxBytes != requestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", k.RequestMaxBytes)
+	if *k.RequestMaxBytes != requestMaxBytes {
+		t.Errorf("bad request_max_bytes: %q", *k.RequestMaxBytes)
 	}
-	if k.AuthMethod != "scram-sha-512" {
-		t.Errorf("bad auth_method: %q", k.AuthMethod)
+	if *k.AuthMethod != "scram-sha-512" {
+		t.Errorf("bad auth_method: %q", *k.AuthMethod)
 	}
-	if k.User != "foobar" {
-		t.Errorf("bad user: %q", k.User)
+	if *k.User != "foobar" {
+		t.Errorf("bad user: %q", *k.User)
 	}
-	if k.Password != "deadbeef" {
-		t.Errorf("bad password: %q", k.Password)
+	if *k.Password != "deadbeef" {
+		t.Errorf("bad password: %q", *k.Password)
 	}
 
 	// Update
@@ -218,11 +218,11 @@ func TestClient_Kafkas(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uk.Name != "new-test-kafka" {
-		t.Errorf("bad name: %q", uk.Name)
+	if *uk.Name != "new-test-kafka" {
+		t.Errorf("bad name: %q", *uk.Name)
 	}
-	if uk.Topic != "new-kafka-topic" {
-		t.Errorf("bad topic: %q", uk.Topic)
+	if *uk.Topic != "new-kafka-topic" {
+		t.Errorf("bad topic: %q", *uk.Topic)
 	}
 
 	// Delete

--- a/fastly/kinesis.go
+++ b/fastly/kinesis.go
@@ -3,45 +3,26 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Kinesis represents a Kinesis response from the Fastly API.
 type Kinesis struct {
-	AccessKey         string     `mapstructure:"access_key"`
+	AccessKey         *string    `mapstructure:"access_key"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	IAMRole           string     `mapstructure:"iam_role"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	Region            string     `mapstructure:"region"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	SecretKey         string     `mapstructure:"secret_key"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	StreamName        string     `mapstructure:"topic"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	IAMRole           *string    `mapstructure:"iam_role"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	Region            *string    `mapstructure:"region"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	SecretKey         *string    `mapstructure:"secret_key"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	StreamName        *string    `mapstructure:"topic"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// kinesisByName is a sortable list of Kinesis.
-type kinesisByName []*Kinesis
-
-// Len implement the sortable interface.
-func (s kinesisByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s kinesisByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s kinesisByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListKinesisInput is used as input to the ListKinesis function.
@@ -72,7 +53,6 @@ func (c *Client) ListKinesis(i *ListKinesisInput) ([]*Kinesis, error) {
 	if err := decodeBodyMap(resp.Body, &kineses); err != nil {
 		return nil, err
 	}
-	sort.Stable(kinesisByName(kineses))
 	return kineses, nil
 }
 

--- a/fastly/kinesis_test.go
+++ b/fastly/kinesis_test.go
@@ -20,7 +20,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/create", func(c *Client) {
 		kinesisCreateResp1, err = c.CreateKinesis(&CreateKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           ToPointer("test-kinesis"),
 			StreamName:     ToPointer("stream-name"),
 			Region:         ToPointer("us-east-1"),
@@ -38,7 +38,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/create2", func(c *Client) {
 		kinesisCreateResp2, err = c.CreateKinesis(&CreateKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           ToPointer("test-kinesis-2"),
 			StreamName:     ToPointer("stream-name"),
 			Region:         ToPointer("us-east-1"),
@@ -56,7 +56,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/create3", func(c *Client) {
 		_, err = c.CreateKinesis(&CreateKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           ToPointer("test-kinesis-3"),
 			StreamName:     ToPointer("stream-name"),
 			Region:         ToPointer("us-east-1"),
@@ -76,7 +76,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/create4", func(c *Client) {
 		_, err = c.CreateKinesis(&CreateKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           ToPointer("test-kinesis-3"),
 			StreamName:     ToPointer("stream-name"),
 			Region:         ToPointer("us-east-1"),
@@ -95,19 +95,19 @@ func TestClient_Kinesis(t *testing.T) {
 		record(t, "kinesis/cleanup", func(c *Client) {
 			c.DeleteKinesis(&DeleteKinesisInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: v.Number,
+				ServiceVersion: *v.Number,
 				Name:           "test-kinesis",
 			})
 
 			c.DeleteKinesis(&DeleteKinesisInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: v.Number,
+				ServiceVersion: *v.Number,
 				Name:           "test-kinesis-2",
 			})
 
 			c.DeleteKinesis(&DeleteKinesisInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: v.Number,
+				ServiceVersion: *v.Number,
 				Name:           "new-test-kinesis",
 			})
 		})
@@ -158,7 +158,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/list", func(c *Client) {
 		kineses, err = c.ListKinesis(&ListKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 		})
 	})
 	if err != nil {
@@ -173,7 +173,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/get", func(c *Client) {
 		kinesisGetResp, err = c.GetKinesis(&GetKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           "test-kinesis",
 		})
 	})
@@ -184,7 +184,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/get2", func(c *Client) {
 		kinesisGetResp2, err = c.GetKinesis(&GetKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           "test-kinesis-2",
 		})
 	})
@@ -243,7 +243,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/update", func(c *Client) {
 		kinesisUpdateResp1, err = c.UpdateKinesis(&UpdateKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           "test-kinesis",
 			NewName:        ToPointer("new-test-kinesis"),
 		})
@@ -257,7 +257,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/update2", func(c *Client) {
 		kinesisUpdateResp2, err = c.UpdateKinesis(&UpdateKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           "new-test-kinesis",
 			AccessKey:      ToPointer(""),
 			SecretKey:      ToPointer(""),
@@ -273,7 +273,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/update3", func(c *Client) {
 		kinesisUpdateResp3, err = c.UpdateKinesis(&UpdateKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           "test-kinesis-2",
 			AccessKey:      ToPointer("AKIAIOSFODNN7EXAMPLE"),
 			SecretKey:      ToPointer("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
@@ -289,7 +289,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/update4", func(c *Client) {
 		_, err = c.UpdateKinesis(&UpdateKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           "test-kinesis",
 			IAMRole:        ToPointer("badarn"),
 		})
@@ -324,7 +324,7 @@ func TestClient_Kinesis(t *testing.T) {
 	record(t, "kinesis/delete", func(c *Client) {
 		err = c.DeleteKinesis(&DeleteKinesisInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Name:           "new-test-kinesis",
 		})
 	})

--- a/fastly/kinesis_test.go
+++ b/fastly/kinesis_test.go
@@ -113,44 +113,44 @@ func TestClient_Kinesis(t *testing.T) {
 		})
 	}()
 
-	if kinesisCreateResp1.Name != "test-kinesis" {
-		t.Errorf("bad name: %q", kinesisCreateResp1.Name)
+	if *kinesisCreateResp1.Name != "test-kinesis" {
+		t.Errorf("bad name: %q", *kinesisCreateResp1.Name)
 	}
-	if kinesisCreateResp1.StreamName != "stream-name" {
-		t.Errorf("bad bucket_name: %q", kinesisCreateResp1.StreamName)
+	if *kinesisCreateResp1.StreamName != "stream-name" {
+		t.Errorf("bad bucket_name: %q", *kinesisCreateResp1.StreamName)
 	}
-	if kinesisCreateResp1.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
-		t.Errorf("bad access_key: %q", kinesisCreateResp1.AccessKey)
+	if *kinesisCreateResp1.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("bad access_key: %q", *kinesisCreateResp1.AccessKey)
 	}
-	if kinesisCreateResp1.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
-		t.Errorf("bad secret_key: %q", kinesisCreateResp1.SecretKey)
+	if *kinesisCreateResp1.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Errorf("bad secret_key: %q", *kinesisCreateResp1.SecretKey)
 	}
-	if kinesisCreateResp1.IAMRole != "" {
-		t.Errorf("bad iam_role: %q", kinesisCreateResp1.IAMRole)
+	if kinesisCreateResp1.IAMRole != nil {
+		t.Errorf("bad iam_role: %q", *kinesisCreateResp1.IAMRole)
 	}
-	if kinesisCreateResp1.Region != "us-east-1" {
-		t.Errorf("bad domain: %q", kinesisCreateResp1.Region)
+	if *kinesisCreateResp1.Region != "us-east-1" {
+		t.Errorf("bad domain: %q", *kinesisCreateResp1.Region)
 	}
-	if kinesisCreateResp1.Format != "format" {
-		t.Errorf("bad format: %q", kinesisCreateResp1.Format)
+	if *kinesisCreateResp1.Format != "format" {
+		t.Errorf("bad format: %q", *kinesisCreateResp1.Format)
 	}
-	if kinesisCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", kinesisCreateResp1.FormatVersion)
+	if *kinesisCreateResp1.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *kinesisCreateResp1.FormatVersion)
 	}
-	if kinesisCreateResp1.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", kinesisCreateResp1.Placement)
+	if *kinesisCreateResp1.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *kinesisCreateResp1.Placement)
 	}
-	if kinesisCreateResp1.ResponseCondition != "" {
-		t.Errorf("bad response_condition: %q", kinesisCreateResp1.ResponseCondition)
+	if *kinesisCreateResp1.ResponseCondition != "" {
+		t.Errorf("bad response_condition: %q", *kinesisCreateResp1.ResponseCondition)
 	}
-	if kinesisCreateResp2.AccessKey != "" {
-		t.Errorf("bad access_key: %q", kinesisCreateResp2.AccessKey)
+	if kinesisCreateResp2.AccessKey != nil {
+		t.Errorf("bad access_key: %q", *kinesisCreateResp2.AccessKey)
 	}
-	if kinesisCreateResp2.SecretKey != "" {
-		t.Errorf("bad secret_key: %q", kinesisCreateResp2.SecretKey)
+	if kinesisCreateResp2.SecretKey != nil {
+		t.Errorf("bad secret_key: %q", *kinesisCreateResp2.SecretKey)
 	}
-	if kinesisCreateResp2.IAMRole != "arn:aws:iam::123456789012:role/S3Access" {
-		t.Errorf("bad iam_role: %q", kinesisCreateResp2.IAMRole)
+	if *kinesisCreateResp2.IAMRole != "arn:aws:iam::123456789012:role/S3Access" {
+		t.Errorf("bad iam_role: %q", *kinesisCreateResp2.IAMRole)
 	}
 
 	// List
@@ -192,44 +192,50 @@ func TestClient_Kinesis(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if kinesisCreateResp1.Name != kinesisGetResp.Name {
-		t.Errorf("bad name: %q", kinesisCreateResp1.Name)
+	if *kinesisCreateResp1.Name != *kinesisGetResp.Name {
+		t.Errorf("bad name: %q", *kinesisCreateResp1.Name)
 	}
-	if kinesisCreateResp1.StreamName != kinesisGetResp.StreamName {
-		t.Errorf("bad bucket_name: %q", kinesisCreateResp1.StreamName)
+	if *kinesisCreateResp1.StreamName != *kinesisGetResp.StreamName {
+		t.Errorf("bad bucket_name: %q", *kinesisCreateResp1.StreamName)
 	}
-	if kinesisCreateResp1.AccessKey != kinesisGetResp.AccessKey {
-		t.Errorf("bad access_key: %q", kinesisCreateResp1.AccessKey)
+	if *kinesisCreateResp1.AccessKey != *kinesisGetResp.AccessKey {
+		t.Errorf("bad access_key: %q", *kinesisCreateResp1.AccessKey)
 	}
-	if kinesisCreateResp1.SecretKey != kinesisGetResp.SecretKey {
-		t.Errorf("bad secret_key: %q", kinesisCreateResp1.SecretKey)
+	if *kinesisCreateResp1.SecretKey != *kinesisGetResp.SecretKey {
+		t.Errorf("bad secret_key: %q", *kinesisCreateResp1.SecretKey)
 	}
-	if kinesisCreateResp1.IAMRole != kinesisGetResp.IAMRole {
-		t.Errorf("bad iam_role: %q", kinesisCreateResp1.IAMRole)
+	if kinesisCreateResp1.IAMRole != nil && kinesisGetResp.IAMRole != nil {
+		if *kinesisCreateResp1.IAMRole != *kinesisGetResp.IAMRole {
+			t.Errorf("bad iam_role: %q", *kinesisCreateResp1.IAMRole)
+		}
 	}
-	if kinesisCreateResp1.Region != kinesisGetResp.Region {
-		t.Errorf("bad domain: %q", kinesisCreateResp1.Region)
+	if *kinesisCreateResp1.Region != *kinesisGetResp.Region {
+		t.Errorf("bad domain: %q", *kinesisCreateResp1.Region)
 	}
-	if kinesisCreateResp1.Format != kinesisGetResp.Format {
-		t.Errorf("bad format: %q", kinesisCreateResp1.Format)
+	if *kinesisCreateResp1.Format != *kinesisGetResp.Format {
+		t.Errorf("bad format: %q", *kinesisCreateResp1.Format)
 	}
-	if kinesisCreateResp1.FormatVersion != kinesisGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", kinesisCreateResp1.FormatVersion)
+	if *kinesisCreateResp1.FormatVersion != *kinesisGetResp.FormatVersion {
+		t.Errorf("bad format_version: %q", *kinesisCreateResp1.FormatVersion)
 	}
-	if kinesisCreateResp1.Placement != kinesisGetResp.Placement {
-		t.Errorf("bad placement: %q", kinesisCreateResp1.Placement)
+	if *kinesisCreateResp1.Placement != *kinesisGetResp.Placement {
+		t.Errorf("bad placement: %q", *kinesisCreateResp1.Placement)
 	}
-	if kinesisCreateResp1.ResponseCondition != "" {
-		t.Errorf("bad response_condition: %q", kinesisCreateResp1.ResponseCondition)
+	if *kinesisCreateResp1.ResponseCondition != "" {
+		t.Errorf("bad response_condition: %q", *kinesisCreateResp1.ResponseCondition)
 	}
-	if kinesisCreateResp2.AccessKey != kinesisGetResp2.AccessKey {
-		t.Errorf("bad access_key: %q", kinesisGetResp2.AccessKey)
+	if kinesisCreateResp2.AccessKey != nil && kinesisGetResp2.AccessKey != nil {
+		if *kinesisCreateResp2.AccessKey != *kinesisGetResp2.AccessKey {
+			t.Errorf("bad access_key: %q", *kinesisGetResp2.AccessKey)
+		}
 	}
-	if kinesisCreateResp2.SecretKey != kinesisGetResp2.SecretKey {
-		t.Errorf("bad secret_key: %q", kinesisGetResp2.SecretKey)
+	if kinesisCreateResp2.SecretKey != nil && kinesisGetResp2.SecretKey != nil {
+		if *kinesisCreateResp2.SecretKey != *kinesisGetResp2.SecretKey {
+			t.Errorf("bad secret_key: %q", *kinesisGetResp2.SecretKey)
+		}
 	}
-	if kinesisCreateResp2.IAMRole != kinesisGetResp2.IAMRole {
-		t.Errorf("bad iam_role: %q", kinesisGetResp2.IAMRole)
+	if *kinesisCreateResp2.IAMRole != *kinesisGetResp2.IAMRole {
+		t.Errorf("bad iam_role: %q", *kinesisGetResp2.IAMRole)
 	}
 
 	// Update
@@ -292,26 +298,26 @@ func TestClient_Kinesis(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if kinesisUpdateResp1.Name != "new-test-kinesis" {
-		t.Errorf("bad name: %q", kinesisUpdateResp1.Name)
+	if *kinesisUpdateResp1.Name != "new-test-kinesis" {
+		t.Errorf("bad name: %q", *kinesisUpdateResp1.Name)
 	}
-	if kinesisUpdateResp2.AccessKey != "" {
-		t.Errorf("bad access_key: %q", kinesisUpdateResp2.AccessKey)
+	if *kinesisUpdateResp2.AccessKey != "" {
+		t.Errorf("bad access_key: %q", *kinesisUpdateResp2.AccessKey)
 	}
-	if kinesisUpdateResp2.SecretKey != "" {
-		t.Errorf("bad secret_key: %q", kinesisUpdateResp2.SecretKey)
+	if *kinesisUpdateResp2.SecretKey != "" {
+		t.Errorf("bad secret_key: %q", *kinesisUpdateResp2.SecretKey)
 	}
-	if kinesisUpdateResp2.IAMRole != "arn:aws:iam::123456789012:role/S3Access" {
-		t.Errorf("bad iam_role: %q", kinesisUpdateResp2.IAMRole)
+	if *kinesisUpdateResp2.IAMRole != "arn:aws:iam::123456789012:role/S3Access" {
+		t.Errorf("bad iam_role: %q", *kinesisUpdateResp2.IAMRole)
 	}
-	if kinesisUpdateResp3.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
-		t.Errorf("bad access_key: %q", kinesisUpdateResp3.AccessKey)
+	if *kinesisUpdateResp3.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("bad access_key: %q", *kinesisUpdateResp3.AccessKey)
 	}
-	if kinesisUpdateResp3.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
-		t.Errorf("bad secret_key: %q", kinesisUpdateResp3.SecretKey)
+	if *kinesisUpdateResp3.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Errorf("bad secret_key: %q", *kinesisUpdateResp3.SecretKey)
 	}
-	if kinesisUpdateResp3.IAMRole != "" {
-		t.Errorf("bad iam_role: %q", kinesisUpdateResp3.IAMRole)
+	if *kinesisUpdateResp3.IAMRole != "" {
+		t.Errorf("bad iam_role: %q", *kinesisUpdateResp3.IAMRole)
 	}
 
 	// Delete

--- a/fastly/logentries.go
+++ b/fastly/logentries.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,36 +10,18 @@ import (
 type Logentries struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	Port              int        `mapstructure:"port"`
-	Region            string     `mapstructure:"region"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	Token             string     `mapstructure:"token"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	Port              *int       `mapstructure:"port"`
+	Region            *string    `mapstructure:"region"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	Token             *string    `mapstructure:"token"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	UseTLS            bool       `mapstructure:"use_tls"`
-}
-
-// logentriesByName is a sortable list of logentries.
-type logentriesByName []*Logentries
-
-// Len implements the sortable interface.
-func (s logentriesByName) Len() int {
-	return len(s)
-}
-
-// Swap implements the sortable interface.
-func (s logentriesByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implements the sortable interface.
-func (s logentriesByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	UseTLS            *bool      `mapstructure:"use_tls"`
 }
 
 // ListLogentriesInput is used as input to the ListLogentries function.
@@ -71,7 +52,6 @@ func (c *Client) ListLogentries(i *ListLogentriesInput) ([]*Logentries, error) {
 	if err := decodeBodyMap(resp.Body, &ls); err != nil {
 		return nil, err
 	}
-	sort.Stable(logentriesByName(ls))
 	return ls, nil
 }
 

--- a/fastly/logentries_test.go
+++ b/fastly/logentries_test.go
@@ -18,7 +18,7 @@ func TestClient_Logentries(t *testing.T) {
 	record(t, "logentries/create", func(c *Client) {
 		le, err = c.CreateLogentries(&CreateLogentriesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-logentries"),
 			Port:           ToPointer(0),
 			UseTLS:         ToPointer(Compatibool(true)),
@@ -37,13 +37,13 @@ func TestClient_Logentries(t *testing.T) {
 		record(t, "logentries/delete", func(c *Client) {
 			_ = c.DeleteLogentries(&DeleteLogentriesInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-logentries",
 			})
 
 			_ = c.DeleteLogentries(&DeleteLogentriesInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-logentries",
 			})
 		})
@@ -79,7 +79,7 @@ func TestClient_Logentries(t *testing.T) {
 	record(t, "logentries/list", func(c *Client) {
 		les, err = c.ListLogentries(&ListLogentriesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -94,7 +94,7 @@ func TestClient_Logentries(t *testing.T) {
 	record(t, "logentries/get", func(c *Client) {
 		nle, err = c.GetLogentries(&GetLogentriesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-logentries",
 		})
 	})
@@ -128,7 +128,7 @@ func TestClient_Logentries(t *testing.T) {
 	record(t, "logentries/update", func(c *Client) {
 		ule, err = c.UpdateLogentries(&UpdateLogentriesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-logentries",
 			NewName:        ToPointer("new-test-logentries"),
 			FormatVersion:  ToPointer(2),
@@ -152,7 +152,7 @@ func TestClient_Logentries(t *testing.T) {
 	record(t, "logentries/delete", func(c *Client) {
 		err = c.DeleteLogentries(&DeleteLogentriesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-logentries",
 		})
 	})

--- a/fastly/logentries_test.go
+++ b/fastly/logentries_test.go
@@ -49,29 +49,29 @@ func TestClient_Logentries(t *testing.T) {
 		})
 	}()
 
-	if le.Name != "test-logentries" {
-		t.Errorf("bad name: %q", le.Name)
+	if *le.Name != "test-logentries" {
+		t.Errorf("bad name: %q", *le.Name)
 	}
-	if le.Port != 0 {
-		t.Errorf("bad port: %q", le.Port)
+	if *le.Port != 0 {
+		t.Errorf("bad port: %q", *le.Port)
 	}
-	if !le.UseTLS {
-		t.Errorf("bad use_tls: %t", le.UseTLS)
+	if !*le.UseTLS {
+		t.Errorf("bad use_tls: %t", *le.UseTLS)
 	}
-	if le.Token != "abcd1234" {
-		t.Errorf("bad token: %q", le.Token)
+	if *le.Token != "abcd1234" {
+		t.Errorf("bad token: %q", *le.Token)
 	}
-	if le.Format != "format" {
-		t.Errorf("bad format: %q", le.Format)
+	if *le.Format != "format" {
+		t.Errorf("bad format: %q", *le.Format)
 	}
-	if le.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", le.FormatVersion)
+	if *le.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *le.FormatVersion)
 	}
-	if le.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", le.Placement)
+	if *le.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *le.Placement)
 	}
-	if le.Region != "us" {
-		t.Errorf("bad region: %q", le.Region)
+	if *le.Region != "us" {
+		t.Errorf("bad region: %q", *le.Region)
 	}
 
 	// List
@@ -101,26 +101,26 @@ func TestClient_Logentries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if le.Name != nle.Name {
-		t.Errorf("bad name: %q", le.Name)
+	if *le.Name != *nle.Name {
+		t.Errorf("bad name: %q", *le.Name)
 	}
-	if le.Port != nle.Port {
-		t.Errorf("bad port: %q", le.Port)
+	if *le.Port != *nle.Port {
+		t.Errorf("bad port: %q", *le.Port)
 	}
-	if le.UseTLS != nle.UseTLS {
-		t.Errorf("bad use_tls: %t", le.UseTLS)
+	if *le.UseTLS != *nle.UseTLS {
+		t.Errorf("bad use_tls: %t", *le.UseTLS)
 	}
-	if le.Token != nle.Token {
-		t.Errorf("bad token: %q", le.Token)
+	if *le.Token != *nle.Token {
+		t.Errorf("bad token: %q", *le.Token)
 	}
-	if le.Format != nle.Format {
-		t.Errorf("bad format: %q", le.Format)
+	if *le.Format != *nle.Format {
+		t.Errorf("bad format: %q", *le.Format)
 	}
-	if le.FormatVersion != nle.FormatVersion {
-		t.Errorf("bad format_version: %q", le.FormatVersion)
+	if *le.FormatVersion != *nle.FormatVersion {
+		t.Errorf("bad format_version: %q", *le.FormatVersion)
 	}
-	if le.Placement != nle.Placement {
-		t.Errorf("bad placement: %q", le.Placement)
+	if *le.Placement != *nle.Placement {
+		t.Errorf("bad placement: %q", *le.Placement)
 	}
 
 	// Update
@@ -138,14 +138,14 @@ func TestClient_Logentries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ule.Name != "new-test-logentries" {
-		t.Errorf("bad name: %q", ule.Name)
+	if *ule.Name != "new-test-logentries" {
+		t.Errorf("bad name: %q", *ule.Name)
 	}
-	if ule.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", ule.FormatVersion)
+	if *ule.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *ule.FormatVersion)
 	}
-	if ule.Region != "ap" {
-		t.Errorf("bad region: %q", ule.Region)
+	if *ule.Region != "ap" {
+		t.Errorf("bad region: %q", *ule.Region)
 	}
 
 	// Delete

--- a/fastly/loggly.go
+++ b/fastly/loggly.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,33 +10,15 @@ import (
 type Loggly struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	Token             string     `mapstructure:"token"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	Token             *string    `mapstructure:"token"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// logglyByName is a sortable list of loggly.
-type logglyByName []*Loggly
-
-// Len implement the sortable interface.
-func (s logglyByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s logglyByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s logglyByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListLogglyInput is used as input to the ListLoggly function.
@@ -68,7 +49,6 @@ func (c *Client) ListLoggly(i *ListLogglyInput) ([]*Loggly, error) {
 	if err := decodeBodyMap(resp.Body, &ls); err != nil {
 		return nil, err
 	}
-	sort.Stable(logglyByName(ls))
 	return ls, nil
 }
 

--- a/fastly/loggly_test.go
+++ b/fastly/loggly_test.go
@@ -46,20 +46,20 @@ func TestClient_Loggly(t *testing.T) {
 		})
 	}()
 
-	if lg.Name != "test-loggly" {
-		t.Errorf("bad name: %q", lg.Name)
+	if *lg.Name != "test-loggly" {
+		t.Errorf("bad name: %q", *lg.Name)
 	}
-	if lg.Token != "abcd1234" {
-		t.Errorf("bad token: %q", lg.Token)
+	if *lg.Token != "abcd1234" {
+		t.Errorf("bad token: %q", *lg.Token)
 	}
-	if lg.Format != "format" {
-		t.Errorf("bad format: %q", lg.Format)
+	if *lg.Format != "format" {
+		t.Errorf("bad format: %q", *lg.Format)
 	}
-	if lg.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", lg.FormatVersion)
+	if *lg.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *lg.FormatVersion)
 	}
-	if lg.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", lg.Placement)
+	if *lg.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *lg.Placement)
 	}
 
 	// List
@@ -89,20 +89,20 @@ func TestClient_Loggly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if lg.Name != nlg.Name {
-		t.Errorf("bad name: %q", lg.Name)
+	if *lg.Name != *nlg.Name {
+		t.Errorf("bad name: %q", *lg.Name)
 	}
-	if lg.Token != nlg.Token {
-		t.Errorf("bad token: %q", lg.Token)
+	if *lg.Token != *nlg.Token {
+		t.Errorf("bad token: %q", *lg.Token)
 	}
-	if lg.Format != nlg.Format {
-		t.Errorf("bad format: %q", lg.Format)
+	if *lg.Format != *nlg.Format {
+		t.Errorf("bad format: %q", *lg.Format)
 	}
-	if lg.FormatVersion != nlg.FormatVersion {
-		t.Errorf("bad format_version: %q", lg.FormatVersion)
+	if *lg.FormatVersion != *nlg.FormatVersion {
+		t.Errorf("bad format_version: %q", *lg.FormatVersion)
 	}
-	if lg.Placement != nlg.Placement {
-		t.Errorf("bad placement: %q", lg.Placement)
+	if *lg.Placement != *nlg.Placement {
+		t.Errorf("bad placement: %q", *lg.Placement)
 	}
 
 	// Update
@@ -119,11 +119,11 @@ func TestClient_Loggly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ulg.Name != "new-test-loggly" {
-		t.Errorf("bad name: %q", ulg.Name)
+	if *ulg.Name != "new-test-loggly" {
+		t.Errorf("bad name: %q", *ulg.Name)
 	}
-	if ulg.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", ulg.FormatVersion)
+	if *ulg.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *ulg.FormatVersion)
 	}
 
 	// Delete

--- a/fastly/loggly_test.go
+++ b/fastly/loggly_test.go
@@ -18,7 +18,7 @@ func TestClient_Loggly(t *testing.T) {
 	record(t, "loggly/create", func(c *Client) {
 		lg, err = c.CreateLoggly(&CreateLogglyInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-loggly"),
 			Token:          ToPointer("abcd1234"),
 			Format:         ToPointer("format"),
@@ -34,13 +34,13 @@ func TestClient_Loggly(t *testing.T) {
 		record(t, "loggly/delete", func(c *Client) {
 			_ = c.DeleteLoggly(&DeleteLogglyInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-loggly",
 			})
 
 			_ = c.DeleteLoggly(&DeleteLogglyInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-loggly",
 			})
 		})
@@ -67,7 +67,7 @@ func TestClient_Loggly(t *testing.T) {
 	record(t, "loggly/list", func(c *Client) {
 		les, err = c.ListLoggly(&ListLogglyInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -82,7 +82,7 @@ func TestClient_Loggly(t *testing.T) {
 	record(t, "loggly/get", func(c *Client) {
 		nlg, err = c.GetLoggly(&GetLogglyInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-loggly",
 		})
 	})
@@ -110,7 +110,7 @@ func TestClient_Loggly(t *testing.T) {
 	record(t, "loggly/update", func(c *Client) {
 		ulg, err = c.UpdateLoggly(&UpdateLogglyInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-loggly",
 			NewName:        ToPointer("new-test-loggly"),
 			FormatVersion:  ToPointer(2),
@@ -130,7 +130,7 @@ func TestClient_Loggly(t *testing.T) {
 	record(t, "loggly/delete", func(c *Client) {
 		err = c.DeleteLoggly(&DeleteLogglyInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-loggly",
 		})
 	})

--- a/fastly/logshuttle.go
+++ b/fastly/logshuttle.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,34 +10,16 @@ import (
 type Logshuttle struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	Token             string     `mapstructure:"token"`
-	URL               string     `mapstructure:"url"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	Token             *string    `mapstructure:"token"`
+	URL               *string    `mapstructure:"url"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// logshuttlesByName is a sortable list of logshuttles.
-type logshuttlesByName []*Logshuttle
-
-// Len implement the sortable interface.
-func (l logshuttlesByName) Len() int {
-	return len(l)
-}
-
-// Swap implement the sortable interface.
-func (l logshuttlesByName) Swap(i, j int) {
-	l[i], l[j] = l[j], l[i]
-}
-
-// Less implement the sortable interface.
-func (l logshuttlesByName) Less(i, j int) bool {
-	return l[i].Name < l[j].Name
 }
 
 // ListLogshuttlesInput is used as input to the ListLogshuttles function.
@@ -69,7 +50,6 @@ func (c *Client) ListLogshuttles(i *ListLogshuttlesInput) ([]*Logshuttle, error)
 	if err := decodeBodyMap(resp.Body, &ls); err != nil {
 		return nil, err
 	}
-	sort.Stable(logshuttlesByName(ls))
 	return ls, nil
 }
 

--- a/fastly/logshuttle_test.go
+++ b/fastly/logshuttle_test.go
@@ -48,23 +48,23 @@ func TestClient_Logshuttles(t *testing.T) {
 		})
 	}()
 
-	if l.Name != "test-logshuttle" {
-		t.Errorf("bad name: %q", l.Name)
+	if *l.Name != "test-logshuttle" {
+		t.Errorf("bad name: %q", *l.Name)
 	}
-	if l.Format != "%h %l %u %t \"%r\" %>s %b" {
-		t.Errorf("bad format: %q", l.Format)
+	if *l.Format != "%h %l %u %t \"%r\" %>s %b" {
+		t.Errorf("bad format: %q", *l.Format)
 	}
-	if l.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", l.FormatVersion)
+	if *l.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *l.FormatVersion)
 	}
-	if l.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", l.Placement)
+	if *l.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *l.Placement)
 	}
-	if l.Token != "super-secure-token" {
-		t.Errorf("bad token: %q", l.Token)
+	if *l.Token != "super-secure-token" {
+		t.Errorf("bad token: %q", *l.Token)
 	}
-	if l.URL != "https://logs.example.com" {
-		t.Errorf("bad url: %q", l.URL)
+	if *l.URL != "https://logs.example.com" {
+		t.Errorf("bad url: %q", *l.URL)
 	}
 
 	// List
@@ -94,23 +94,23 @@ func TestClient_Logshuttles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if l.Name != nl.Name {
-		t.Errorf("bad name: %q", l.Name)
+	if *l.Name != *nl.Name {
+		t.Errorf("bad name: %q", *l.Name)
 	}
-	if l.Format != nl.Format {
-		t.Errorf("bad format: %q", l.Format)
+	if *l.Format != *nl.Format {
+		t.Errorf("bad format: %q", *l.Format)
 	}
-	if l.FormatVersion != nl.FormatVersion {
-		t.Errorf("bad format_version: %q", l.FormatVersion)
+	if *l.FormatVersion != *nl.FormatVersion {
+		t.Errorf("bad format_version: %q", *l.FormatVersion)
 	}
-	if l.Placement != nl.Placement {
-		t.Errorf("bad placement: %q", l.Placement)
+	if *l.Placement != *nl.Placement {
+		t.Errorf("bad placement: %q", *l.Placement)
 	}
-	if l.Token != nl.Token {
-		t.Errorf("bad token: %q", l.Token)
+	if *l.Token != *nl.Token {
+		t.Errorf("bad token: %q", *l.Token)
 	}
-	if l.URL != nl.URL {
-		t.Errorf("bad url: %q", l.URL)
+	if *l.URL != *nl.URL {
+		t.Errorf("bad url: %q", *l.URL)
 	}
 
 	// Update
@@ -128,14 +128,14 @@ func TestClient_Logshuttles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ul.Name != "new-test-logshuttle" {
-		t.Errorf("bad name: %q", ul.Name)
+	if *ul.Name != "new-test-logshuttle" {
+		t.Errorf("bad name: %q", *ul.Name)
 	}
-	if ul.Token != "new-token" {
-		t.Errorf("bad token: %q", ul.Token)
+	if *ul.Token != "new-token" {
+		t.Errorf("bad token: %q", *ul.Token)
 	}
-	if ul.URL != "https://logs2.example.com" {
-		t.Errorf("bad url: %q", ul.URL)
+	if *ul.URL != "https://logs2.example.com" {
+		t.Errorf("bad url: %q", *ul.URL)
 	}
 
 	// Delete

--- a/fastly/logshuttle_test.go
+++ b/fastly/logshuttle_test.go
@@ -18,7 +18,7 @@ func TestClient_Logshuttles(t *testing.T) {
 	record(t, "logshuttles/create", func(c *Client) {
 		l, err = c.CreateLogshuttle(&CreateLogshuttleInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-logshuttle"),
 			Format:         ToPointer("%h %l %u %t \"%r\" %>s %b"),
 			FormatVersion:  ToPointer(2),
@@ -36,13 +36,13 @@ func TestClient_Logshuttles(t *testing.T) {
 		record(t, "logshuttles/cleanup", func(c *Client) {
 			_ = c.DeleteLogshuttle(&DeleteLogshuttleInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-logshuttle",
 			})
 
 			_ = c.DeleteLogshuttle(&DeleteLogshuttleInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-logshuttle",
 			})
 		})
@@ -72,7 +72,7 @@ func TestClient_Logshuttles(t *testing.T) {
 	record(t, "logshuttles/list", func(c *Client) {
 		ls, err = c.ListLogshuttles(&ListLogshuttlesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func TestClient_Logshuttles(t *testing.T) {
 	record(t, "logshuttles/get", func(c *Client) {
 		nl, err = c.GetLogshuttle(&GetLogshuttleInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-logshuttle",
 		})
 	})
@@ -118,7 +118,7 @@ func TestClient_Logshuttles(t *testing.T) {
 	record(t, "logshuttles/update", func(c *Client) {
 		ul, err = c.UpdateLogshuttle(&UpdateLogshuttleInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-logshuttle",
 			NewName:        ToPointer("new-test-logshuttle"),
 			Token:          ToPointer("new-token"),
@@ -142,7 +142,7 @@ func TestClient_Logshuttles(t *testing.T) {
 	record(t, "logshuttles/delete", func(c *Client) {
 		err = c.DeleteLogshuttle(&DeleteLogshuttleInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-logshuttle",
 		})
 	})

--- a/fastly/newrelic.go
+++ b/fastly/newrelic.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,34 +10,16 @@ import (
 type NewRelic struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	Region            string     `mapstructure:"region"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	Token             string     `mapstructure:"token"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	Region            *string    `mapstructure:"region"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	Token             *string    `mapstructure:"token"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// newrelicByName is a sortable list of newrelic.
-type newrelicByName []*NewRelic
-
-// Len implement the sortable interface.
-func (s newrelicByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s newrelicByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s newrelicByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListNewRelicInput is used as input to the ListNewRelic function.
@@ -69,7 +50,6 @@ func (c *Client) ListNewRelic(i *ListNewRelicInput) ([]*NewRelic, error) {
 	if err := decodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
-	sort.Stable(newrelicByName(n))
 	return n, nil
 }
 
@@ -160,7 +140,7 @@ type UpdateNewRelicInput struct {
 	Format *string `url:"format,omitempty"`
 	// FormatVersion is the version of the custom logging format used for the configured endpoint.
 	FormatVersion *int `url:"format_version,omitempty"`
-	// Name is the name of the newrelic to update.
+	// Name is the name of the newrelic to update (required).
 	Name string `url:"-"`
 	// NewName is the new name for the resource.
 	NewName *string `url:"name,omitempty"`

--- a/fastly/newrelic_test.go
+++ b/fastly/newrelic_test.go
@@ -18,7 +18,7 @@ func TestClient_NewRelic(t *testing.T) {
 	record(t, "newrelic/create", func(c *Client) {
 		newRelicResp1, err = c.CreateNewRelic(&CreateNewRelicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-newrelic"),
 			Token:          ToPointer("abcd1234"),
 			Format:         ToPointer("format"),
@@ -33,7 +33,7 @@ func TestClient_NewRelic(t *testing.T) {
 	record(t, "newrelic/create2", func(c *Client) {
 		newRelicResp2, err = c.CreateNewRelic(&CreateNewRelicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-newrelic-2"),
 			Token:          ToPointer("abcd1234"),
 			Format:         ToPointer("format"),
@@ -49,7 +49,7 @@ func TestClient_NewRelic(t *testing.T) {
 	record(t, "newrelic/create3", func(c *Client) {
 		_, err = c.CreateNewRelic(&CreateNewRelicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-newrelic-3"),
 			Token:          ToPointer("abcd1234"),
 			Format:         ToPointer("format"),
@@ -66,19 +66,19 @@ func TestClient_NewRelic(t *testing.T) {
 		record(t, "newrelic/delete", func(c *Client) {
 			_ = c.DeleteNewRelic(&DeleteNewRelicInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-newrelic",
 			})
 
 			_ = c.DeleteNewRelic(&DeleteNewRelicInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-newrelic-2",
 			})
 
 			_ = c.DeleteNewRelic(&DeleteNewRelicInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-newrelic",
 			})
 		})
@@ -126,7 +126,7 @@ func TestClient_NewRelic(t *testing.T) {
 	record(t, "newrelic/list", func(c *Client) {
 		ln, err = c.ListNewRelic(&ListNewRelicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -141,7 +141,7 @@ func TestClient_NewRelic(t *testing.T) {
 	record(t, "newrelic/get", func(c *Client) {
 		newRelicGetResp, err = c.GetNewRelic(&GetNewRelicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-newrelic",
 		})
 	})
@@ -152,7 +152,7 @@ func TestClient_NewRelic(t *testing.T) {
 	record(t, "newrelic/get2", func(c *Client) {
 		newRelicGetResp2, err = c.GetNewRelic(&GetNewRelicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-newrelic-2",
 		})
 	})
@@ -202,7 +202,7 @@ func TestClient_NewRelic(t *testing.T) {
 	record(t, "newrelic/update", func(c *Client) {
 		newRelicUpdateResp1, err = c.UpdateNewRelic(&UpdateNewRelicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-newrelic",
 			NewName:        ToPointer("new-test-newrelic"),
 			FormatVersion:  ToPointer(2),
@@ -217,7 +217,7 @@ func TestClient_NewRelic(t *testing.T) {
 	record(t, "newrelic/update2", func(c *Client) {
 		_, err = c.UpdateNewRelic(&UpdateNewRelicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-newrelic",
 			Region:         ToPointer("zz"),
 		})
@@ -240,7 +240,7 @@ func TestClient_NewRelic(t *testing.T) {
 	record(t, "newrelic/delete", func(c *Client) {
 		err = c.DeleteNewRelic(&DeleteNewRelicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-newrelic",
 		})
 	})

--- a/fastly/newrelic_test.go
+++ b/fastly/newrelic_test.go
@@ -84,42 +84,41 @@ func TestClient_NewRelic(t *testing.T) {
 		})
 	}()
 
-	if newRelicResp1.Name != "test-newrelic" {
-		t.Errorf("bad name: %q", newRelicResp1.Name)
+	if *newRelicResp1.Name != "test-newrelic" {
+		t.Errorf("bad name: %q", *newRelicResp1.Name)
 	}
-	if newRelicResp1.Token != "abcd1234" {
-		t.Errorf("bad token: %q", newRelicResp1.Token)
+	if *newRelicResp1.Token != "abcd1234" {
+		t.Errorf("bad token: %q", *newRelicResp1.Token)
 	}
-	if newRelicResp1.Format != "format" {
-		t.Errorf("bad format: %q", newRelicResp1.Format)
+	if *newRelicResp1.Format != "format" {
+		t.Errorf("bad format: %q", *newRelicResp1.Format)
 	}
-	if newRelicResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", newRelicResp1.FormatVersion)
+	if *newRelicResp1.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *newRelicResp1.FormatVersion)
 	}
-	if newRelicResp1.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", newRelicResp1.Placement)
+	if *newRelicResp1.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *newRelicResp1.Placement)
 	}
-	if newRelicResp1.Region != "us" {
-		t.Errorf("bad region: %q", newRelicResp1.Region)
+	if *newRelicResp1.Region != "us" {
+		t.Errorf("bad region: %q", *newRelicResp1.Region)
 	}
-
-	if newRelicResp2.Name != "test-newrelic-2" {
-		t.Errorf("bad name: %q", newRelicResp2.Name)
+	if *newRelicResp2.Name != "test-newrelic-2" {
+		t.Errorf("bad name: %q", *newRelicResp2.Name)
 	}
-	if newRelicResp2.Token != "abcd1234" {
-		t.Errorf("bad token: %q", newRelicResp2.Token)
+	if *newRelicResp2.Token != "abcd1234" {
+		t.Errorf("bad token: %q", *newRelicResp2.Token)
 	}
-	if newRelicResp2.Format != "format" {
-		t.Errorf("bad format: %q", newRelicResp2.Format)
+	if *newRelicResp2.Format != "format" {
+		t.Errorf("bad format: %q", *newRelicResp2.Format)
 	}
-	if newRelicResp2.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", newRelicResp2.FormatVersion)
+	if *newRelicResp2.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *newRelicResp2.FormatVersion)
 	}
-	if newRelicResp2.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", newRelicResp2.Placement)
+	if *newRelicResp2.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *newRelicResp2.Placement)
 	}
-	if newRelicResp2.Region != "eu" {
-		t.Errorf("bad region: %q", newRelicResp2.Region)
+	if *newRelicResp2.Region != "eu" {
+		t.Errorf("bad region: %q", *newRelicResp2.Region)
 	}
 
 	// List
@@ -161,42 +160,41 @@ func TestClient_NewRelic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if newRelicResp1.Name != newRelicGetResp.Name {
-		t.Errorf("bad name: %q", newRelicResp1.Name)
+	if *newRelicResp1.Name != *newRelicGetResp.Name {
+		t.Errorf("bad name: %q", *newRelicResp1.Name)
 	}
-	if newRelicResp1.Token != newRelicGetResp.Token {
-		t.Errorf("bad token: %q", newRelicResp1.Token)
+	if *newRelicResp1.Token != *newRelicGetResp.Token {
+		t.Errorf("bad token: %q", *newRelicResp1.Token)
 	}
-	if newRelicResp1.Format != newRelicGetResp.Format {
-		t.Errorf("bad format: %q", newRelicResp1.Format)
+	if *newRelicResp1.Format != *newRelicGetResp.Format {
+		t.Errorf("bad format: %q", *newRelicResp1.Format)
 	}
-	if newRelicResp1.FormatVersion != newRelicGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", newRelicResp1.FormatVersion)
+	if *newRelicResp1.FormatVersion != *newRelicGetResp.FormatVersion {
+		t.Errorf("bad format_version: %q", *newRelicResp1.FormatVersion)
 	}
-	if newRelicResp1.Placement != newRelicGetResp.Placement {
-		t.Errorf("bad placement: %q", newRelicResp1.Placement)
+	if *newRelicResp1.Placement != *newRelicGetResp.Placement {
+		t.Errorf("bad placement: %q", *newRelicResp1.Placement)
 	}
-	if newRelicResp1.Region != newRelicGetResp.Region {
-		t.Errorf("bad region: %q", newRelicResp1.Region)
+	if *newRelicResp1.Region != *newRelicGetResp.Region {
+		t.Errorf("bad region: %q", *newRelicResp1.Region)
 	}
-
-	if newRelicResp2.Name != newRelicGetResp2.Name {
-		t.Errorf("bad name: %q", newRelicResp2.Name)
+	if *newRelicResp2.Name != *newRelicGetResp2.Name {
+		t.Errorf("bad name: %q", *newRelicResp2.Name)
 	}
-	if newRelicResp2.Token != newRelicGetResp2.Token {
-		t.Errorf("bad token: %q", newRelicResp2.Token)
+	if *newRelicResp2.Token != *newRelicGetResp2.Token {
+		t.Errorf("bad token: %q", *newRelicResp2.Token)
 	}
-	if newRelicResp2.Format != newRelicGetResp2.Format {
-		t.Errorf("bad format: %q", newRelicResp2.Format)
+	if *newRelicResp2.Format != *newRelicGetResp2.Format {
+		t.Errorf("bad format: %q", *newRelicResp2.Format)
 	}
-	if newRelicResp2.FormatVersion != newRelicGetResp2.FormatVersion {
-		t.Errorf("bad format_version: %q", newRelicResp2.FormatVersion)
+	if *newRelicResp2.FormatVersion != *newRelicGetResp2.FormatVersion {
+		t.Errorf("bad format_version: %q", *newRelicResp2.FormatVersion)
 	}
-	if newRelicResp2.Placement != newRelicGetResp2.Placement {
-		t.Errorf("bad placement: %q", newRelicResp2.Placement)
+	if *newRelicResp2.Placement != *newRelicGetResp2.Placement {
+		t.Errorf("bad placement: %q", *newRelicResp2.Placement)
 	}
-	if newRelicResp2.Region != newRelicGetResp2.Region {
-		t.Errorf("bad region: %q", newRelicResp2.Region)
+	if *newRelicResp2.Region != *newRelicGetResp2.Region {
+		t.Errorf("bad region: %q", *newRelicResp2.Region)
 	}
 
 	// Update
@@ -228,14 +226,14 @@ func TestClient_NewRelic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if newRelicUpdateResp1.Name != "new-test-newrelic" {
-		t.Errorf("bad name: %q", newRelicUpdateResp1.Name)
+	if *newRelicUpdateResp1.Name != "new-test-newrelic" {
+		t.Errorf("bad name: %q", *newRelicUpdateResp1.Name)
 	}
-	if newRelicUpdateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", newRelicUpdateResp1.FormatVersion)
+	if *newRelicUpdateResp1.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *newRelicUpdateResp1.FormatVersion)
 	}
-	if newRelicUpdateResp1.Region != "eu" {
-		t.Errorf("bad region: %q", newRelicUpdateResp1.Region)
+	if *newRelicUpdateResp1.Region != "eu" {
+		t.Errorf("bad region: %q", *newRelicUpdateResp1.Region)
 	}
 
 	// Delete

--- a/fastly/newrelicotlp.go
+++ b/fastly/newrelicotlp.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,27 +10,17 @@ import (
 type NewRelicOTLP struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	Region            string     `mapstructure:"region"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	Token             string     `mapstructure:"token"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	Region            *string    `mapstructure:"region"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	Token             *string    `mapstructure:"token"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	URL               string     `mapstructure:"url"`
-}
-
-// newrelicOTLPByName is a sortable list of newrelic.
-type newrelicOTLPByName []*NewRelicOTLP
-
-// Len, Swap, and Less implement the sortable interface.
-func (s newrelicOTLPByName) Len() int      { return len(s) }
-func (s newrelicOTLPByName) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s newrelicOTLPByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	URL               *string    `mapstructure:"url"`
 }
 
 // ListNewRelicOTLPInput is used as input to the ListNewRelicOTLP function.
@@ -58,12 +47,12 @@ func (c *Client) ListNewRelicOTLP(i *ListNewRelicOTLPInput) ([]*NewRelicOTLP, er
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var n []*NewRelicOTLP
 	if err := decodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
-	sort.Stable(newrelicOTLPByName(n))
 	return n, nil
 }
 
@@ -97,7 +86,6 @@ func (c *Client) CreateNewRelicOTLP(i *CreateNewRelicOTLPInput) (*NewRelicOTLP, 
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
 	}
-
 	if i.ServiceVersion == 0 {
 		return nil, ErrMissingServiceVersion
 	}
@@ -119,10 +107,8 @@ func (c *Client) CreateNewRelicOTLP(i *CreateNewRelicOTLPInput) (*NewRelicOTLP, 
 type GetNewRelicOTLPInput struct {
 	// ServiceID is the ID of the service (required).
 	ServiceID string
-
 	// ServiceVersion is the specific configuration version (required).
 	ServiceVersion int
-
 	// Name is the name of the newrelic to fetch.
 	Name string
 }
@@ -132,11 +118,9 @@ func (c *Client) GetNewRelicOTLP(i *GetNewRelicOTLPInput) (*NewRelicOTLP, error)
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
 	}
-
 	if i.ServiceVersion == 0 {
 		return nil, ErrMissingServiceVersion
 	}
-
 	if i.Name == "" {
 		return nil, ErrMissingName
 	}
@@ -160,7 +144,7 @@ type UpdateNewRelicOTLPInput struct {
 	Format *string `url:"format,omitempty"`
 	// FormatVersion is the version of the custom logging format used for the configured endpoint.
 	FormatVersion *int `url:"format_version,omitempty"`
-	// Name is the name of the newrelic to update.
+	// Name is the name of the newrelic to update (required).
 	Name string `url:"-"`
 	// NewName is the new name for the resource.
 	NewName *string `url:"name,omitempty"`
@@ -186,11 +170,9 @@ func (c *Client) UpdateNewRelicOTLP(i *UpdateNewRelicOTLPInput) (*NewRelicOTLP, 
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
 	}
-
 	if i.ServiceVersion == 0 {
 		return nil, ErrMissingServiceVersion
 	}
-
 	if i.Name == "" {
 		return nil, ErrMissingName
 	}
@@ -223,11 +205,9 @@ func (c *Client) DeleteNewRelicOTLP(i *DeleteNewRelicOTLPInput) error {
 	if i.ServiceID == "" {
 		return ErrMissingServiceID
 	}
-
 	if i.ServiceVersion == 0 {
 		return ErrMissingServiceVersion
 	}
-
 	if i.Name == "" {
 		return ErrMissingName
 	}

--- a/fastly/newrelicotlp_test.go
+++ b/fastly/newrelicotlp_test.go
@@ -47,23 +47,23 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 		})
 	}()
 
-	if n.Name != "test-newrelicotlp" {
-		t.Errorf("bad name: %q", n.Name)
+	if *n.Name != "test-newrelicotlp" {
+		t.Errorf("bad name: %q", *n.Name)
 	}
-	if n.Token != "abcd1234" {
-		t.Errorf("bad token: %q", n.Token)
+	if *n.Token != "abcd1234" {
+		t.Errorf("bad token: %q", *n.Token)
 	}
-	if n.URL != "https://example.nr-data.net" {
-		t.Errorf("bad url: %q", n.URL)
+	if *n.URL != "https://example.nr-data.net" {
+		t.Errorf("bad url: %q", *n.URL)
 	}
-	if n.Format != "format" {
-		t.Errorf("bad format: %q", n.Format)
+	if *n.Format != "format" {
+		t.Errorf("bad format: %q", *n.Format)
 	}
-	if n.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", n.FormatVersion)
+	if *n.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *n.FormatVersion)
 	}
-	if n.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", n.Placement)
+	if *n.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *n.Placement)
 	}
 
 	// List
@@ -93,23 +93,23 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n.Name != nn.Name {
-		t.Errorf("bad name: %q", n.Name)
+	if *n.Name != *nn.Name {
+		t.Errorf("bad name: %q", *n.Name)
 	}
-	if n.Token != nn.Token {
-		t.Errorf("bad token: %q", n.Token)
+	if *n.Token != *nn.Token {
+		t.Errorf("bad token: %q", *n.Token)
 	}
-	if n.URL != nn.URL {
-		t.Errorf("bad url: %q", n.URL)
+	if *n.URL != *nn.URL {
+		t.Errorf("bad url: %q", *n.URL)
 	}
-	if n.Format != nn.Format {
-		t.Errorf("bad format: %q", n.Format)
+	if *n.Format != *nn.Format {
+		t.Errorf("bad format: %q", *n.Format)
 	}
-	if n.FormatVersion != nn.FormatVersion {
-		t.Errorf("bad format_version: %q", n.FormatVersion)
+	if *n.FormatVersion != *nn.FormatVersion {
+		t.Errorf("bad format_version: %q", *n.FormatVersion)
 	}
-	if n.Placement != nn.Placement {
-		t.Errorf("bad placement: %q", n.Placement)
+	if *n.Placement != *nn.Placement {
+		t.Errorf("bad placement: %q", *n.Placement)
 	}
 
 	// Update
@@ -126,11 +126,11 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if un.Name != "new-test-newrelicotlp" {
-		t.Errorf("bad name: %q", un.Name)
+	if *un.Name != "new-test-newrelicotlp" {
+		t.Errorf("bad name: %q", *un.Name)
 	}
-	if un.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", un.FormatVersion)
+	if *un.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *un.FormatVersion)
 	}
 
 	// Delete

--- a/fastly/newrelicotlp_test.go
+++ b/fastly/newrelicotlp_test.go
@@ -18,7 +18,7 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 	record(t, "newrelicotlp/create", func(c *Client) {
 		n, err = c.CreateNewRelicOTLP(&CreateNewRelicOTLPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-newrelicotlp"),
 			Token:          ToPointer("abcd1234"),
 			URL:            ToPointer("https://example.nr-data.net"),
@@ -35,13 +35,13 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 		record(t, "newrelicotlp/delete", func(c *Client) {
 			c.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-newrelicotlp",
 			})
 
 			c.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-newrelicotlp",
 			})
 		})
@@ -71,7 +71,7 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 	record(t, "newrelicotlp/list", func(c *Client) {
 		ln, err = c.ListNewRelicOTLP(&ListNewRelicOTLPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -86,7 +86,7 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 	record(t, "newrelicotlp/get", func(c *Client) {
 		nn, err = c.GetNewRelicOTLP(&GetNewRelicOTLPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-newrelicotlp",
 		})
 	})
@@ -117,7 +117,7 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 	record(t, "newrelicotlp/update", func(c *Client) {
 		un, err = c.UpdateNewRelicOTLP(&UpdateNewRelicOTLPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-newrelicotlp",
 			NewName:        ToPointer("new-test-newrelicotlp"),
 			FormatVersion:  ToPointer(2),
@@ -137,7 +137,7 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 	record(t, "newrelicotlp/delete", func(c *Client) {
 		err = c.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-newrelicotlp",
 		})
 	})

--- a/fastly/openstack.go
+++ b/fastly/openstack.go
@@ -3,51 +3,32 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Openstack represents a Openstack response from the Fastly API.
 type Openstack struct {
-	AccessKey         string     `mapstructure:"access_key"`
-	BucketName        string     `mapstructure:"bucket_name"`
-	CompressionCodec  string     `mapstructure:"compression_codec"`
+	AccessKey         *string    `mapstructure:"access_key"`
+	BucketName        *string    `mapstructure:"bucket_name"`
+	CompressionCodec  *string    `mapstructure:"compression_codec"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	GzipLevel         int        `mapstructure:"gzip_level"`
-	MessageType       string     `mapstructure:"message_type"`
-	Name              string     `mapstructure:"name"`
-	Path              string     `mapstructure:"path"`
-	Period            int        `mapstructure:"period"`
-	Placement         string     `mapstructure:"placement"`
-	PublicKey         string     `mapstructure:"public_key"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TimestampFormat   string     `mapstructure:"timestamp_format"`
-	URL               string     `mapstructure:"url"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	GzipLevel         *int       `mapstructure:"gzip_level"`
+	MessageType       *string    `mapstructure:"message_type"`
+	Name              *string    `mapstructure:"name"`
+	Path              *string    `mapstructure:"path"`
+	Period            *int       `mapstructure:"period"`
+	Placement         *string    `mapstructure:"placement"`
+	PublicKey         *string    `mapstructure:"public_key"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TimestampFormat   *string    `mapstructure:"timestamp_format"`
+	URL               *string    `mapstructure:"url"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	User              string     `mapstructure:"user"`
-}
-
-// openstacksByName is a sortable list of Openstack.
-type openstacksByName []*Openstack
-
-// Len implement the sortable interface.
-func (o openstacksByName) Len() int {
-	return len(o)
-}
-
-// Swap implement the sortable interface.
-func (o openstacksByName) Swap(i, j int) {
-	o[i], o[j] = o[j], o[i]
-}
-
-// Less implement the sortable interface.
-func (o openstacksByName) Less(i, j int) bool {
-	return o[i].Name < o[j].Name
+	User              *string    `mapstructure:"user"`
 }
 
 // ListOpenstackInput is used as input to the ListOpenstack function.
@@ -78,7 +59,6 @@ func (c *Client) ListOpenstack(i *ListOpenstackInput) ([]*Openstack, error) {
 	if err := decodeBodyMap(resp.Body, &openstacks); err != nil {
 		return nil, err
 	}
-	sort.Stable(openstacksByName(openstacks))
 	return openstacks, nil
 }
 

--- a/fastly/openstack_test.go
+++ b/fastly/openstack_test.go
@@ -18,7 +18,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/create", func(c *Client) {
 		osCreateResp1, err = c.CreateOpenstack(&CreateOpenstackInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-openstack"),
 			User:             ToPointer("user"),
 			AccessKey:        ToPointer("secret-key"),
@@ -42,7 +42,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/create2", func(c *Client) {
 		osCreateResp2, err = c.CreateOpenstack(&CreateOpenstackInput{
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-openstack-2"),
 			User:            ToPointer("user"),
 			AccessKey:       ToPointer("secret-key"),
@@ -66,7 +66,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/create3", func(c *Client) {
 		osCreateResp3, err = c.CreateOpenstack(&CreateOpenstackInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-openstack-3"),
 			User:             ToPointer("user"),
 			AccessKey:        ToPointer("secret-key"),
@@ -92,7 +92,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/create4", func(c *Client) {
 		_, err = c.CreateOpenstack(&CreateOpenstackInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-openstack-4"),
 			User:             ToPointer("user"),
 			AccessKey:        ToPointer("secret-key"),
@@ -119,25 +119,25 @@ func TestClient_Openstack(t *testing.T) {
 		record(t, "openstack/cleanup", func(c *Client) {
 			_ = c.DeleteOpenstack(&DeleteOpenstackInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-openstack",
 			})
 
 			_ = c.DeleteOpenstack(&DeleteOpenstackInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-openstack-2",
 			})
 
 			_ = c.DeleteOpenstack(&DeleteOpenstackInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-openstack-3",
 			})
 
 			_ = c.DeleteOpenstack(&DeleteOpenstackInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-openstack",
 			})
 		})
@@ -206,7 +206,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/list", func(c *Client) {
 		lc, err = c.ListOpenstack(&ListOpenstackInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -221,7 +221,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/get", func(c *Client) {
 		osGetResp, err = c.GetOpenstack(&GetOpenstackInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-openstack",
 		})
 	})
@@ -279,7 +279,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/update", func(c *Client) {
 		osUpdateResp1, err = c.UpdateOpenstack(&UpdateOpenstackInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-openstack",
 			User:             ToPointer("new-user"),
 			NewName:          ToPointer("new-test-openstack"),
@@ -293,7 +293,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/update2", func(c *Client) {
 		osUpdateResp2, err = c.UpdateOpenstack(&UpdateOpenstackInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-openstack-2",
 			CompressionCodec: ToPointer("zstd"),
 		})
@@ -305,7 +305,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/update3", func(c *Client) {
 		osUpdateResp3, err = c.UpdateOpenstack(&UpdateOpenstackInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-openstack-3",
 			GzipLevel:      ToPointer(9),
 		})
@@ -343,7 +343,7 @@ func TestClient_Openstack(t *testing.T) {
 	record(t, "openstack/delete", func(c *Client) {
 		err = c.DeleteOpenstack(&DeleteOpenstackInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-openstack",
 		})
 	})

--- a/fastly/openstack_test.go
+++ b/fastly/openstack_test.go
@@ -143,64 +143,62 @@ func TestClient_Openstack(t *testing.T) {
 		})
 	}()
 
-	if osCreateResp1.Name != "test-openstack" {
-		t.Errorf("bad name: %q", osCreateResp1.Name)
+	if *osCreateResp1.Name != "test-openstack" {
+		t.Errorf("bad name: %q", *osCreateResp1.Name)
 	}
-	if osCreateResp1.User != "user" {
-		t.Errorf("bad user: %q", osCreateResp1.User)
+	if *osCreateResp1.User != "user" {
+		t.Errorf("bad user: %q", *osCreateResp1.User)
 	}
-	if osCreateResp1.BucketName != "bucket-name" {
-		t.Errorf("bad bucket_name: %q", osCreateResp1.BucketName)
+	if *osCreateResp1.BucketName != "bucket-name" {
+		t.Errorf("bad bucket_name: %q", *osCreateResp1.BucketName)
 	}
-	if osCreateResp1.AccessKey != "secret-key" {
-		t.Errorf("bad access_key: %q", osCreateResp1.AccessKey)
+	if *osCreateResp1.AccessKey != "secret-key" {
+		t.Errorf("bad access_key: %q", *osCreateResp1.AccessKey)
 	}
-	if osCreateResp1.Path != "/path" {
-		t.Errorf("bad path: %q", osCreateResp1.Path)
+	if *osCreateResp1.Path != "/path" {
+		t.Errorf("bad path: %q", *osCreateResp1.Path)
 	}
-	if osCreateResp1.URL != "https://logs.example.com/v1.0" {
-		t.Errorf("bad url: %q", osCreateResp1.URL)
+	if *osCreateResp1.URL != "https://logs.example.com/v1.0" {
+		t.Errorf("bad url: %q", *osCreateResp1.URL)
 	}
-	if osCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", osCreateResp1.Period)
+	if *osCreateResp1.Period != 12 {
+		t.Errorf("bad period: %q", *osCreateResp1.Period)
 	}
-	if osCreateResp1.CompressionCodec != "snappy" {
-		t.Errorf("bad comprssion_codec: %q", osCreateResp1.CompressionCodec)
+	if *osCreateResp1.CompressionCodec != "snappy" {
+		t.Errorf("bad comprssion_codec: %q", *osCreateResp1.CompressionCodec)
 	}
-	if osCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", osCreateResp1.GzipLevel)
+	if *osCreateResp1.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *osCreateResp1.GzipLevel)
 	}
-	if osCreateResp1.Format != "format" {
-		t.Errorf("bad format: %q", osCreateResp1.Format)
+	if *osCreateResp1.Format != "format" {
+		t.Errorf("bad format: %q", *osCreateResp1.Format)
 	}
-	if osCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", osCreateResp1.FormatVersion)
+	if *osCreateResp1.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *osCreateResp1.FormatVersion)
 	}
-	if osCreateResp1.TimestampFormat != "%Y" {
-		t.Errorf("bad timestamp_format: %q", osCreateResp1.TimestampFormat)
+	if *osCreateResp1.TimestampFormat != "%Y" {
+		t.Errorf("bad timestamp_format: %q", *osCreateResp1.TimestampFormat)
 	}
-	if osCreateResp1.MessageType != "classic" {
-		t.Errorf("bad message_type: %q", osCreateResp1.MessageType)
+	if *osCreateResp1.MessageType != "classic" {
+		t.Errorf("bad message_type: %q", *osCreateResp1.MessageType)
 	}
-	if osCreateResp1.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", osCreateResp1.Placement)
+	if *osCreateResp1.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *osCreateResp1.Placement)
 	}
-	if osCreateResp1.PublicKey != pgpPublicKey() {
-		t.Errorf("bad public_key: %q", osCreateResp1.PublicKey)
+	if *osCreateResp1.PublicKey != pgpPublicKey() {
+		t.Errorf("bad public_key: %q", *osCreateResp1.PublicKey)
 	}
-
-	if osCreateResp2.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", osCreateResp2.CompressionCodec)
+	if osCreateResp2.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *osCreateResp2.CompressionCodec)
 	}
-	if osCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", osCreateResp2.GzipLevel)
+	if *osCreateResp2.GzipLevel != 8 {
+		t.Errorf("bad gzip_level: %q", *osCreateResp2.GzipLevel)
 	}
-
-	if osCreateResp3.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", osCreateResp3.CompressionCodec)
+	if *osCreateResp3.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *osCreateResp3.CompressionCodec)
 	}
-	if osCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", osCreateResp3.GzipLevel)
+	if *osCreateResp3.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *osCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -230,50 +228,50 @@ func TestClient_Openstack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if osCreateResp1.Name != osGetResp.Name {
-		t.Errorf("bad name: %q", osCreateResp1.Name)
+	if *osCreateResp1.Name != *osGetResp.Name {
+		t.Errorf("bad name: %q", *osCreateResp1.Name)
 	}
-	if osCreateResp1.User != osGetResp.User {
-		t.Errorf("bad user: %q", osCreateResp1.User)
+	if *osCreateResp1.User != *osGetResp.User {
+		t.Errorf("bad user: %q", *osCreateResp1.User)
 	}
-	if osCreateResp1.BucketName != osGetResp.BucketName {
-		t.Errorf("bad bucket_name: %q", osCreateResp1.BucketName)
+	if *osCreateResp1.BucketName != *osGetResp.BucketName {
+		t.Errorf("bad bucket_name: %q", *osCreateResp1.BucketName)
 	}
-	if osCreateResp1.AccessKey != osGetResp.AccessKey {
-		t.Errorf("bad access_key: %q", osCreateResp1.AccessKey)
+	if *osCreateResp1.AccessKey != *osGetResp.AccessKey {
+		t.Errorf("bad access_key: %q", *osCreateResp1.AccessKey)
 	}
-	if osCreateResp1.Path != osGetResp.Path {
-		t.Errorf("bad path: %q", osCreateResp1.Path)
+	if *osCreateResp1.Path != *osGetResp.Path {
+		t.Errorf("bad path: %q", *osCreateResp1.Path)
 	}
-	if osCreateResp1.URL != osGetResp.URL {
-		t.Errorf("bad url: %q", osCreateResp1.URL)
+	if *osCreateResp1.URL != *osGetResp.URL {
+		t.Errorf("bad url: %q", *osCreateResp1.URL)
 	}
-	if osCreateResp1.Period != osGetResp.Period {
-		t.Errorf("bad period: %q", osCreateResp1.Period)
+	if *osCreateResp1.Period != *osGetResp.Period {
+		t.Errorf("bad period: %q", *osCreateResp1.Period)
 	}
-	if osCreateResp1.CompressionCodec != osGetResp.CompressionCodec {
-		t.Errorf("bad compression_codec: %q", osCreateResp1.CompressionCodec)
+	if *osCreateResp1.CompressionCodec != *osGetResp.CompressionCodec {
+		t.Errorf("bad compression_codec: %q", *osCreateResp1.CompressionCodec)
 	}
-	if osCreateResp1.GzipLevel != osGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", osCreateResp1.GzipLevel)
+	if *osCreateResp1.GzipLevel != *osGetResp.GzipLevel {
+		t.Errorf("bad gzip_level: %q", *osCreateResp1.GzipLevel)
 	}
-	if osCreateResp1.Format != osGetResp.Format {
-		t.Errorf("bad format: %q", osCreateResp1.Format)
+	if *osCreateResp1.Format != *osGetResp.Format {
+		t.Errorf("bad format: %q", *osCreateResp1.Format)
 	}
-	if osCreateResp1.FormatVersion != osGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", osCreateResp1.FormatVersion)
+	if *osCreateResp1.FormatVersion != *osGetResp.FormatVersion {
+		t.Errorf("bad format_version: %q", *osCreateResp1.FormatVersion)
 	}
-	if osCreateResp1.TimestampFormat != osGetResp.TimestampFormat {
-		t.Errorf("bad timestamp_format: %q", osCreateResp1.TimestampFormat)
+	if *osCreateResp1.TimestampFormat != *osGetResp.TimestampFormat {
+		t.Errorf("bad timestamp_format: %q", *osCreateResp1.TimestampFormat)
 	}
-	if osCreateResp1.MessageType != osGetResp.MessageType {
-		t.Errorf("bad message_type: %q", osCreateResp1.MessageType)
+	if *osCreateResp1.MessageType != *osGetResp.MessageType {
+		t.Errorf("bad message_type: %q", *osCreateResp1.MessageType)
 	}
-	if osCreateResp1.Placement != osGetResp.Placement {
-		t.Errorf("bad placement: %q", osCreateResp1.Placement)
+	if *osCreateResp1.Placement != *osGetResp.Placement {
+		t.Errorf("bad placement: %q", *osCreateResp1.Placement)
 	}
-	if osCreateResp1.PublicKey != osGetResp.PublicKey {
-		t.Errorf("bad public_key: %q", osCreateResp1.PublicKey)
+	if *osCreateResp1.PublicKey != *osGetResp.PublicKey {
+		t.Errorf("bad public_key: %q", *osCreateResp1.PublicKey)
 	}
 
 	// Update
@@ -316,31 +314,29 @@ func TestClient_Openstack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if osUpdateResp1.Name != "new-test-openstack" {
-		t.Errorf("bad name: %q", osUpdateResp1.Name)
+	if *osUpdateResp1.Name != "new-test-openstack" {
+		t.Errorf("bad name: %q", *osUpdateResp1.Name)
 	}
-	if osUpdateResp1.User != "new-user" {
-		t.Errorf("bad user: %q", osUpdateResp1.User)
+	if *osUpdateResp1.User != "new-user" {
+		t.Errorf("bad user: %q", *osUpdateResp1.User)
 	}
-	if osUpdateResp1.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", osUpdateResp1.CompressionCodec)
+	if *osUpdateResp1.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *osUpdateResp1.CompressionCodec)
 	}
-	if osUpdateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", osUpdateResp1.GzipLevel)
+	if osUpdateResp1.GzipLevel != nil {
+		t.Errorf("bad gzip_level: %q", *osUpdateResp1.GzipLevel)
 	}
-
-	if osUpdateResp2.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", osUpdateResp2.CompressionCodec)
+	if *osUpdateResp2.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *osUpdateResp2.CompressionCodec)
 	}
-	if osUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", osUpdateResp2.GzipLevel)
+	if *osUpdateResp2.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *osUpdateResp2.GzipLevel)
 	}
-
-	if osUpdateResp3.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", osUpdateResp3.CompressionCodec)
+	if osUpdateResp3.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *osUpdateResp3.CompressionCodec)
 	}
-	if osUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", osUpdateResp3.GzipLevel)
+	if *osUpdateResp3.GzipLevel != 9 {
+		t.Errorf("bad gzip_level: %q", *osUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/origin_inspector.go
+++ b/fastly/origin_inspector.go
@@ -10,85 +10,85 @@ import (
 // OriginInspector represents the response format returned for a request to
 // the historical Origin Inspector metrics endpoint.
 type OriginInspector struct {
-	Data   []OriginData `mapstructure:"data"`
-	Meta   OriginMeta   `mapstructure:"meta"`
-	Status string       `mapstructure:"status"`
+	Data   []*OriginData `mapstructure:"data"`
+	Meta   *OriginMeta   `mapstructure:"meta"`
+	Status *string       `mapstructure:"status"`
 }
 
 // OriginData represents the series of values over time for a single
 // dimension combination.
 type OriginData struct {
 	Dimensions map[string]string `mapstructure:"dimensions"`
-	Values     []OriginMetrics   `mapstructure:"values"`
+	Values     []*OriginMetrics  `mapstructure:"values"`
 }
 
 // OriginMetrics represents the possible metrics that can be returned by a call
 // to the Origin Inspector endpoints.
 type OriginMetrics struct {
-	Latency0to1ms         uint64 `mapstructure:"latency_0_to_1ms"`
-	Latency10000to60000ms uint64 `mapstructure:"latency_10000_to_60000ms"`
-	Latency1000to5000ms   uint64 `mapstructure:"latency_1000_to_5000ms"`
-	Latency100to250ms     uint64 `mapstructure:"latency_100_to_250ms"`
-	Latency10to50ms       uint64 `mapstructure:"latency_10_to_50ms"`
-	Latency1to5ms         uint64 `mapstructure:"latency_1_to_5ms"`
-	Latency250to500ms     uint64 `mapstructure:"latency_250_to_500ms"`
-	Latency5000to10000ms  uint64 `mapstructure:"latency_5000_to_10000ms"`
-	Latency500to1000ms    uint64 `mapstructure:"latency_500_to_1000ms"`
-	Latency50to100ms      uint64 `mapstructure:"latency_50_to_100ms"`
-	Latency5to10ms        uint64 `mapstructure:"latency_5_to_10ms"`
-	Latency60000ms        uint64 `mapstructure:"latency_60000ms"`
-	RespBodyBytes         uint64 `mapstructure:"resp_body_bytes"`
-	RespHeaderBytes       uint64 `mapstructure:"resp_header_bytes"`
-	Responses             uint64 `mapstructure:"responses"`
-	Status1xx             uint64 `mapstructure:"status_1xx"`
-	Status200             uint64 `mapstructure:"status_200"`
-	Status204             uint64 `mapstructure:"status_204"`
-	Status206             uint64 `mapstructure:"status_206"`
-	Status2xx             uint64 `mapstructure:"status_2xx"`
-	Status301             uint64 `mapstructure:"status_301"`
-	Status302             uint64 `mapstructure:"status_302"`
-	Status304             uint64 `mapstructure:"status_304"`
-	Status3xx             uint64 `mapstructure:"status_3xx"`
-	Status400             uint64 `mapstructure:"status_400"`
-	Status401             uint64 `mapstructure:"status_401"`
-	Status403             uint64 `mapstructure:"status_403"`
-	Status404             uint64 `mapstructure:"status_404"`
-	Status416             uint64 `mapstructure:"status_416"`
-	Status429             uint64 `mapstructure:"status_429"`
-	Status4xx             uint64 `mapstructure:"status_4xx"`
-	Status500             uint64 `mapstructure:"status_500"`
-	Status501             uint64 `mapstructure:"status_501"`
-	Status502             uint64 `mapstructure:"status_502"`
-	Status503             uint64 `mapstructure:"status_503"`
-	Status504             uint64 `mapstructure:"status_504"`
-	Status505             uint64 `mapstructure:"status_505"`
-	Status5xx             uint64 `mapstructure:"status_5xx"`
-	Timestamp             uint64 `mapstructure:"timestamp"`
+	Latency0to1ms         *uint64 `mapstructure:"latency_0_to_1ms"`
+	Latency10000to60000ms *uint64 `mapstructure:"latency_10000_to_60000ms"`
+	Latency1000to5000ms   *uint64 `mapstructure:"latency_1000_to_5000ms"`
+	Latency100to250ms     *uint64 `mapstructure:"latency_100_to_250ms"`
+	Latency10to50ms       *uint64 `mapstructure:"latency_10_to_50ms"`
+	Latency1to5ms         *uint64 `mapstructure:"latency_1_to_5ms"`
+	Latency250to500ms     *uint64 `mapstructure:"latency_250_to_500ms"`
+	Latency5000to10000ms  *uint64 `mapstructure:"latency_5000_to_10000ms"`
+	Latency500to1000ms    *uint64 `mapstructure:"latency_500_to_1000ms"`
+	Latency50to100ms      *uint64 `mapstructure:"latency_50_to_100ms"`
+	Latency5to10ms        *uint64 `mapstructure:"latency_5_to_10ms"`
+	Latency60000ms        *uint64 `mapstructure:"latency_60000ms"`
+	RespBodyBytes         *uint64 `mapstructure:"resp_body_bytes"`
+	RespHeaderBytes       *uint64 `mapstructure:"resp_header_bytes"`
+	Responses             *uint64 `mapstructure:"responses"`
+	Status1xx             *uint64 `mapstructure:"status_1xx"`
+	Status200             *uint64 `mapstructure:"status_200"`
+	Status204             *uint64 `mapstructure:"status_204"`
+	Status206             *uint64 `mapstructure:"status_206"`
+	Status2xx             *uint64 `mapstructure:"status_2xx"`
+	Status301             *uint64 `mapstructure:"status_301"`
+	Status302             *uint64 `mapstructure:"status_302"`
+	Status304             *uint64 `mapstructure:"status_304"`
+	Status3xx             *uint64 `mapstructure:"status_3xx"`
+	Status400             *uint64 `mapstructure:"status_400"`
+	Status401             *uint64 `mapstructure:"status_401"`
+	Status403             *uint64 `mapstructure:"status_403"`
+	Status404             *uint64 `mapstructure:"status_404"`
+	Status416             *uint64 `mapstructure:"status_416"`
+	Status429             *uint64 `mapstructure:"status_429"`
+	Status4xx             *uint64 `mapstructure:"status_4xx"`
+	Status500             *uint64 `mapstructure:"status_500"`
+	Status501             *uint64 `mapstructure:"status_501"`
+	Status502             *uint64 `mapstructure:"status_502"`
+	Status503             *uint64 `mapstructure:"status_503"`
+	Status504             *uint64 `mapstructure:"status_504"`
+	Status505             *uint64 `mapstructure:"status_505"`
+	Status5xx             *uint64 `mapstructure:"status_5xx"`
+	Timestamp             *uint64 `mapstructure:"timestamp"`
 }
 
-// OriginMeta is the meta section returned for /metrics/origins responses
+// OriginMeta is the meta section returned for /metrics/origins responses.
 type OriginMeta struct {
-	Downsample string            `mapstructure:"downsample"`
-	End        string            `mapstructure:"end"`
+	Downsample *string           `mapstructure:"downsample"`
+	End        *string           `mapstructure:"end"`
 	Filters    map[string]string `mapstructure:"filters"`
-	GroupBy    string            `mapstructure:"group_by"`
-	Limit      int               `mapstructure:"limit"`
-	Metric     string            `mapstructure:"metric"`
-	NextCursor string            `mapstructure:"next_cursor"`
-	Sort       string            `mapstructure:"sort"`
-	Start      string            `mapstructure:"start"`
+	GroupBy    *string           `mapstructure:"group_by"`
+	Limit      *int              `mapstructure:"limit"`
+	Metric     *string           `mapstructure:"metric"`
+	NextCursor *string           `mapstructure:"next_cursor"`
+	Sort       *string           `mapstructure:"sort"`
+	Start      *string           `mapstructure:"start"`
 }
 
 // GetOriginMetricsInput is the input to an OriginMetrics request.
 type GetOriginMetricsInput struct {
 	// Cursor is the value from a previous response to retrieve the next page. To request the first page, this should be empty.
-	Cursor string
+	Cursor *string
 	// Datacenters limits query to one or more specific POPs.
 	Datacenters []string
 	// Downsample is the duration of sample windows.
-	Downsample string
+	Downsample *string
 	// End is a valid ISO-8601-formatted date and time, or UNIX timestamp, indicating the exclusive end of the query time range. If not provided, a default is chosen based on the provided downsample value.
-	End time.Time
+	End *time.Time
 	// GroupBy is the dimensions to return in the query.
 	GroupBy []string
 	// Hosts limits query to one or more specific origin hosts.
@@ -97,10 +97,10 @@ type GetOriginMetricsInput struct {
 	Metrics []string
 	// Regions limits query to one or more specific geographic regions.
 	Regions []string
-	// ServiceID is an alphanumeric string identifying the service.
+	// ServiceID is an alphanumeric string identifying the service (required).
 	ServiceID string
 	// Start is a valid ISO-8601-formatted date and time, or UNIX timestamp, indicating the inclusive start of the query time range. If not provided, a default is chosen based on the provided downsample value.
-	Start time.Time
+	Start *time.Time
 }
 
 // GetOriginMetricsForService retrieves the specified resource.
@@ -125,27 +125,29 @@ func (c *Client) GetOriginMetricsForServiceJSON(i *GetOriginMetricsInput, dst in
 
 	p := "/metrics/origins/services/" + i.ServiceID
 
-	start := ""
-	if !i.Start.IsZero() {
-		start = strconv.FormatInt(i.Start.Unix(), 10)
+	ro := &RequestOptions{
+		Params: map[string]string{
+			"datacenter": strings.Join(i.Datacenters, ","),
+			"group_by":   strings.Join(i.GroupBy, ","),
+			"host":       strings.Join(i.Hosts, ","),
+			"metric":     strings.Join(i.Metrics, ","),
+			"region":     strings.Join(i.Regions, ","),
+		},
 	}
-	end := ""
-	if !i.End.IsZero() {
-		end = strconv.FormatInt(i.End.Unix(), 10)
+	if i.Cursor != nil {
+		ro.Params["cursor"] = *i.Cursor
+	}
+	if i.Downsample != nil {
+		ro.Params["downsample"] = *i.Downsample
+	}
+	if i.End != nil {
+		ro.Params["end"] = strconv.FormatInt(i.End.Unix(), 10)
+	}
+	if i.Start != nil {
+		ro.Params["start"] = strconv.FormatInt(i.Start.Unix(), 10)
 	}
 
-	r, err := c.Get(p, &RequestOptions{
-		Params: map[string]string{
-			"start":      start,
-			"end":        end,
-			"downsample": i.Downsample,
-			"metric":     strings.Join(i.Metrics, ","),
-			"host":       strings.Join(i.Hosts, ","),
-			"datacenter": strings.Join(i.Datacenters, ","),
-			"region":     strings.Join(i.Regions, ","),
-			"cursor":     i.Cursor,
-		},
-	})
+	r, err := c.Get(p, ro)
 	if err != nil {
 		return err
 	}

--- a/fastly/origin_inspector_test.go
+++ b/fastly/origin_inspector_test.go
@@ -16,16 +16,16 @@ func TestClient_GetOriginMetricsForService(t *testing.T) {
 	var err error
 	record(t, "origin_inspector/metrics_for_service", func(c *Client) {
 		_, err = c.GetOriginMetricsForService(&GetOriginMetricsInput{
-			ServiceID:   testServiceID,
-			Start:       start,
-			End:         end,
-			Hosts:       []string{"host01"},
+			Cursor:      ToPointer(""),
 			Datacenters: []string{"LHR", "JFK"},
-			Metrics:     []string{"responses", "status_2xx"},
+			Downsample:  ToPointer("day"),
+			End:         &end,
 			GroupBy:     []string{"host"},
-			Downsample:  "day",
+			Hosts:       []string{"host01"},
+			Metrics:     []string{"responses", "status_2xx"},
 			Regions:     []string{"europe", "usa"},
-			Cursor:      "",
+			ServiceID:   testServiceID,
+			Start:       &start,
 		})
 	})
 	if err != nil {

--- a/fastly/package.go
+++ b/fastly/package.go
@@ -12,11 +12,11 @@ import (
 type Package struct {
 	CreatedAt      *time.Time `mapstructure:"created_at"`
 	DeletedAt      *time.Time `mapstructure:"deleted_at"`
-	ID             string
-	Metadata       PackageMetadata `mapstructure:"metadata"`
-	ServiceID      string          `mapstructure:"service_id"`
-	ServiceVersion int             `mapstructure:"version"`
-	UpdatedAt      *time.Time      `mapstructure:"updated_at"`
+	ID             *string
+	Metadata       *PackageMetadata `mapstructure:"metadata"`
+	ServiceID      *string          `mapstructure:"service_id"`
+	ServiceVersion *int             `mapstructure:"version"`
+	UpdatedAt      *time.Time       `mapstructure:"updated_at"`
 }
 
 // PackageMetadata is a container for metadata returned about a package.
@@ -24,12 +24,12 @@ type Package struct {
 // the raw data is returned as a json sub-block.
 type PackageMetadata struct {
 	Authors     []string `mapstructure:"authors"`
-	Description string   `mapstructure:"description"`
-	FilesHash   string   `mapstructure:"files_hash"`
-	HashSum     string   `mapstructure:"hashsum"`
-	Language    string   `mapstructure:"language"`
-	Name        string   `mapstructure:"name"`
-	Size        int64    `mapstructure:"size"`
+	Description *string  `mapstructure:"description"`
+	FilesHash   *string  `mapstructure:"files_hash"`
+	HashSum     *string  `mapstructure:"hashsum"`
+	Language    *string  `mapstructure:"language"`
+	Name        *string  `mapstructure:"name"`
+	Size        *int64   `mapstructure:"size"`
 }
 
 // GetPackageInput is used as input to the GetPackage function.
@@ -59,7 +59,7 @@ func (c *Client) GetPackage(i *GetPackageInput) (*Package, error) {
 // UpdatePackageInput is used as input to the UpdatePackage function.
 type UpdatePackageInput struct {
 	// PackagePath is the local filesystem path to the package to upload.
-	PackagePath string
+	PackagePath *string
 	// PackageContent is the data in raw of the package to upload.
 	PackageContent []byte
 	// ServiceID is the ID of the service (required).
@@ -77,8 +77,8 @@ func (c *Client) UpdatePackage(i *UpdatePackageInput) (*Package, error) {
 
 	var body io.ReadCloser
 	switch {
-	case i.PackagePath != "":
-		resp, err := c.PutFormFile(urlPath, i.PackagePath, "package", nil)
+	case i.PackagePath != nil:
+		resp, err := c.PutFormFile(urlPath, *i.PackagePath, "package", nil)
 		if err != nil {
 			return nil, err
 		}

--- a/fastly/package_test.go
+++ b/fastly/package_test.go
@@ -32,7 +32,7 @@ func TestClient_Package(t *testing.T) {
 	recordIgnoreBody(t, fixtureBase+"update", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      *testService.ID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			PackagePath:    ToPointer("test_assets/package/valid.tar.gz"),
 		})
 	})
@@ -42,7 +42,7 @@ func TestClient_Package(t *testing.T) {
 	if *wp.ServiceID != *testService.ID {
 		t.Errorf("bad serviceID: %q != %q", *wp.ID, *testService.ID)
 	}
-	if *wp.ServiceVersion != testVersion.Number {
+	if *wp.ServiceVersion != *testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", *wp.ServiceVersion, testVersion.Number)
 	}
 
@@ -50,7 +50,7 @@ func TestClient_Package(t *testing.T) {
 	record(t, fixtureBase+"get", func(c *Client) {
 		wp, err = c.GetPackage(&GetPackageInput{
 			ServiceID:      *testService.ID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 		})
 	})
 	if err != nil {
@@ -60,7 +60,7 @@ func TestClient_Package(t *testing.T) {
 	if *wp.ServiceID != *testService.ID {
 		t.Errorf("bad serviceID: %q != %q", *wp.ID, *testService.ID)
 	}
-	if *wp.ServiceVersion != testVersion.Number {
+	if *wp.ServiceVersion != *testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", wp.ServiceVersion, testVersion.Number)
 	}
 
@@ -89,7 +89,7 @@ func TestClient_Package(t *testing.T) {
 	recordIgnoreBody(t, fixtureBase+"update", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      *testService.ID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			PackageContent: validPackageContent,
 		})
 	})
@@ -99,7 +99,7 @@ func TestClient_Package(t *testing.T) {
 	if *wp.ServiceID != *testService.ID {
 		t.Errorf("bad serviceID: %q != %q", *wp.ID, *testService.ID)
 	}
-	if *wp.ServiceVersion != testVersion.Number {
+	if *wp.ServiceVersion != *testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", *wp.ServiceVersion, testVersion.Number)
 	}
 
@@ -107,7 +107,7 @@ func TestClient_Package(t *testing.T) {
 	record(t, fixtureBase+"get", func(c *Client) {
 		wp, err = c.GetPackage(&GetPackageInput{
 			ServiceID:      *testService.ID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 		})
 	})
 	if err != nil {
@@ -117,7 +117,7 @@ func TestClient_Package(t *testing.T) {
 	if *wp.ServiceID != *testService.ID {
 		t.Errorf("bad serviceID: %q != %q", *wp.ID, *testService.ID)
 	}
-	if *wp.ServiceVersion != testVersion.Number {
+	if *wp.ServiceVersion != *testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", wp.ServiceVersion, testVersion.Number)
 	}
 
@@ -142,7 +142,7 @@ func TestClient_Package(t *testing.T) {
 	recordIgnoreBody(t, fixtureBase+"update_invalid", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      *testService.ID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			PackagePath:    ToPointer("test_assets/package/invalid.tar.gz"),
 		})
 	})
@@ -156,7 +156,7 @@ func TestClient_Package(t *testing.T) {
 	recordIgnoreBody(t, fixtureBase+"update_invalid", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      *testService.ID,
-			ServiceVersion: testVersion.Number,
+			ServiceVersion: *testVersion.Number,
 			PackageContent: invalidPackageContent,
 		})
 	})

--- a/fastly/package_test.go
+++ b/fastly/package_test.go
@@ -10,8 +10,8 @@ func TestClient_Package(t *testing.T) {
 	nameSuffix := "package"
 
 	testService := createTestServiceWasm(t, fixtureBase+"service_create", nameSuffix)
-	testVersion := createTestVersion(t, fixtureBase+"service_version", testService.ID)
-	defer deleteTestService(t, fixtureBase+"service_delete", testService.ID)
+	testVersion := createTestVersion(t, fixtureBase+"service_version", *testService.ID)
+	defer deleteTestService(t, fixtureBase+"service_delete", *testService.ID)
 
 	testData := Package{
 		Metadata: &PackageMetadata{
@@ -31,7 +31,7 @@ func TestClient_Package(t *testing.T) {
 
 	recordIgnoreBody(t, fixtureBase+"update", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
-			ServiceID:      testService.ID,
+			ServiceID:      *testService.ID,
 			ServiceVersion: testVersion.Number,
 			PackagePath:    ToPointer("test_assets/package/valid.tar.gz"),
 		})
@@ -39,8 +39,8 @@ func TestClient_Package(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *wp.ServiceID != testService.ID {
-		t.Errorf("bad serviceID: %q != %q", *wp.ID, testService.ID)
+	if *wp.ServiceID != *testService.ID {
+		t.Errorf("bad serviceID: %q != %q", *wp.ID, *testService.ID)
 	}
 	if *wp.ServiceVersion != testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", *wp.ServiceVersion, testVersion.Number)
@@ -49,7 +49,7 @@ func TestClient_Package(t *testing.T) {
 	// Get
 	record(t, fixtureBase+"get", func(c *Client) {
 		wp, err = c.GetPackage(&GetPackageInput{
-			ServiceID:      testService.ID,
+			ServiceID:      *testService.ID,
 			ServiceVersion: testVersion.Number,
 		})
 	})
@@ -57,8 +57,8 @@ func TestClient_Package(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if *wp.ServiceID != testService.ID {
-		t.Errorf("bad serviceID: %q != %q", *wp.ID, testService.ID)
+	if *wp.ServiceID != *testService.ID {
+		t.Errorf("bad serviceID: %q != %q", *wp.ID, *testService.ID)
 	}
 	if *wp.ServiceVersion != testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", wp.ServiceVersion, testVersion.Number)
@@ -88,7 +88,7 @@ func TestClient_Package(t *testing.T) {
 	validPackageContent, _ := os.ReadFile("test_assets/package/valid.tar.gz")
 	recordIgnoreBody(t, fixtureBase+"update", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
-			ServiceID:      testService.ID,
+			ServiceID:      *testService.ID,
 			ServiceVersion: testVersion.Number,
 			PackageContent: validPackageContent,
 		})
@@ -96,8 +96,8 @@ func TestClient_Package(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *wp.ServiceID != testService.ID {
-		t.Errorf("bad serviceID: %q != %q", *wp.ID, testService.ID)
+	if *wp.ServiceID != *testService.ID {
+		t.Errorf("bad serviceID: %q != %q", *wp.ID, *testService.ID)
 	}
 	if *wp.ServiceVersion != testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", *wp.ServiceVersion, testVersion.Number)
@@ -106,7 +106,7 @@ func TestClient_Package(t *testing.T) {
 	// Get
 	record(t, fixtureBase+"get", func(c *Client) {
 		wp, err = c.GetPackage(&GetPackageInput{
-			ServiceID:      testService.ID,
+			ServiceID:      *testService.ID,
 			ServiceVersion: testVersion.Number,
 		})
 	})
@@ -114,8 +114,8 @@ func TestClient_Package(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if *wp.ServiceID != testService.ID {
-		t.Errorf("bad serviceID: %q != %q", *wp.ID, testService.ID)
+	if *wp.ServiceID != *testService.ID {
+		t.Errorf("bad serviceID: %q != %q", *wp.ID, *testService.ID)
 	}
 	if *wp.ServiceVersion != testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", wp.ServiceVersion, testVersion.Number)
@@ -141,7 +141,7 @@ func TestClient_Package(t *testing.T) {
 
 	recordIgnoreBody(t, fixtureBase+"update_invalid", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
-			ServiceID:      testService.ID,
+			ServiceID:      *testService.ID,
 			ServiceVersion: testVersion.Number,
 			PackagePath:    ToPointer("test_assets/package/invalid.tar.gz"),
 		})
@@ -155,7 +155,7 @@ func TestClient_Package(t *testing.T) {
 	invalidPackageContent, _ := os.ReadFile("test_assets/package/invalid.tar.gz")
 	recordIgnoreBody(t, fixtureBase+"update_invalid", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
-			ServiceID:      testService.ID,
+			ServiceID:      *testService.ID,
 			ServiceVersion: testVersion.Number,
 			PackageContent: invalidPackageContent,
 		})

--- a/fastly/package_test.go
+++ b/fastly/package_test.go
@@ -14,13 +14,13 @@ func TestClient_Package(t *testing.T) {
 	defer deleteTestService(t, fixtureBase+"service_delete", testService.ID)
 
 	testData := Package{
-		Metadata: PackageMetadata{
-			Description: "Default package template used by the Fastly CLI for Rust-based Compute@Edge projects.",
-			HashSum:     "f99485bd301e23f028474d26d398da525de17a372ae9e7026891d7f85361d2540d14b3b091929c3f170eade573595e20b3405a9e29651ede59915f2e1652f616",
-			Language:    "rust",
-			Name:        "wasm-test",
-			Size:        2015936,
-			FilesHash:   "a763d3c88968ebc17691900d3c14306762296df8e47a1c2d7661cee0e0c5aa6d4c082a7c128d6e719fe333b73b46fe3ae32694716ccd2efa21f5d9f049ceec6d",
+		Metadata: &PackageMetadata{
+			Description: ToPointer("Default package template used by the Fastly CLI for Rust-based Compute@Edge projects."),
+			HashSum:     ToPointer("f99485bd301e23f028474d26d398da525de17a372ae9e7026891d7f85361d2540d14b3b091929c3f170eade573595e20b3405a9e29651ede59915f2e1652f616"),
+			Language:    ToPointer("rust"),
+			Name:        ToPointer("wasm-test"),
+			Size:        ToPointer(int64(2015936)),
+			FilesHash:   ToPointer("a763d3c88968ebc17691900d3c14306762296df8e47a1c2d7661cee0e0c5aa6d4c082a7c128d6e719fe333b73b46fe3ae32694716ccd2efa21f5d9f049ceec6d"),
 		},
 	}
 
@@ -33,17 +33,17 @@ func TestClient_Package(t *testing.T) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      testService.ID,
 			ServiceVersion: testVersion.Number,
-			PackagePath:    "test_assets/package/valid.tar.gz",
+			PackagePath:    ToPointer("test_assets/package/valid.tar.gz"),
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if wp.ServiceID != testService.ID {
-		t.Errorf("bad serviceID: %q != %q", wp.ID, testService.ID)
+	if *wp.ServiceID != testService.ID {
+		t.Errorf("bad serviceID: %q != %q", *wp.ID, testService.ID)
 	}
-	if wp.ServiceVersion != testVersion.Number {
-		t.Errorf("bad serviceVersion: %d != %d", wp.ServiceVersion, testVersion.Number)
+	if *wp.ServiceVersion != testVersion.Number {
+		t.Errorf("bad serviceVersion: %d != %d", *wp.ServiceVersion, testVersion.Number)
 	}
 
 	// Get
@@ -57,30 +57,30 @@ func TestClient_Package(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if wp.ServiceID != testService.ID {
-		t.Errorf("bad serviceID: %q != %q", wp.ID, testService.ID)
+	if *wp.ServiceID != testService.ID {
+		t.Errorf("bad serviceID: %q != %q", *wp.ID, testService.ID)
 	}
-	if wp.ServiceVersion != testVersion.Number {
+	if *wp.ServiceVersion != testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", wp.ServiceVersion, testVersion.Number)
 	}
 
-	if wp.Metadata.Name != testData.Metadata.Name {
-		t.Errorf("bad package name: %q != %q", wp.Metadata.Name, testData.Metadata.Name)
+	if *wp.Metadata.Name != *testData.Metadata.Name {
+		t.Errorf("bad package name: %q != %q", *wp.Metadata.Name, *testData.Metadata.Name)
 	}
-	if wp.Metadata.Description != testData.Metadata.Description {
-		t.Errorf("bad package description: %q != %q", wp.Metadata.Description, testData.Metadata.Description)
+	if *wp.Metadata.Description != *testData.Metadata.Description {
+		t.Errorf("bad package description: %q != %q", *wp.Metadata.Description, *testData.Metadata.Description)
 	}
-	if wp.Metadata.Size != testData.Metadata.Size {
-		t.Errorf("bad package size: %q != %q", wp.Metadata.Size, testData.Metadata.Size)
+	if *wp.Metadata.Size != *testData.Metadata.Size {
+		t.Errorf("bad package size: %q != %q", *wp.Metadata.Size, *testData.Metadata.Size)
 	}
-	if wp.Metadata.HashSum != testData.Metadata.HashSum {
-		t.Errorf("bad package hashsum: %q != %q", wp.Metadata.HashSum, testData.Metadata.HashSum)
+	if *wp.Metadata.HashSum != *testData.Metadata.HashSum {
+		t.Errorf("bad package hashsum: %q != %q", *wp.Metadata.HashSum, *testData.Metadata.HashSum)
 	}
-	if wp.Metadata.FilesHash != testData.Metadata.FilesHash {
-		t.Errorf("bad package files_hash: %q != %q", wp.Metadata.FilesHash, testData.Metadata.FilesHash)
+	if *wp.Metadata.FilesHash != *testData.Metadata.FilesHash {
+		t.Errorf("bad package files_hash: %q != %q", *wp.Metadata.FilesHash, *testData.Metadata.FilesHash)
 	}
-	if wp.Metadata.Language != testData.Metadata.Language {
-		t.Errorf("bad package language: %q != %q", wp.Metadata.Language, testData.Metadata.Language)
+	if *wp.Metadata.Language != *testData.Metadata.Language {
+		t.Errorf("bad package language: %q != %q", *wp.Metadata.Language, *testData.Metadata.Language)
 	}
 
 	// Update with valid package bytes
@@ -96,11 +96,11 @@ func TestClient_Package(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if wp.ServiceID != testService.ID {
-		t.Errorf("bad serviceID: %q != %q", wp.ID, testService.ID)
+	if *wp.ServiceID != testService.ID {
+		t.Errorf("bad serviceID: %q != %q", *wp.ID, testService.ID)
 	}
-	if wp.ServiceVersion != testVersion.Number {
-		t.Errorf("bad serviceVersion: %d != %d", wp.ServiceVersion, testVersion.Number)
+	if *wp.ServiceVersion != testVersion.Number {
+		t.Errorf("bad serviceVersion: %d != %d", *wp.ServiceVersion, testVersion.Number)
 	}
 
 	// Get
@@ -114,27 +114,27 @@ func TestClient_Package(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if wp.ServiceID != testService.ID {
-		t.Errorf("bad serviceID: %q != %q", wp.ID, testService.ID)
+	if *wp.ServiceID != testService.ID {
+		t.Errorf("bad serviceID: %q != %q", *wp.ID, testService.ID)
 	}
-	if wp.ServiceVersion != testVersion.Number {
+	if *wp.ServiceVersion != testVersion.Number {
 		t.Errorf("bad serviceVersion: %d != %d", wp.ServiceVersion, testVersion.Number)
 	}
 
-	if wp.Metadata.Name != testData.Metadata.Name {
-		t.Errorf("bad package name: %q != %q", wp.Metadata.Name, testData.Metadata.Name)
+	if *wp.Metadata.Name != *testData.Metadata.Name {
+		t.Errorf("bad package name: %q != %q", *wp.Metadata.Name, *testData.Metadata.Name)
 	}
-	if wp.Metadata.Description != testData.Metadata.Description {
-		t.Errorf("bad package description: %q != %q", wp.Metadata.Description, testData.Metadata.Description)
+	if *wp.Metadata.Description != *testData.Metadata.Description {
+		t.Errorf("bad package description: %q != %q", *wp.Metadata.Description, *testData.Metadata.Description)
 	}
-	if wp.Metadata.Size != testData.Metadata.Size {
-		t.Errorf("bad package size: %q != %q", wp.Metadata.Size, testData.Metadata.Size)
+	if *wp.Metadata.Size != *testData.Metadata.Size {
+		t.Errorf("bad package size: %q != %q", *wp.Metadata.Size, *testData.Metadata.Size)
 	}
-	if wp.Metadata.HashSum != testData.Metadata.HashSum {
-		t.Errorf("bad package hashsum: %q != %q", wp.Metadata.HashSum, testData.Metadata.HashSum)
+	if *wp.Metadata.HashSum != *testData.Metadata.HashSum {
+		t.Errorf("bad package hashsum: %q != %q", *wp.Metadata.HashSum, *testData.Metadata.HashSum)
 	}
-	if wp.Metadata.Language != testData.Metadata.Language {
-		t.Errorf("bad package language: %q != %q", wp.Metadata.Language, testData.Metadata.Language)
+	if *wp.Metadata.Language != *testData.Metadata.Language {
+		t.Errorf("bad package language: %q != %q", *wp.Metadata.Language, *testData.Metadata.Language)
 	}
 
 	// Update with invalid package file path
@@ -143,11 +143,10 @@ func TestClient_Package(t *testing.T) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      testService.ID,
 			ServiceVersion: testVersion.Number,
-			PackagePath:    "test_assets/package/invalid.tar.gz",
+			PackagePath:    ToPointer("test_assets/package/invalid.tar.gz"),
 		})
 	})
-	if err == nil && (wp.Metadata.Size > 0 || wp.Metadata.Language != "" || wp.Metadata.HashSum != "" || wp.Metadata.Description != "" ||
-		wp.Metadata.Name != "") {
+	if err == nil && (wp.Metadata.Size != nil || wp.Metadata.Language != nil || wp.Metadata.HashSum != nil || wp.Metadata.Description != nil || wp.Metadata.Name != nil) {
 		t.Fatal("Invalid package upload completed rather than failed.")
 	}
 
@@ -161,8 +160,7 @@ func TestClient_Package(t *testing.T) {
 			PackageContent: invalidPackageContent,
 		})
 	})
-	if err == nil && (wp.Metadata.Size > 0 || wp.Metadata.Language != "" || wp.Metadata.HashSum != "" || wp.Metadata.Description != "" ||
-		wp.Metadata.Name != "") {
+	if err == nil && (wp.Metadata.Size != nil || wp.Metadata.Language != nil || wp.Metadata.HashSum != nil || wp.Metadata.Description != nil || wp.Metadata.Name != nil) {
 		t.Fatal("Invalid package upload completed rather than failed.")
 	}
 }

--- a/fastly/paginator.go
+++ b/fastly/paginator.go
@@ -21,7 +21,7 @@ type PaginatorKVStoreEntries interface {
 // This is because we don't assign it to any of the defined function parameters.
 // If we did, then we could do this: https://go.dev/play/p/dfTMGjaSSAX.
 // This means we have to have the caller pass the API path.
-func NewPaginator[T any](client *Client, input *listInput, path string) *ListPaginator[T] {
+func NewPaginator[T any](client *Client, input *ListOpts, path string) *ListPaginator[T] {
 	return &ListPaginator[T]{
 		client: client,
 		input:  input,
@@ -29,8 +29,8 @@ func NewPaginator[T any](client *Client, input *listInput, path string) *ListPag
 	}
 }
 
-// listInput configures the API list options.
-type listInput struct {
+// ListOpts configures the API list options.
+type ListOpts struct {
 	// Direction is the direction in which to sort results.
 	Direction string
 	// Page is the current page.
@@ -50,7 +50,7 @@ type ListPaginator[T any] struct {
 	// Private
 	client   *Client
 	consumed bool
-	input    *listInput
+	input    *ListOpts
 	path     string
 }
 

--- a/fastly/paginator.go
+++ b/fastly/paginator.go
@@ -14,11 +14,14 @@ type PaginatorKVStoreEntries interface {
 	Err() error
 }
 
+// NewPaginator returns a *ListPaginator[T].
+// Exposed for the purposes of mocking the paginator within the Fastly CLI.
+//
 // NOTE: We can't identify the underlying type of the type parameter T.
 // This is because we don't assign it to any of the defined function parameters.
 // If we did, then we could do this: https://go.dev/play/p/dfTMGjaSSAX.
 // This means we have to have the caller pass the API path.
-func newPaginator[T any](client *Client, input *listInput, path string) *ListPaginator[T] {
+func NewPaginator[T any](client *Client, input *listInput, path string) *ListPaginator[T] {
 	return &ListPaginator[T]{
 		client: client,
 		input:  input,

--- a/fastly/paginator.go
+++ b/fastly/paginator.go
@@ -21,10 +21,10 @@ type PaginatorKVStoreEntries interface {
 // This is because we don't assign it to any of the defined function parameters.
 // If we did, then we could do this: https://go.dev/play/p/dfTMGjaSSAX.
 // This means we have to have the caller pass the API path.
-func NewPaginator[T any](client *Client, input *ListOpts, path string) *ListPaginator[T] {
+func NewPaginator[T any](client *Client, opts *ListOpts, path string) *ListPaginator[T] {
 	return &ListPaginator[T]{
 		client: client,
-		input:  input,
+		opts:   opts,
 		path:   path,
 	}
 }
@@ -50,7 +50,7 @@ type ListPaginator[T any] struct {
 	// Private
 	client   *Client
 	consumed bool
-	input    *ListOpts
+	opts     *ListOpts
 	path     string
 }
 
@@ -71,19 +71,19 @@ func (p *ListPaginator[T]) Remaining() int {
 func (p *ListPaginator[T]) GetNext() ([]*T, error) {
 	var perPage int
 	const maxPerPage = 100
-	if p.input.PerPage <= 0 {
+	if p.opts.PerPage <= 0 {
 		perPage = maxPerPage
 	} else {
-		perPage = p.input.PerPage
+		perPage = p.opts.PerPage
 	}
 
 	// page is not specified, fetch from the beginning
-	if p.input.Page <= 0 && p.CurrentPage == 0 {
+	if p.opts.Page <= 0 && p.CurrentPage == 0 {
 		p.CurrentPage = 1
 	} else {
 		// page is specified, fetch from a given page
 		if !p.consumed {
-			p.CurrentPage = p.input.Page
+			p.CurrentPage = p.opts.Page
 		} else {
 			p.CurrentPage++
 		}
@@ -96,11 +96,11 @@ func (p *ListPaginator[T]) GetNext() ([]*T, error) {
 		},
 	}
 
-	if p.input.Direction != "" {
-		requestOptions.Params["direction"] = p.input.Direction
+	if p.opts.Direction != "" {
+		requestOptions.Params["direction"] = p.opts.Direction
 	}
-	if p.input.Sort != "" {
-		requestOptions.Params["sort"] = p.input.Sort
+	if p.opts.Sort != "" {
+		requestOptions.Params["sort"] = p.opts.Sort
 	}
 
 	resp, err := p.client.Get(p.path, requestOptions)

--- a/fastly/paginator.go
+++ b/fastly/paginator.go
@@ -1,6 +1,7 @@
 package fastly
 
 import (
+	"net/http"
 	"net/url"
 	"strconv"
 
@@ -14,6 +15,11 @@ type PaginatorKVStoreEntries interface {
 	Err() error
 }
 
+// PaginationClient represents a HTTP client.
+type PaginationClient interface {
+	Get(p string, ro *RequestOptions) (*http.Response, error)
+}
+
 // NewPaginator returns a *ListPaginator[T].
 // Exposed for the purposes of mocking the paginator within the Fastly CLI.
 //
@@ -21,7 +27,7 @@ type PaginatorKVStoreEntries interface {
 // This is because we don't assign it to any of the defined function parameters.
 // If we did, then we could do this: https://go.dev/play/p/dfTMGjaSSAX.
 // This means we have to have the caller pass the API path.
-func NewPaginator[T any](client *Client, opts ListOpts, path string) *ListPaginator[T] {
+func NewPaginator[T any](client PaginationClient, opts ListOpts, path string) *ListPaginator[T] {
 	return &ListPaginator[T]{
 		client: client,
 		opts:   opts,
@@ -48,7 +54,7 @@ type ListPaginator[T any] struct {
 	NextPage    int
 
 	// Private
-	client   *Client
+	client   PaginationClient
 	consumed bool
 	opts     ListOpts
 	path     string

--- a/fastly/paginator.go
+++ b/fastly/paginator.go
@@ -22,9 +22,15 @@ type PaginatorKVStoreEntries interface {
 // If we did, then we could do this: https://go.dev/play/p/dfTMGjaSSAX.
 // This means we have to have the caller pass the API path.
 func NewPaginator[T any](client *Client, opts *ListOpts, path string) *ListPaginator[T] {
+	// We don't expect users to call this function directly, but in case they do
+	// we need to code defensively and not presume a non-nil value.
+	o := ListOpts{}
+	if opts != nil {
+		o = *opts
+	}
 	return &ListPaginator[T]{
 		client: client,
-		opts:   opts,
+		opts:   o,
 		path:   path,
 	}
 }
@@ -50,7 +56,7 @@ type ListPaginator[T any] struct {
 	// Private
 	client   *Client
 	consumed bool
-	opts     *ListOpts
+	opts     ListOpts
 	path     string
 }
 

--- a/fastly/paginator.go
+++ b/fastly/paginator.go
@@ -21,16 +21,10 @@ type PaginatorKVStoreEntries interface {
 // This is because we don't assign it to any of the defined function parameters.
 // If we did, then we could do this: https://go.dev/play/p/dfTMGjaSSAX.
 // This means we have to have the caller pass the API path.
-func NewPaginator[T any](client *Client, opts *ListOpts, path string) *ListPaginator[T] {
-	// We don't expect users to call this function directly, but in case they do
-	// we need to code defensively and not presume a non-nil value.
-	o := ListOpts{}
-	if opts != nil {
-		o = *opts
-	}
+func NewPaginator[T any](client *Client, opts ListOpts, path string) *ListPaginator[T] {
 	return &ListPaginator[T]{
 		client: client,
-		opts:   o,
+		opts:   opts,
 		path:   path,
 	}
 }

--- a/fastly/papertrail.go
+++ b/fastly/papertrail.go
@@ -3,42 +3,23 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Papertrail represents a papertrail response from the Fastly API.
 type Papertrail struct {
-	Address           string     `mapstructure:"address"`
+	Address           *string    `mapstructure:"address"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	Port              int        `mapstructure:"port"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	Port              *int       `mapstructure:"port"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// papertrailsByName is a sortable list of papertrails.
-type papertrailsByName []*Papertrail
-
-// Len implement the sortable interface.
-func (s papertrailsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s papertrailsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s papertrailsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListPapertrailsInput is used as input to the ListPapertrails function.
@@ -69,7 +50,6 @@ func (c *Client) ListPapertrails(i *ListPapertrailsInput) ([]*Papertrail, error)
 	if err := decodeBodyMap(resp.Body, &ps); err != nil {
 		return nil, err
 	}
-	sort.Stable(papertrailsByName(ps))
 	return ps, nil
 }
 

--- a/fastly/papertrail_test.go
+++ b/fastly/papertrail_test.go
@@ -18,7 +18,7 @@ func TestClient_Papertrails(t *testing.T) {
 	record(t, "papertrails/create", func(c *Client) {
 		p, err = c.CreatePapertrail(&CreatePapertrailInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-papertrail"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
 			Port:           ToPointer(1234),
@@ -36,13 +36,13 @@ func TestClient_Papertrails(t *testing.T) {
 		record(t, "papertrails/cleanup", func(c *Client) {
 			_ = c.DeletePapertrail(&DeletePapertrailInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-papertrail",
 			})
 
 			_ = c.DeletePapertrail(&DeletePapertrailInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-papertrail",
 			})
 		})
@@ -72,7 +72,7 @@ func TestClient_Papertrails(t *testing.T) {
 	record(t, "papertrails/list", func(c *Client) {
 		ps, err = c.ListPapertrails(&ListPapertrailsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func TestClient_Papertrails(t *testing.T) {
 	record(t, "papertrails/get", func(c *Client) {
 		np, err = c.GetPapertrail(&GetPapertrailInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-papertrail",
 		})
 	})
@@ -118,7 +118,7 @@ func TestClient_Papertrails(t *testing.T) {
 	record(t, "papertrails/update", func(c *Client) {
 		up, err = c.UpdatePapertrail(&UpdatePapertrailInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-papertrail",
 			NewName:        ToPointer("new-test-papertrail"),
 		})
@@ -134,7 +134,7 @@ func TestClient_Papertrails(t *testing.T) {
 	record(t, "papertrails/delete", func(c *Client) {
 		err = c.DeletePapertrail(&DeletePapertrailInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-papertrail",
 		})
 	})

--- a/fastly/papertrail_test.go
+++ b/fastly/papertrail_test.go
@@ -48,23 +48,23 @@ func TestClient_Papertrails(t *testing.T) {
 		})
 	}()
 
-	if p.Name != "test-papertrail" {
-		t.Errorf("bad name: %q", p.Name)
+	if *p.Name != "test-papertrail" {
+		t.Errorf("bad name: %q", *p.Name)
 	}
-	if p.Address != "integ-test.go-fastly.com" {
-		t.Errorf("bad address: %q", p.Address)
+	if *p.Address != "integ-test.go-fastly.com" {
+		t.Errorf("bad address: %q", *p.Address)
 	}
-	if p.Port != 1234 {
-		t.Errorf("bad port: %q", p.Port)
+	if *p.Port != 1234 {
+		t.Errorf("bad port: %q", *p.Port)
 	}
-	if p.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", p.FormatVersion)
+	if *p.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *p.FormatVersion)
 	}
-	if p.Format != "format" {
-		t.Errorf("bad format: %q", p.Format)
+	if *p.Format != "format" {
+		t.Errorf("bad format: %q", *p.Format)
 	}
-	if p.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", p.Placement)
+	if *p.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *p.Placement)
 	}
 
 	// List
@@ -94,23 +94,23 @@ func TestClient_Papertrails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Name != np.Name {
-		t.Errorf("bad name: %q", p.Name)
+	if *p.Name != *np.Name {
+		t.Errorf("bad name: %q", *p.Name)
 	}
-	if p.Address != np.Address {
-		t.Errorf("bad address: %q", p.Address)
+	if *p.Address != *np.Address {
+		t.Errorf("bad address: %q", *p.Address)
 	}
-	if p.Port != np.Port {
-		t.Errorf("bad port: %q", p.Port)
+	if *p.Port != *np.Port {
+		t.Errorf("bad port: %q", *p.Port)
 	}
-	if p.FormatVersion != np.FormatVersion {
-		t.Errorf("bad format_version: %q", p.FormatVersion)
+	if *p.FormatVersion != *np.FormatVersion {
+		t.Errorf("bad format_version: %q", *p.FormatVersion)
 	}
-	if p.Format != np.Format {
-		t.Errorf("bad format: %q", p.Format)
+	if *p.Format != *np.Format {
+		t.Errorf("bad format: %q", *p.Format)
 	}
-	if p.Placement != np.Placement {
-		t.Errorf("bad placement: %q", p.Placement)
+	if *p.Placement != *np.Placement {
+		t.Errorf("bad placement: %q", *p.Placement)
 	}
 
 	// Update
@@ -126,8 +126,8 @@ func TestClient_Papertrails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if up.Name != "new-test-papertrail" {
-		t.Errorf("bad name: %q", up.Name)
+	if *up.Name != "new-test-papertrail" {
+		t.Errorf("bad name: %q", *up.Name)
 	}
 
 	// Delete

--- a/fastly/pool.go
+++ b/fastly/pool.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -21,59 +20,35 @@ const (
 // PoolType is a type of pool.
 type PoolType string
 
-// PoolTypePtr returns pointer to PoolType.
-func PoolTypePtr(t PoolType) *PoolType {
-	pt := PoolType(t)
-	return &pt
-}
-
 // Pool represents a pool response from the Fastly API.
 type Pool struct {
-	Comment          string     `mapstructure:"comment"`
-	ConnectTimeout   int        `mapstructure:"connect_timeout"`
+	Comment          *string    `mapstructure:"comment"`
+	ConnectTimeout   *int       `mapstructure:"connect_timeout"`
 	CreatedAt        *time.Time `mapstructure:"created_at"`
 	DeletedAt        *time.Time `mapstructure:"deleted_at"`
-	FirstByteTimeout int        `mapstructure:"first_byte_timeout"`
-	Healthcheck      string     `mapstructure:"healthcheck"`
-	ID               string     `mapstructure:"id"`
-	MaxConnDefault   int        `mapstructure:"max_conn_default"`
-	MaxTLSVersion    string     `mapstructure:"max_tls_version"`
-	MinTLSVersion    string     `mapstructure:"min_tls_version"`
-	Name             string     `mapstructure:"name"`
-	OverrideHost     string     `mapstructure:"override_host"`
-	Quorum           int        `mapstructure:"quorum"`
-	RequestCondition string     `mapstructure:"request_condition"`
-	ServiceID        string     `mapstructure:"service_id"`
-	ServiceVersion   int        `mapstructure:"version"`
-	Shield           string     `mapstructure:"shield"`
-	TLSCACert        string     `mapstructure:"tls_ca_cert"`
-	TLSCertHostname  string     `mapstructure:"tls_cert_hostname"`
-	TLSCheckCert     bool       `mapstructure:"tls_check_cert"`
-	TLSCiphers       string     `mapstructure:"tls_ciphers"`
-	TLSClientCert    string     `mapstructure:"tls_client_cert"`
-	TLSClientKey     string     `mapstructure:"tls_client_key"`
-	TLSSNIHostname   string     `mapstructure:"tls_sni_hostname"`
-	Type             PoolType   `mapstructure:"type"`
+	FirstByteTimeout *int       `mapstructure:"first_byte_timeout"`
+	Healthcheck      *string    `mapstructure:"healthcheck"`
+	ID               *string    `mapstructure:"id"`
+	MaxConnDefault   *int       `mapstructure:"max_conn_default"`
+	MaxTLSVersion    *string    `mapstructure:"max_tls_version"`
+	MinTLSVersion    *string    `mapstructure:"min_tls_version"`
+	Name             *string    `mapstructure:"name"`
+	OverrideHost     *string    `mapstructure:"override_host"`
+	Quorum           *int       `mapstructure:"quorum"`
+	RequestCondition *string    `mapstructure:"request_condition"`
+	ServiceID        *string    `mapstructure:"service_id"`
+	ServiceVersion   *int       `mapstructure:"version"`
+	Shield           *string    `mapstructure:"shield"`
+	TLSCACert        *string    `mapstructure:"tls_ca_cert"`
+	TLSCertHostname  *string    `mapstructure:"tls_cert_hostname"`
+	TLSCheckCert     *bool      `mapstructure:"tls_check_cert"`
+	TLSCiphers       *string    `mapstructure:"tls_ciphers"`
+	TLSClientCert    *string    `mapstructure:"tls_client_cert"`
+	TLSClientKey     *string    `mapstructure:"tls_client_key"`
+	TLSSNIHostname   *string    `mapstructure:"tls_sni_hostname"`
+	Type             *PoolType  `mapstructure:"type"`
 	UpdatedAt        *time.Time `mapstructure:"updated_at"`
-	UseTLS           bool       `mapstructure:"use_tls"`
-}
-
-// poolsByName is a sortable list of pools.
-type poolsByName []*Pool
-
-// Len implement the sortable interface.
-func (s poolsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s poolsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s poolsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	UseTLS           *bool      `mapstructure:"use_tls"`
 }
 
 // ListPoolsInput is used as input to the ListPools function.
@@ -104,7 +79,6 @@ func (c *Client) ListPools(i *ListPoolsInput) ([]*Pool, error) {
 	if err := decodeBodyMap(resp.Body, &ps); err != nil {
 		return nil, err
 	}
-	sort.Stable(poolsByName(ps))
 	return ps, nil
 }
 

--- a/fastly/pool_test.go
+++ b/fastly/pool_test.go
@@ -21,7 +21,7 @@ func TestClient_Pools(t *testing.T) {
 			Name:            ToPointer("test_pool"),
 			Quorum:          ToPointer(50),
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 			TLSCertHostname: ToPointer("example.com"),
 			Type:            ToPointer(PoolTypeRandom),
 			UseTLS:          ToPointer(Compatibool(true)),
@@ -36,13 +36,13 @@ func TestClient_Pools(t *testing.T) {
 		record(t, "pools/cleanup", func(c *Client) {
 			_ = c.DeletePool(&DeletePoolInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test_pool",
 			})
 
 			_ = c.DeletePool(&DeletePoolInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new_test_pool",
 			})
 		})
@@ -69,7 +69,7 @@ func TestClient_Pools(t *testing.T) {
 	record(t, "pools/list", func(c *Client) {
 		ps, err = c.ListPools(&ListPoolsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -84,7 +84,7 @@ func TestClient_Pools(t *testing.T) {
 	record(t, "pools/get", func(c *Client) {
 		np, err = c.GetPool(&GetPoolInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test_pool",
 		})
 	})
@@ -106,7 +106,7 @@ func TestClient_Pools(t *testing.T) {
 	record(t, "pools/update", func(c *Client) {
 		up, err = c.UpdatePool(&UpdatePoolInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test_pool",
 			NewName:        ToPointer("new_test_pool"),
 			Quorum:         ToPointer(0),
@@ -127,7 +127,7 @@ func TestClient_Pools(t *testing.T) {
 	record(t, "pools/delete", func(c *Client) {
 		err = c.DeletePool(&DeletePoolInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new_test_pool",
 		})
 	})

--- a/fastly/pool_test.go
+++ b/fastly/pool_test.go
@@ -23,7 +23,7 @@ func TestClient_Pools(t *testing.T) {
 			ServiceID:       testServiceID,
 			ServiceVersion:  tv.Number,
 			TLSCertHostname: ToPointer("example.com"),
-			Type:            PoolTypePtr(PoolTypeRandom),
+			Type:            ToPointer(PoolTypeRandom),
 			UseTLS:          ToPointer(Compatibool(true)),
 		})
 	})
@@ -48,24 +48,20 @@ func TestClient_Pools(t *testing.T) {
 		})
 	}()
 
-	if p.Name != "test_pool" {
-		t.Errorf("bad name: %q", p.Name)
+	if *p.Name != "test_pool" {
+		t.Errorf("bad name: %q", *p.Name)
 	}
-
-	if p.Quorum != 50 {
-		t.Errorf("bad quorum: %q", p.Quorum)
+	if *p.Quorum != 50 {
+		t.Errorf("bad quorum: %q", *p.Quorum)
 	}
-
-	if !p.UseTLS {
-		t.Errorf("bad use_tls: %t", p.UseTLS)
+	if !*p.UseTLS {
+		t.Errorf("bad use_tls: %t", *p.UseTLS)
 	}
-
-	if p.TLSCertHostname != "example.com" {
-		t.Errorf("bad tls_cert_hostname: %q", p.TLSCertHostname)
+	if *p.TLSCertHostname != "example.com" {
+		t.Errorf("bad tls_cert_hostname: %q", *p.TLSCertHostname)
 	}
-
-	if p.Type != PoolTypeRandom {
-		t.Errorf("bad type: %q", p.Type)
+	if *p.Type != PoolTypeRandom {
+		t.Errorf("bad type: %q", *p.Type)
 	}
 
 	// List
@@ -95,14 +91,14 @@ func TestClient_Pools(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Name != np.Name {
-		t.Errorf("bad name: %q (%q)", p.Name, np.Name)
+	if *p.Name != *np.Name {
+		t.Errorf("bad name: %q (%q)", *p.Name, *np.Name)
 	}
-	if p.Quorum != np.Quorum {
-		t.Errorf("bad quorum: %q (%q)", p.Quorum, np.Quorum)
+	if *p.Quorum != *np.Quorum {
+		t.Errorf("bad quorum: %q (%q)", *p.Quorum, *np.Quorum)
 	}
-	if p.Type != np.Type {
-		t.Errorf("bad type: %q (%q)", p.Type, np.Type)
+	if *p.Type != *np.Type {
+		t.Errorf("bad type: %q (%q)", *p.Type, *np.Type)
 	}
 
 	// Update
@@ -114,17 +110,17 @@ func TestClient_Pools(t *testing.T) {
 			Name:           "test_pool",
 			NewName:        ToPointer("new_test_pool"),
 			Quorum:         ToPointer(0),
-			Type:           PoolTypePtr(PoolTypeHash),
+			Type:           ToPointer(PoolTypeHash),
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if up.Name != "new_test_pool" {
-		t.Errorf("bad name: %q", up.Name)
+	if *up.Name != "new_test_pool" {
+		t.Errorf("bad name: %q", *up.Name)
 	}
-	if up.Quorum != 0 {
-		t.Errorf("bad quorum: %q", up.Quorum)
+	if *up.Quorum != 0 {
+		t.Errorf("bad quorum: %q", *up.Quorum)
 	}
 
 	// Delete

--- a/fastly/product_enablement.go
+++ b/fastly/product_enablement.go
@@ -6,13 +6,13 @@ import (
 
 // ProductEnablement represents a response from the Fastly API.
 type ProductEnablement struct {
-	Product ProductEnablementNested `mapstructure:"product"`
-	Service ProductEnablementNested `mapstructure:"service"`
+	Product *ProductEnablementNested `mapstructure:"product"`
+	Service *ProductEnablementNested `mapstructure:"service"`
 }
 
 type ProductEnablementNested struct {
-	ID     string `mapstructure:"id,omitempty"`
-	Object string `mapstructure:"object,omitempty"`
+	ID     *string `mapstructure:"id,omitempty"`
+	Object *string `mapstructure:"object,omitempty"`
 }
 
 // Product is a base for the different product variants.

--- a/fastly/product_enablement_test.go
+++ b/fastly/product_enablement_test.go
@@ -21,8 +21,8 @@ func TestClient_ProductEnablement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if pe.Product.ID != ProductBrotliCompression.String() {
-		t.Errorf("bad feature_revision: %s", pe.Product.ID)
+	if *pe.Product.ID != ProductBrotliCompression.String() {
+		t.Errorf("bad feature_revision: %s", *pe.Product.ID)
 	}
 
 	// Get Product status
@@ -37,8 +37,8 @@ func TestClient_ProductEnablement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if gpe.Product.ID != ProductBrotliCompression.String() {
-		t.Errorf("bad feature_revision: %s", gpe.Product.ID)
+	if *gpe.Product.ID != ProductBrotliCompression.String() {
+		t.Errorf("bad feature_revision: %s", *gpe.Product.ID)
 	}
 
 	// Disable Product

--- a/fastly/pubsub.go
+++ b/fastly/pubsub.go
@@ -3,45 +3,26 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Pubsub represents an Pubsub logging response from the Fastly API.
 type Pubsub struct {
-	AccountName       string     `mapstructure:"account_name"`
+	AccountName       *string    `mapstructure:"account_name"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	ProjectID         string     `mapstructure:"project_id"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	SecretKey         string     `mapstructure:"secret_key"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	Topic             string     `mapstructure:"topic"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	ProjectID         *string    `mapstructure:"project_id"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	SecretKey         *string    `mapstructure:"secret_key"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	Topic             *string    `mapstructure:"topic"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	User              string     `mapstructure:"user"`
-}
-
-// pubsubsByName is a sortable list of pubsubs.
-type pubsubsByName []*Pubsub
-
-// Len implement the sortable interface.
-func (s pubsubsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s pubsubsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s pubsubsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	User              *string    `mapstructure:"user"`
 }
 
 // ListPubsubsInput is used as input to the ListPubsubs function.
@@ -72,7 +53,6 @@ func (c *Client) ListPubsubs(i *ListPubsubsInput) ([]*Pubsub, error) {
 	if err := decodeBodyMap(resp.Body, &pubsubs); err != nil {
 		return nil, err
 	}
-	sort.Stable(pubsubsByName(pubsubs))
 	return pubsubs, nil
 }
 

--- a/fastly/pubsub_test.go
+++ b/fastly/pubsub_test.go
@@ -52,19 +52,19 @@ func TestClient_Pubsubs(t *testing.T) {
 		})
 	}()
 
-	if pubsub.Name != "test-pubsub" {
-		t.Errorf("bad name: %q", pubsub.Name)
+	if *pubsub.Name != "test-pubsub" {
+		t.Errorf("bad name: %q", *pubsub.Name)
 	}
-	if pubsub.Topic != "topic" {
-		t.Errorf("bad topic: %q", pubsub.Topic)
+	if *pubsub.Topic != "topic" {
+		t.Errorf("bad topic: %q", *pubsub.Topic)
 	}
-	if pubsub.User != "user" {
-		t.Errorf("bad user: %q", pubsub.User)
+	if *pubsub.User != "user" {
+		t.Errorf("bad user: %q", *pubsub.User)
 	}
-	if pubsub.AccountName != "service-account" {
-		t.Errorf("bad account name: %q", pubsub.AccountName)
+	if *pubsub.AccountName != "service-account" {
+		t.Errorf("bad account name: %q", *pubsub.AccountName)
 	}
-	if strings.TrimSpace(pubsub.SecretKey) != `-----BEGIN PRIVATE KEY-----
+	if strings.TrimSpace(*pubsub.SecretKey) != `-----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC9aQoqdHVA86oq
 TdRQ5HqwMfpiLBBMKNQcAJsO71RKNrDWwJJZiyYbvM4FOWRZFtRSdPIDgX0C0Wg1
 NnqWYvHDyA5Ug+T8kowiQDn56dU6Km2FWO4wnqZeA8q5G7rQVXlqdibuiP7FglHA
@@ -92,19 +92,19 @@ in6kQjl7JS4oCNlPEj6aRPLX2OJresI7oOn+uNatKvlVyfPm6rdxeHCmER1FpR7Q
 A/aNVjPeViKT/R4nK9ytsa+s/1IJVrwLFHJK3toGE660g5w3vKrCjWisMdP4yzzQ
 bv1KwcKoQbNVXwauH79JKc0=
 -----END PRIVATE KEY-----` {
-		t.Errorf("bad secret_key: %q", pubsub.SecretKey)
+		t.Errorf("bad secret_key: %q", *pubsub.SecretKey)
 	}
-	if pubsub.ProjectID != "project-id" {
-		t.Errorf("bad project_id: %q", pubsub.ProjectID)
+	if *pubsub.ProjectID != "project-id" {
+		t.Errorf("bad project_id: %q", *pubsub.ProjectID)
 	}
-	if pubsub.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", pubsub.FormatVersion)
+	if *pubsub.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *pubsub.FormatVersion)
 	}
-	if pubsub.Format != "format" {
-		t.Errorf("bad format: %q", pubsub.Format)
+	if *pubsub.Format != "format" {
+		t.Errorf("bad format: %q", *pubsub.Format)
 	}
-	if pubsub.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", pubsub.Placement)
+	if *pubsub.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *pubsub.Placement)
 	}
 
 	// List
@@ -134,29 +134,29 @@ bv1KwcKoQbNVXwauH79JKc0=
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pubsub.Name != npubsub.Name {
-		t.Errorf("bad name: %q", pubsub.Name)
+	if *pubsub.Name != *npubsub.Name {
+		t.Errorf("bad name: %q", *pubsub.Name)
 	}
-	if pubsub.Topic != npubsub.Topic {
-		t.Errorf("bad topic: %q", pubsub.Topic)
+	if *pubsub.Topic != *npubsub.Topic {
+		t.Errorf("bad topic: %q", *pubsub.Topic)
 	}
-	if pubsub.User != npubsub.User {
-		t.Errorf("bad user: %q", pubsub.User)
+	if *pubsub.User != *npubsub.User {
+		t.Errorf("bad user: %q", *pubsub.User)
 	}
-	if pubsub.SecretKey != npubsub.SecretKey {
-		t.Errorf("bad secret_key: %q", pubsub.SecretKey)
+	if *pubsub.SecretKey != *npubsub.SecretKey {
+		t.Errorf("bad secret_key: %q", *pubsub.SecretKey)
 	}
-	if pubsub.ProjectID != npubsub.ProjectID {
-		t.Errorf("bad project_id: %q", pubsub.ProjectID)
+	if *pubsub.ProjectID != *npubsub.ProjectID {
+		t.Errorf("bad project_id: %q", *pubsub.ProjectID)
 	}
-	if pubsub.FormatVersion != npubsub.FormatVersion {
-		t.Errorf("bad format_version: %q", pubsub.FormatVersion)
+	if *pubsub.FormatVersion != *npubsub.FormatVersion {
+		t.Errorf("bad format_version: %q", *pubsub.FormatVersion)
 	}
-	if pubsub.Format != npubsub.Format {
-		t.Errorf("bad format: %q", pubsub.Format)
+	if *pubsub.Format != *npubsub.Format {
+		t.Errorf("bad format: %q", *pubsub.Format)
 	}
-	if pubsub.Placement != npubsub.Placement {
-		t.Errorf("bad placement: %q", pubsub.Placement)
+	if *pubsub.Placement != *npubsub.Placement {
+		t.Errorf("bad placement: %q", *pubsub.Placement)
 	}
 
 	// Update
@@ -173,11 +173,11 @@ bv1KwcKoQbNVXwauH79JKc0=
 	if err != nil {
 		t.Fatal(err)
 	}
-	if upubsub.Name != "new-test-pubsub" {
-		t.Errorf("bad name: %q", upubsub.Name)
+	if *upubsub.Name != "new-test-pubsub" {
+		t.Errorf("bad name: %q", *upubsub.Name)
 	}
-	if upubsub.Topic != "new-topic" {
-		t.Errorf("bad topic: %q", upubsub.Topic)
+	if *upubsub.Topic != "new-topic" {
+		t.Errorf("bad topic: %q", *upubsub.Topic)
 	}
 
 	// Delete

--- a/fastly/pubsub_test.go
+++ b/fastly/pubsub_test.go
@@ -19,7 +19,7 @@ func TestClient_Pubsubs(t *testing.T) {
 	record(t, "pubsubs/create", func(c *Client) {
 		pubsub, err = c.CreatePubsub(&CreatePubsubInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-pubsub"),
 			Topic:          ToPointer("topic"),
 			User:           ToPointer("user"),
@@ -40,13 +40,13 @@ func TestClient_Pubsubs(t *testing.T) {
 		record(t, "pubsubs/cleanup", func(c *Client) {
 			_ = c.DeletePubsub(&DeletePubsubInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-pubsub",
 			})
 
 			_ = c.DeletePubsub(&DeletePubsubInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-pubsub",
 			})
 		})
@@ -112,7 +112,7 @@ bv1KwcKoQbNVXwauH79JKc0=
 	record(t, "pubsubs/list", func(c *Client) {
 		pubsubs, err = c.ListPubsubs(&ListPubsubsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -127,7 +127,7 @@ bv1KwcKoQbNVXwauH79JKc0=
 	record(t, "pubsubs/get", func(c *Client) {
 		npubsub, err = c.GetPubsub(&GetPubsubInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-pubsub",
 		})
 	})
@@ -164,7 +164,7 @@ bv1KwcKoQbNVXwauH79JKc0=
 	record(t, "pubsubs/update", func(c *Client) {
 		upubsub, err = c.UpdatePubsub(&UpdatePubsubInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-pubsub",
 			NewName:        ToPointer("new-test-pubsub"),
 			Topic:          ToPointer("new-topic"),
@@ -184,7 +184,7 @@ bv1KwcKoQbNVXwauH79JKc0=
 	record(t, "pubsubs/delete", func(c *Client) {
 		err = c.DeletePubsub(&DeletePubsubInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-pubsub",
 		})
 	})

--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -9,9 +9,9 @@ import (
 // Purge is a response from a purge request.
 type Purge struct {
 	// ID is the unique ID of the purge request.
-	ID string `mapstructure:"id"`
+	ID *string `mapstructure:"id"`
 	// Status is the status of the purge, usually "ok".
-	Status string `mapstructure:"status"`
+	Status *string `mapstructure:"status"`
 }
 
 // PurgeInput is used as input to the Purge function.
@@ -90,7 +90,6 @@ func (c *Client) PurgeKey(i *PurgeKeyInput) (*Purge, error) {
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
 	}
-
 	if i.Key == "" {
 		return nil, ErrMissingKey
 	}
@@ -136,7 +135,6 @@ func (c *Client) PurgeKeys(i *PurgeKeysInput) (map[string]string, error) {
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
 	}
-
 	if len(i.Keys) == 0 {
 		return nil, ErrMissingKeys
 	}

--- a/fastly/purge_test.go
+++ b/fastly/purge_test.go
@@ -81,10 +81,10 @@ func TestClient_PurgeKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if purge.Status != "ok" {
+	if *purge.Status != "ok" {
 		t.Error("bad status")
 	}
-	if len(purge.ID) == 0 {
+	if purge.ID == nil {
 		t.Error("bad id")
 	}
 }
@@ -123,7 +123,7 @@ func TestClient_PurgeAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if purge.Status != "ok" {
+	if *purge.Status != "ok" {
 		t.Error("bad status")
 	}
 }

--- a/fastly/realtime_stats.go
+++ b/fastly/realtime_stats.go
@@ -8,12 +8,12 @@ import (
 // RealtimeStatsResponse is a response from Fastly's real-time analytics endpoint
 type RealtimeStatsResponse struct {
 	// AggregateDelay is how long the system will wait before aggregating messages for each second.
-	AggregateDelay uint32 `mapstructure:"AggregateDelay"`
+	AggregateDelay *uint32 `mapstructure:"AggregateDelay"`
 	// Data is a list of records, each representing one second of time.
 	Data  []*RealtimeData `mapstructure:"Data"`
-	Error string          `mapstructure:"Error"`
+	Error *string         `mapstructure:"Error"`
 	// Timestamp is a value to use for subsequent requests.
-	Timestamp uint64 `mapstructure:"Timestamp"`
+	Timestamp *uint64 `mapstructure:"Timestamp"`
 }
 
 // RealtimeData represents combined stats for all Fastly's POPs and aggregate of them.
@@ -24,15 +24,15 @@ type RealtimeData struct {
 	// Datacenter groups measurements by POP.
 	Datacenter map[string]*Stats `mapstructure:"datacenter"`
 	// Recorded is the Unix timestamp at which this record's data was generated.
-	Recorded uint64 `mapstructure:"recorded"`
+	Recorded *uint64 `mapstructure:"recorded"`
 }
 
-// GetRealtimeStatsInput is an input parameter to GetRealtimeStats function
+// GetRealtimeStatsInput is an input parameter to GetRealtimeStats function.
 type GetRealtimeStatsInput struct {
-	Limit uint32
-	// ServiceID is the ID of the service.
+	Limit *uint32
+	// ServiceID is the ID of the service (required).
 	ServiceID string
-	// Timestamp is a value to use for subsequent requests.
+	// Timestamp is a value to use for subsequent requests (required).
 	Timestamp uint64
 }
 
@@ -61,8 +61,8 @@ func (c *RTSClient) GetRealtimeStatsJSON(i *GetRealtimeStatsInput, dst interface
 
 	path := fmt.Sprintf("/v1/channel/%s/ts/%d", i.ServiceID, i.Timestamp)
 
-	if i.Limit != 0 {
-		path = fmt.Sprintf("%s/limit/%d", path, i.Limit)
+	if i.Limit != nil {
+		path = fmt.Sprintf("%s/limit/%d", path, *i.Limit)
 	}
 
 	resp, err := c.client.Get(path, nil)

--- a/fastly/realtime_stats_test.go
+++ b/fastly/realtime_stats_test.go
@@ -24,7 +24,7 @@ func TestStatsClient_GetRealtimeStats(t *testing.T) {
 		_, err = c.GetRealtimeStats(&GetRealtimeStatsInput{
 			ServiceID: testServiceID,
 			Timestamp: 0,
-			Limit:     3,
+			Limit:     ToPointer(uint32(3)),
 		})
 	})
 	if err != nil {
@@ -44,7 +44,7 @@ func TestStatsClient_GetRealtimeStatsJSON(t *testing.T) {
 		err = c.GetRealtimeStatsJSON(&GetRealtimeStatsInput{
 			ServiceID: testServiceID,
 			Timestamp: 0,
-			Limit:     3,
+			Limit:     ToPointer(uint32(3)),
 		}, &ret)
 	})
 	if err != nil {

--- a/fastly/request_setting.go
+++ b/fastly/request_setting.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -44,41 +43,23 @@ type RequestSettingXFF string
 
 // RequestSetting represents a request setting response from the Fastly API.
 type RequestSetting struct {
-	Action           RequestSettingAction `mapstructure:"action"`
-	BypassBusyWait   bool                 `mapstructure:"bypass_busy_wait"`
-	CreatedAt        *time.Time           `mapstructure:"created_at"`
-	DefaultHost      string               `mapstructure:"default_host"`
-	DeletedAt        *time.Time           `mapstructure:"deleted_at"`
-	ForceMiss        bool                 `mapstructure:"force_miss"`
-	ForceSSL         bool                 `mapstructure:"force_ssl"`
-	GeoHeaders       bool                 `mapstructure:"geo_headers"`
-	HashKeys         string               `mapstructure:"hash_keys"`
-	MaxStaleAge      int                  `mapstructure:"max_stale_age"`
-	Name             string               `mapstructure:"name"`
-	RequestCondition string               `mapstructure:"request_condition"`
-	ServiceID        string               `mapstructure:"service_id"`
-	ServiceVersion   int                  `mapstructure:"version"`
-	TimerSupport     bool                 `mapstructure:"timer_support"`
-	UpdatedAt        *time.Time           `mapstructure:"updated_at"`
-	XForwardedFor    RequestSettingXFF    `mapstructure:"xff"`
-}
-
-// requestSettingsByName is a sortable list of request settings.
-type requestSettingsByName []*RequestSetting
-
-// Len implement the sortable interface.
-func (s requestSettingsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s requestSettingsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s requestSettingsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	Action           *RequestSettingAction `mapstructure:"action"`
+	BypassBusyWait   *bool                 `mapstructure:"bypass_busy_wait"`
+	CreatedAt        *time.Time            `mapstructure:"created_at"`
+	DefaultHost      *string               `mapstructure:"default_host"`
+	DeletedAt        *time.Time            `mapstructure:"deleted_at"`
+	ForceMiss        *bool                 `mapstructure:"force_miss"`
+	ForceSSL         *bool                 `mapstructure:"force_ssl"`
+	GeoHeaders       *bool                 `mapstructure:"geo_headers"`
+	HashKeys         *string               `mapstructure:"hash_keys"`
+	MaxStaleAge      *int                  `mapstructure:"max_stale_age"`
+	Name             *string               `mapstructure:"name"`
+	RequestCondition *string               `mapstructure:"request_condition"`
+	ServiceID        *string               `mapstructure:"service_id"`
+	ServiceVersion   *int                  `mapstructure:"version"`
+	TimerSupport     *bool                 `mapstructure:"timer_support"`
+	UpdatedAt        *time.Time            `mapstructure:"updated_at"`
+	XForwardedFor    *RequestSettingXFF    `mapstructure:"xff"`
 }
 
 // ListRequestSettingsInput is used as input to the ListRequestSettings
@@ -110,7 +91,6 @@ func (c *Client) ListRequestSettings(i *ListRequestSettingsInput) ([]*RequestSet
 	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
-	sort.Stable(requestSettingsByName(bs))
 	return bs, nil
 }
 
@@ -238,7 +218,7 @@ type UpdateRequestSettingInput struct {
 	// TimerSupport injects the X-Timer info into the request for viewing origin fetch durations.
 	TimerSupport *Compatibool `url:"timer_support,omitempty"`
 	// XForwardedFor determines header value (clear, leave, append, append_all, overwrite)
-	XForwardedFor RequestSettingXFF `url:"xff,omitempty"`
+	XForwardedFor *RequestSettingXFF `url:"xff,omitempty"`
 }
 
 // UpdateRequestSetting updates the specified resource.

--- a/fastly/request_setting_test.go
+++ b/fastly/request_setting_test.go
@@ -53,38 +53,38 @@ func TestClient_RequestSettings(t *testing.T) {
 		})
 	}()
 
-	if rs.Name != "test-request-setting" {
-		t.Errorf("bad name: %q", rs.Name)
+	if *rs.Name != "test-request-setting" {
+		t.Errorf("bad name: %q", *rs.Name)
 	}
-	if !rs.ForceMiss {
-		t.Errorf("bad force_miss: %t", rs.ForceMiss)
+	if !*rs.ForceMiss {
+		t.Errorf("bad force_miss: %t", *rs.ForceMiss)
 	}
-	if !rs.ForceSSL {
-		t.Errorf("bad force_ssl: %t", rs.ForceSSL)
+	if !*rs.ForceSSL {
+		t.Errorf("bad force_ssl: %t", *rs.ForceSSL)
 	}
-	if rs.Action != RequestSettingActionLookup {
-		t.Errorf("bad action: %q", rs.Action)
+	if *rs.Action != RequestSettingActionLookup {
+		t.Errorf("bad action: %q", *rs.Action)
 	}
-	if !rs.BypassBusyWait {
-		t.Errorf("bad bypass_busy_wait: %t", rs.BypassBusyWait)
+	if !*rs.BypassBusyWait {
+		t.Errorf("bad bypass_busy_wait: %t", *rs.BypassBusyWait)
 	}
-	if rs.MaxStaleAge != 30 {
-		t.Errorf("bad max_stale_age: %d", rs.MaxStaleAge)
+	if *rs.MaxStaleAge != 30 {
+		t.Errorf("bad max_stale_age: %d", *rs.MaxStaleAge)
 	}
-	if rs.HashKeys != "a,b,c" {
-		t.Errorf("bad has_keys: %q", rs.HashKeys)
+	if *rs.HashKeys != "a,b,c" {
+		t.Errorf("bad has_keys: %q", *rs.HashKeys)
 	}
-	if rs.XForwardedFor != RequestSettingXFFLeave {
-		t.Errorf("bad xff: %q", rs.XForwardedFor)
+	if *rs.XForwardedFor != RequestSettingXFFLeave {
+		t.Errorf("bad xff: %q", *rs.XForwardedFor)
 	}
-	if !rs.TimerSupport {
-		t.Errorf("bad timer_support: %t", rs.TimerSupport)
+	if !*rs.TimerSupport {
+		t.Errorf("bad timer_support: %t", *rs.TimerSupport)
 	}
-	if !rs.GeoHeaders {
-		t.Errorf("bad geo_headers: %t", rs.GeoHeaders)
+	if !*rs.GeoHeaders {
+		t.Errorf("bad geo_headers: %t", *rs.GeoHeaders)
 	}
-	if rs.DefaultHost != "example.com" {
-		t.Errorf("bad default_host: %q", rs.DefaultHost)
+	if *rs.DefaultHost != "example.com" {
+		t.Errorf("bad default_host: %q", *rs.DefaultHost)
 	}
 
 	// List
@@ -114,38 +114,38 @@ func TestClient_RequestSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if rs.Name != nrs.Name {
-		t.Errorf("bad name: %q (%q)", rs.Name, nrs.Name)
+	if *rs.Name != *nrs.Name {
+		t.Errorf("bad name: %q (%q)", *rs.Name, *nrs.Name)
 	}
-	if rs.ForceMiss != nrs.ForceMiss {
-		t.Errorf("bad force_miss: %t (%t)", rs.ForceMiss, nrs.ForceMiss)
+	if *rs.ForceMiss != *nrs.ForceMiss {
+		t.Errorf("bad force_miss: %t (%t)", *rs.ForceMiss, *nrs.ForceMiss)
 	}
-	if rs.ForceSSL != nrs.ForceSSL {
-		t.Errorf("bad force_ssl: %t (%t)", rs.ForceSSL, nrs.ForceSSL)
+	if *rs.ForceSSL != *nrs.ForceSSL {
+		t.Errorf("bad force_ssl: %t (%t)", *rs.ForceSSL, *nrs.ForceSSL)
 	}
-	if rs.Action != nrs.Action {
-		t.Errorf("bad action: %q (%q)", rs.Action, nrs.Action)
+	if *rs.Action != *nrs.Action {
+		t.Errorf("bad action: %q (%q)", *rs.Action, *nrs.Action)
 	}
-	if rs.BypassBusyWait != nrs.BypassBusyWait {
-		t.Errorf("bad bypass_busy_wait: %t (%t)", rs.BypassBusyWait, nrs.BypassBusyWait)
+	if *rs.BypassBusyWait != *nrs.BypassBusyWait {
+		t.Errorf("bad bypass_busy_wait: %t (%t)", *rs.BypassBusyWait, *nrs.BypassBusyWait)
 	}
-	if rs.MaxStaleAge != nrs.MaxStaleAge {
-		t.Errorf("bad max_stale_age: %d (%d)", rs.MaxStaleAge, nrs.MaxStaleAge)
+	if *rs.MaxStaleAge != *nrs.MaxStaleAge {
+		t.Errorf("bad max_stale_age: %d (%d)", *rs.MaxStaleAge, *nrs.MaxStaleAge)
 	}
-	if rs.HashKeys != nrs.HashKeys {
-		t.Errorf("bad has_keys: %q (%q)", rs.HashKeys, nrs.HashKeys)
+	if *rs.HashKeys != *nrs.HashKeys {
+		t.Errorf("bad has_keys: %q (%q)", *rs.HashKeys, *nrs.HashKeys)
 	}
-	if rs.XForwardedFor != nrs.XForwardedFor {
-		t.Errorf("bad xff: %q (%q)", rs.XForwardedFor, nrs.XForwardedFor)
+	if *rs.XForwardedFor != *nrs.XForwardedFor {
+		t.Errorf("bad xff: %q (%q)", *rs.XForwardedFor, *nrs.XForwardedFor)
 	}
-	if rs.TimerSupport != nrs.TimerSupport {
-		t.Errorf("bad timer_support: %t (%t)", rs.TimerSupport, nrs.TimerSupport)
+	if *rs.TimerSupport != *nrs.TimerSupport {
+		t.Errorf("bad timer_support: %t (%t)", *rs.TimerSupport, *nrs.TimerSupport)
 	}
-	if rs.GeoHeaders != nrs.GeoHeaders {
-		t.Errorf("bad geo_headers: %t (%t)", rs.GeoHeaders, nrs.GeoHeaders)
+	if *rs.GeoHeaders != *nrs.GeoHeaders {
+		t.Errorf("bad geo_headers: %t (%t)", *rs.GeoHeaders, *nrs.GeoHeaders)
 	}
-	if rs.DefaultHost != nrs.DefaultHost {
-		t.Errorf("bad default_host: %q (%q)", rs.DefaultHost, nrs.DefaultHost)
+	if *rs.DefaultHost != *nrs.DefaultHost {
+		t.Errorf("bad default_host: %q (%q)", *rs.DefaultHost, *nrs.DefaultHost)
 	}
 
 	// Update
@@ -162,11 +162,11 @@ func TestClient_RequestSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if urs.Name != "new-test-request-setting" {
-		t.Errorf("bad name: %q", urs.Name)
+	if *urs.Name != "new-test-request-setting" {
+		t.Errorf("bad name: %q", *urs.Name)
 	}
-	if urs.Action != RequestSettingActionPass {
-		t.Errorf("bad action: %q", urs.Action)
+	if *urs.Action != RequestSettingActionPass {
+		t.Errorf("bad action: %q", *urs.Action)
 	}
 
 	// Update 2 (wrap empty string with RequestSettingAction)
@@ -182,8 +182,8 @@ func TestClient_RequestSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if urs2.Action != "" {
-		t.Errorf("bad action: %q", urs2.Action)
+	if *urs2.Action != "" {
+		t.Errorf("bad action: %q", *urs2.Action)
 	}
 
 	// Update 3 (use explicit RequestSettingActionUnset type)
@@ -199,8 +199,8 @@ func TestClient_RequestSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if urs3.Action != RequestSettingActionUnset {
-		t.Errorf("bad action: %q", urs3.Action)
+	if *urs3.Action != RequestSettingActionUnset {
+		t.Errorf("bad action: %q", *urs3.Action)
 	}
 
 	// Delete

--- a/fastly/request_setting_test.go
+++ b/fastly/request_setting_test.go
@@ -18,7 +18,7 @@ func TestClient_RequestSettings(t *testing.T) {
 	record(t, "request_settings/create", func(c *Client) {
 		rs, err = c.CreateRequestSetting(&CreateRequestSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-request-setting"),
 			ForceMiss:      ToPointer(Compatibool(true)),
 			ForceSSL:       ToPointer(Compatibool(true)),
@@ -41,13 +41,13 @@ func TestClient_RequestSettings(t *testing.T) {
 		record(t, "request_settings/cleanup", func(c *Client) {
 			_ = c.DeleteRequestSetting(&DeleteRequestSettingInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-request-setting",
 			})
 
 			_ = c.DeleteRequestSetting(&DeleteRequestSettingInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-request-setting",
 			})
 		})
@@ -92,7 +92,7 @@ func TestClient_RequestSettings(t *testing.T) {
 	record(t, "request_settings/list", func(c *Client) {
 		rss, err = c.ListRequestSettings(&ListRequestSettingsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -107,7 +107,7 @@ func TestClient_RequestSettings(t *testing.T) {
 	record(t, "request_settings/get", func(c *Client) {
 		nrs, err = c.GetRequestSetting(&GetRequestSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-request-setting",
 		})
 	})
@@ -153,7 +153,7 @@ func TestClient_RequestSettings(t *testing.T) {
 	record(t, "request_settings/update", func(c *Client) {
 		urs, err = c.UpdateRequestSetting(&UpdateRequestSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-request-setting",
 			NewName:        ToPointer("new-test-request-setting"),
 			Action:         ToPointer(RequestSettingActionPass),
@@ -174,7 +174,7 @@ func TestClient_RequestSettings(t *testing.T) {
 	record(t, "request_settings/update-2", func(c *Client) {
 		urs2, err = c.UpdateRequestSetting(&UpdateRequestSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-request-setting",
 			Action:         ToPointer(RequestSettingAction("")),
 		})
@@ -191,7 +191,7 @@ func TestClient_RequestSettings(t *testing.T) {
 	record(t, "request_settings/update-3", func(c *Client) {
 		urs3, err = c.UpdateRequestSetting(&UpdateRequestSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-request-setting",
 			Action:         ToPointer(RequestSettingActionUnset),
 		})
@@ -207,7 +207,7 @@ func TestClient_RequestSettings(t *testing.T) {
 	record(t, "request_settings/delete", func(c *Client) {
 		err = c.DeleteRequestSetting(&DeleteRequestSettingInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-request-setting",
 		})
 	})

--- a/fastly/resource.go
+++ b/fastly/resource.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -14,37 +13,21 @@ type Resource struct {
 	// CreatedAt is the date and time in ISO 8601 format.
 	DeletedAt *time.Time `mapstructure:"deleted_at" json:"deleted_at"`
 	// HREF is the path to the resource.
-	HREF string `mapstructure:"href" json:"href"`
+	HREF *string `mapstructure:"href" json:"href"`
 	// ID is an alphanumeric string identifying the resource link.
-	ID string `mapstructure:"id" json:"id"`
+	ID *string `mapstructure:"id" json:"id"`
 	// Name is the name of the resource being linked to.
-	Name string `mapstructure:"name" json:"name"`
+	Name *string `mapstructure:"name" json:"name"`
 	// ResourceID is the ID of the linked resource.
-	ResourceID string `mapstructure:"resource_id" json:"resource_id"`
+	ResourceID *string `mapstructure:"resource_id" json:"resource_id"`
 	// ResourceType is the type of the linked resource.
-	ResourceType string `mapstructure:"resource_type" json:"resource_type"`
+	ResourceType *string `mapstructure:"resource_type" json:"resource_type"`
 	// ServiceID is an alphanumeric string identifying the service.
-	ServiceID string `mapstructure:"service_id" json:"service_id"`
+	ServiceID *string `mapstructure:"service_id" json:"service_id"`
 	// ServiceVersion is an integer identifying a service version.
-	ServiceVersion int `mapstructure:"version" json:"version"`
+	ServiceVersion *int `mapstructure:"version" json:"version"`
 	// UpdatedAt is the date and time in ISO 8601 format.
 	UpdatedAt *time.Time `mapstructure:"updated_at" json:"updated_at"`
-}
-
-// resourcesByName is a sortable list of resources.
-type resourcesByName []*Resource
-
-// Len, Swap, and Less implement the sortable interface.
-func (s resourcesByName) Len() int {
-	return len(s)
-}
-
-func (s resourcesByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s resourcesByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListResourcesInput is used as input to the ListResources function.
@@ -75,7 +58,6 @@ func (c *Client) ListResources(i *ListResourcesInput) ([]*Resource, error) {
 	if err := decodeBodyMap(resp.Body, &rs); err != nil {
 		return nil, err
 	}
-	sort.Stable(resourcesByName(rs))
 	return rs, nil
 }
 

--- a/fastly/resource_test.go
+++ b/fastly/resource_test.go
@@ -46,7 +46,7 @@ func TestClient_Resources(t *testing.T) {
 	record(t, "resources/create", func(c *Client) {
 		r, err = c.CreateResource(&CreateResourceInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer(kvStoreNameForServiceLinking),
 			ResourceID:     ToPointer(o.ID),
 		})
@@ -61,7 +61,7 @@ func TestClient_Resources(t *testing.T) {
 			_ = c.DeleteResource(&DeleteResourceInput{
 				ID:             *r.ID,
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 			})
 		})
 	}()
@@ -75,7 +75,7 @@ func TestClient_Resources(t *testing.T) {
 	record(t, "resources/list", func(c *Client) {
 		rs, err = c.ListResources(&ListResourcesInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -91,7 +91,7 @@ func TestClient_Resources(t *testing.T) {
 		gr, err = c.GetResource(&GetResourceInput{
 			ID:             *r.ID,
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -107,7 +107,7 @@ func TestClient_Resources(t *testing.T) {
 		ur, err = c.UpdateResource(&UpdateResourceInput{
 			ID:             *r.ID,
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("new-kv-store-alias-for-my-service"),
 		})
 	})
@@ -123,7 +123,7 @@ func TestClient_Resources(t *testing.T) {
 		err = c.DeleteResource(&DeleteResourceInput{
 			ID:             *ur.ID,
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {

--- a/fastly/resource_test.go
+++ b/fastly/resource_test.go
@@ -59,15 +59,15 @@ func TestClient_Resources(t *testing.T) {
 	defer func() {
 		record(t, "resources/cleanup", func(c *Client) {
 			_ = c.DeleteResource(&DeleteResourceInput{
-				ID:             r.ID,
+				ID:             *r.ID,
 				ServiceID:      testServiceID,
 				ServiceVersion: tv.Number,
 			})
 		})
 	}()
 
-	if r.Name != kvStoreNameForServiceLinking {
-		t.Errorf("bad name: %q", r.Name)
+	if *r.Name != kvStoreNameForServiceLinking {
+		t.Errorf("bad name: %q", *r.Name)
 	}
 
 	// List
@@ -89,7 +89,7 @@ func TestClient_Resources(t *testing.T) {
 	var gr *Resource
 	record(t, "resources/get", func(c *Client) {
 		gr, err = c.GetResource(&GetResourceInput{
-			ID:             r.ID,
+			ID:             *r.ID,
 			ServiceID:      testServiceID,
 			ServiceVersion: tv.Number,
 		})
@@ -97,15 +97,15 @@ func TestClient_Resources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.Name != gr.Name {
-		t.Errorf("bad name: %q (%q)", r.Name, gr.Name)
+	if *r.Name != *gr.Name {
+		t.Errorf("bad name: %q (%q)", *r.Name, *gr.Name)
 	}
 
 	// Update
 	var ur *Resource
 	record(t, "resources/update", func(c *Client) {
 		ur, err = c.UpdateResource(&UpdateResourceInput{
-			ID:             r.ID,
+			ID:             *r.ID,
 			ServiceID:      testServiceID,
 			ServiceVersion: tv.Number,
 			Name:           ToPointer("new-kv-store-alias-for-my-service"),
@@ -114,14 +114,14 @@ func TestClient_Resources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ur.Name != "new-kv-store-alias-for-my-service" {
-		t.Errorf("bad name: %q", ur.Name)
+	if *ur.Name != "new-kv-store-alias-for-my-service" {
+		t.Errorf("bad name: %q", *ur.Name)
 	}
 
 	// Delete
 	record(t, "resources/delete", func(c *Client) {
 		err = c.DeleteResource(&DeleteResourceInput{
-			ID:             ur.ID,
+			ID:             *ur.ID,
 			ServiceID:      testServiceID,
 			ServiceVersion: tv.Number,
 		})
@@ -256,13 +256,13 @@ func TestResourceJSONRoundtrip(t *testing.T) {
 	r := Resource{
 		CreatedAt:      &now,
 		DeletedAt:      &now,
-		HREF:           "the/href",
-		ID:             "the-id",
-		Name:           "the-name",
-		ResourceID:     "the-resource-id",
-		ResourceType:   "the-resource-type",
-		ServiceID:      "the-service-id",
-		ServiceVersion: 1,
+		HREF:           ToPointer("the/href"),
+		ID:             ToPointer("the-id"),
+		Name:           ToPointer("the-name"),
+		ResourceID:     ToPointer("the-resource-id"),
+		ResourceType:   ToPointer("the-resource-type"),
+		ServiceID:      ToPointer("the-service-id"),
+		ServiceVersion: ToPointer(1),
 		UpdatedAt:      &now,
 	}
 
@@ -284,28 +284,27 @@ func TestResourceJSONRoundtrip(t *testing.T) {
 	}
 	t.Logf("Decoded:\n%#v", decoded)
 
-	if got, want := decoded.HREF, r.HREF; got != want {
+	if got, want := *decoded.HREF, *r.HREF; got != want {
 		t.Errorf("HREF: got %q, want %q", got, want)
 	}
-	if got, want := decoded.ID, r.ID; got != want {
+	if got, want := *decoded.ID, *r.ID; got != want {
 		t.Errorf("ID: got %q, want %q", got, want)
 	}
-	if got, want := decoded.Name, r.Name; got != want {
+	if got, want := *decoded.Name, *r.Name; got != want {
 		t.Errorf("Name: got %q, want %q", got, want)
 	}
-	if got, want := decoded.ResourceID, r.ResourceID; got != want {
+	if got, want := *decoded.ResourceID, *r.ResourceID; got != want {
 		t.Errorf("ResourceID: got %q, want %q", got, want)
 	}
-	if got, want := decoded.ResourceType, r.ResourceType; got != want {
+	if got, want := *decoded.ResourceType, *r.ResourceType; got != want {
 		t.Errorf("ResourceType: got %q, want %q", got, want)
 	}
-	if got, want := decoded.ServiceID, r.ServiceID; got != want {
+	if got, want := *decoded.ServiceID, *r.ServiceID; got != want {
 		t.Errorf("ServiceID: got %q, want %q", got, want)
 	}
-	if got, want := decoded.ServiceVersion, r.ServiceVersion; got != want {
+	if got, want := *decoded.ServiceVersion, *r.ServiceVersion; got != want {
 		t.Errorf("ServiceVersion: got %q, want %q", got, want)
 	}
-
 	if got, want := decoded.CreatedAt, r.CreatedAt; got == nil || !got.Equal(*want) {
 		t.Errorf("CreatedAt: got %s, want %s", got, want)
 	}

--- a/fastly/response_object.go
+++ b/fastly/response_object.go
@@ -3,42 +3,23 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // ResponseObject represents a response object response from the Fastly API.
 type ResponseObject struct {
-	CacheCondition   string     `mapstructure:"cache_condition"`
-	Content          string     `mapstructure:"content"`
-	ContentType      string     `mapstructure:"content_type"`
+	CacheCondition   *string    `mapstructure:"cache_condition"`
+	Content          *string    `mapstructure:"content"`
+	ContentType      *string    `mapstructure:"content_type"`
 	CreatedAt        *time.Time `mapstructure:"created_at"`
 	DeletedAt        *time.Time `mapstructure:"deleted_at"`
-	Name             string     `mapstructure:"name"`
-	RequestCondition string     `mapstructure:"request_condition"`
-	Response         string     `mapstructure:"response"`
-	ServiceID        string     `mapstructure:"service_id"`
-	ServiceVersion   int        `mapstructure:"version"`
-	Status           int        `mapstructure:"status"`
+	Name             *string    `mapstructure:"name"`
+	RequestCondition *string    `mapstructure:"request_condition"`
+	Response         *string    `mapstructure:"response"`
+	ServiceID        *string    `mapstructure:"service_id"`
+	ServiceVersion   *int       `mapstructure:"version"`
+	Status           *int       `mapstructure:"status"`
 	UpdatedAt        *time.Time `mapstructure:"updated_at"`
-}
-
-// responseObjectsByName is a sortable list of response objects.
-type responseObjectsByName []*ResponseObject
-
-// Len implement the sortable interface.
-func (s responseObjectsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s responseObjectsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s responseObjectsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListResponseObjectsInput is used as input to the ListResponseObjects
@@ -70,7 +51,6 @@ func (c *Client) ListResponseObjects(i *ListResponseObjectsInput) ([]*ResponseOb
 	if err := decodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
-	sort.Stable(responseObjectsByName(bs))
 	return bs, nil
 }
 

--- a/fastly/response_object_test.go
+++ b/fastly/response_object_test.go
@@ -47,20 +47,20 @@ func TestClient_ResponseObjects(t *testing.T) {
 		})
 	}()
 
-	if ro.Name != "test-response-object" {
-		t.Errorf("bad name: %q", ro.Name)
+	if *ro.Name != "test-response-object" {
+		t.Errorf("bad name: %q", *ro.Name)
 	}
-	if ro.Status != 200 {
-		t.Errorf("bad status: %q", ro.Status)
+	if *ro.Status != 200 {
+		t.Errorf("bad status: %q", *ro.Status)
 	}
-	if ro.Response != "Ok" {
-		t.Errorf("bad response: %q", ro.Response)
+	if *ro.Response != "Ok" {
+		t.Errorf("bad response: %q", *ro.Response)
 	}
-	if ro.Content != "abcd" {
-		t.Errorf("bad content: %q", ro.Content)
+	if *ro.Content != "abcd" {
+		t.Errorf("bad content: %q", *ro.Content)
 	}
-	if ro.ContentType != "text/plain" {
-		t.Errorf("bad content_type: %q", ro.ContentType)
+	if *ro.ContentType != "text/plain" {
+		t.Errorf("bad content_type: %q", *ro.ContentType)
 	}
 
 	// List
@@ -90,20 +90,20 @@ func TestClient_ResponseObjects(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ro.Name != nro.Name {
-		t.Errorf("bad name: %q", ro.Name)
+	if *ro.Name != *nro.Name {
+		t.Errorf("bad name: %q", *ro.Name)
 	}
-	if ro.Status != nro.Status {
-		t.Errorf("bad status: %q", ro.Status)
+	if *ro.Status != *nro.Status {
+		t.Errorf("bad status: %q", *ro.Status)
 	}
-	if ro.Response != nro.Response {
-		t.Errorf("bad response: %q", ro.Response)
+	if *ro.Response != *nro.Response {
+		t.Errorf("bad response: %q", *ro.Response)
 	}
-	if ro.Content != nro.Content {
-		t.Errorf("bad content: %q", ro.Content)
+	if *ro.Content != *nro.Content {
+		t.Errorf("bad content: %q", *ro.Content)
 	}
-	if ro.ContentType != nro.ContentType {
-		t.Errorf("bad content_type: %q", ro.ContentType)
+	if *ro.ContentType != *nro.ContentType {
+		t.Errorf("bad content_type: %q", *ro.ContentType)
 	}
 
 	// Update
@@ -119,8 +119,8 @@ func TestClient_ResponseObjects(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uro.Name != "new-test-response-object" {
-		t.Errorf("bad name: %q", uro.Name)
+	if *uro.Name != "new-test-response-object" {
+		t.Errorf("bad name: %q", *uro.Name)
 	}
 
 	// Delete

--- a/fastly/response_object_test.go
+++ b/fastly/response_object_test.go
@@ -18,7 +18,7 @@ func TestClient_ResponseObjects(t *testing.T) {
 	record(t, "response_objects/create", func(c *Client) {
 		ro, err = c.CreateResponseObject(&CreateResponseObjectInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-response-object"),
 			Status:         ToPointer(200),
 			Response:       ToPointer("Ok"),
@@ -35,13 +35,13 @@ func TestClient_ResponseObjects(t *testing.T) {
 		record(t, "response_objects/cleanup", func(c *Client) {
 			_ = c.DeleteResponseObject(&DeleteResponseObjectInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-response-object",
 			})
 
 			_ = c.DeleteResponseObject(&DeleteResponseObjectInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-response-object",
 			})
 		})
@@ -68,7 +68,7 @@ func TestClient_ResponseObjects(t *testing.T) {
 	record(t, "response_objects/list", func(c *Client) {
 		ros, err = c.ListResponseObjects(&ListResponseObjectsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -83,7 +83,7 @@ func TestClient_ResponseObjects(t *testing.T) {
 	record(t, "response_objects/get", func(c *Client) {
 		nro, err = c.GetResponseObject(&GetResponseObjectInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-response-object",
 		})
 	})
@@ -111,7 +111,7 @@ func TestClient_ResponseObjects(t *testing.T) {
 	record(t, "response_objects/update", func(c *Client) {
 		uro, err = c.UpdateResponseObject(&UpdateResponseObjectInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-response-object",
 			NewName:        ToPointer("new-test-response-object"),
 		})
@@ -127,7 +127,7 @@ func TestClient_ResponseObjects(t *testing.T) {
 	record(t, "response_objects/delete", func(c *Client) {
 		err = c.DeleteResponseObject(&DeleteResponseObjectInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-response-object",
 		})
 	})

--- a/fastly/s3.go
+++ b/fastly/s3.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -57,51 +56,33 @@ const (
 
 // S3 represents a S3 response from the Fastly API.
 type S3 struct {
-	ACL                          S3AccessControlList    `mapstructure:"acl"`
-	AccessKey                    string                 `mapstructure:"access_key"`
-	BucketName                   string                 `mapstructure:"bucket_name"`
-	CompressionCodec             string                 `mapstructure:"compression_codec"`
-	CreatedAt                    *time.Time             `mapstructure:"created_at"`
-	DeletedAt                    *time.Time             `mapstructure:"deleted_at"`
-	Domain                       string                 `mapstructure:"domain"`
-	FileMaxBytes                 int                    `mapstructure:"file_max_bytes"`
-	Format                       string                 `mapstructure:"format"`
-	FormatVersion                int                    `mapstructure:"format_version"`
-	GzipLevel                    int                    `mapstructure:"gzip_level"`
-	IAMRole                      string                 `mapstructure:"iam_role"`
-	MessageType                  string                 `mapstructure:"message_type"`
-	Name                         string                 `mapstructure:"name"`
-	Path                         string                 `mapstructure:"path"`
-	Period                       int                    `mapstructure:"period"`
-	Placement                    string                 `mapstructure:"placement"`
-	PublicKey                    string                 `mapstructure:"public_key"`
-	Redundancy                   S3Redundancy           `mapstructure:"redundancy"`
-	ResponseCondition            string                 `mapstructure:"response_condition"`
-	SecretKey                    string                 `mapstructure:"secret_key"`
-	ServerSideEncryption         S3ServerSideEncryption `mapstructure:"server_side_encryption"`
-	ServerSideEncryptionKMSKeyID string                 `mapstructure:"server_side_encryption_kms_key_id"`
-	ServiceID                    string                 `mapstructure:"service_id"`
-	ServiceVersion               int                    `mapstructure:"version"`
-	TimestampFormat              string                 `mapstructure:"timestamp_format"`
-	UpdatedAt                    *time.Time             `mapstructure:"updated_at"`
-}
-
-// s3sByName is a sortable list of S3s.
-type s3sByName []*S3
-
-// Len implement the sortable interface.
-func (s s3sByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s s3sByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s s3sByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	ACL                          *S3AccessControlList    `mapstructure:"acl"`
+	AccessKey                    *string                 `mapstructure:"access_key"`
+	BucketName                   *string                 `mapstructure:"bucket_name"`
+	CompressionCodec             *string                 `mapstructure:"compression_codec"`
+	CreatedAt                    *time.Time              `mapstructure:"created_at"`
+	DeletedAt                    *time.Time              `mapstructure:"deleted_at"`
+	Domain                       *string                 `mapstructure:"domain"`
+	FileMaxBytes                 *int                    `mapstructure:"file_max_bytes"`
+	Format                       *string                 `mapstructure:"format"`
+	FormatVersion                *int                    `mapstructure:"format_version"`
+	GzipLevel                    *int                    `mapstructure:"gzip_level"`
+	IAMRole                      *string                 `mapstructure:"iam_role"`
+	MessageType                  *string                 `mapstructure:"message_type"`
+	Name                         *string                 `mapstructure:"name"`
+	Path                         *string                 `mapstructure:"path"`
+	Period                       *int                    `mapstructure:"period"`
+	Placement                    *string                 `mapstructure:"placement"`
+	PublicKey                    *string                 `mapstructure:"public_key"`
+	Redundancy                   *S3Redundancy           `mapstructure:"redundancy"`
+	ResponseCondition            *string                 `mapstructure:"response_condition"`
+	SecretKey                    *string                 `mapstructure:"secret_key"`
+	ServerSideEncryption         *S3ServerSideEncryption `mapstructure:"server_side_encryption"`
+	ServerSideEncryptionKMSKeyID *string                 `mapstructure:"server_side_encryption_kms_key_id"`
+	ServiceID                    *string                 `mapstructure:"service_id"`
+	ServiceVersion               *int                    `mapstructure:"version"`
+	TimestampFormat              *string                 `mapstructure:"timestamp_format"`
+	UpdatedAt                    *time.Time              `mapstructure:"updated_at"`
 }
 
 // ListS3sInput is used as input to the ListS3s function.
@@ -132,7 +113,6 @@ func (c *Client) ListS3s(i *ListS3sInput) ([]*S3, error) {
 	if err := decodeBodyMap(resp.Body, &s3s); err != nil {
 		return nil, err
 	}
-	sort.Stable(s3sByName(s3s))
 	return s3s, nil
 }
 
@@ -277,7 +257,7 @@ type UpdateS3Input struct {
 	IAMRole *string `url:"iam_role,omitempty"`
 	// MessageType is how the message should be formatted (classic, loggly, logplex, blank).
 	MessageType *string `url:"message_type,omitempty"`
-	// Name is the name of the S3 to update.
+	// Name is the name of the S3 to update (required).
 	Name string `url:"-"`
 	// NewName is the new name for the resource.
 	NewName *string `url:"name,omitempty"`

--- a/fastly/s3_test.go
+++ b/fastly/s3_test.go
@@ -244,107 +244,107 @@ func TestClient_S3s(t *testing.T) {
 		})
 	}()
 
-	if s3CreateResp1.Name != "test-s3" {
-		t.Errorf("bad name: %q", s3CreateResp1.Name)
+	if *s3CreateResp1.Name != "test-s3" {
+		t.Errorf("bad name: %q", *s3CreateResp1.Name)
 	}
-	if s3CreateResp1.BucketName != "bucket-name" {
-		t.Errorf("bad bucket_name: %q", s3CreateResp1.BucketName)
+	if *s3CreateResp1.BucketName != "bucket-name" {
+		t.Errorf("bad bucket_name: %q", *s3CreateResp1.BucketName)
 	}
-	if s3CreateResp1.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
-		t.Errorf("bad access_key: %q", s3CreateResp1.AccessKey)
+	if *s3CreateResp1.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("bad access_key: %q", *s3CreateResp1.AccessKey)
 	}
-	if s3CreateResp1.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
-		t.Errorf("bad secret_key: %q", s3CreateResp1.SecretKey)
+	if *s3CreateResp1.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Errorf("bad secret_key: %q", *s3CreateResp1.SecretKey)
 	}
-	if s3CreateResp1.IAMRole != "" {
-		t.Errorf("bad iam_role: %q", s3CreateResp1.IAMRole)
+	if s3CreateResp1.IAMRole != nil {
+		t.Errorf("bad iam_role: %q", *s3CreateResp1.IAMRole)
 	}
-	if s3CreateResp1.Domain != "s3.us-east-1.amazonaws.com" {
-		t.Errorf("bad domain: %q", s3CreateResp1.Domain)
+	if *s3CreateResp1.Domain != "s3.us-east-1.amazonaws.com" {
+		t.Errorf("bad domain: %q", *s3CreateResp1.Domain)
 	}
-	if s3CreateResp1.Path != "/path" {
-		t.Errorf("bad path: %q", s3CreateResp1.Path)
+	if *s3CreateResp1.Path != "/path" {
+		t.Errorf("bad path: %q", *s3CreateResp1.Path)
 	}
-	if s3CreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", s3CreateResp1.Period)
+	if *s3CreateResp1.Period != 12 {
+		t.Errorf("bad period: %q", *s3CreateResp1.Period)
 	}
-	if s3CreateResp1.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", s3CreateResp1.CompressionCodec)
+	if *s3CreateResp1.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *s3CreateResp1.CompressionCodec)
 	}
-	if s3CreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", s3CreateResp1.GzipLevel)
+	if *s3CreateResp1.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *s3CreateResp1.GzipLevel)
 	}
-	if s3CreateResp1.Format != "format" {
-		t.Errorf("bad format: %q", s3CreateResp1.Format)
+	if *s3CreateResp1.Format != "format" {
+		t.Errorf("bad format: %q", *s3CreateResp1.Format)
 	}
-	if s3CreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", s3CreateResp1.FormatVersion)
+	if *s3CreateResp1.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *s3CreateResp1.FormatVersion)
 	}
-	if s3CreateResp1.TimestampFormat != "%Y" {
-		t.Errorf("bad timestamp_format: %q", s3CreateResp1.TimestampFormat)
+	if *s3CreateResp1.TimestampFormat != "%Y" {
+		t.Errorf("bad timestamp_format: %q", *s3CreateResp1.TimestampFormat)
 	}
-	if s3CreateResp1.Redundancy != S3RedundancyReduced {
-		t.Errorf("bad redundancy: %q", s3CreateResp1.Redundancy)
+	if *s3CreateResp1.Redundancy != S3RedundancyReduced {
+		t.Errorf("bad redundancy: %q", *s3CreateResp1.Redundancy)
 	}
-	if s3CreateResp1.MessageType != "classic" {
-		t.Errorf("bad message_type: %q", s3CreateResp1.MessageType)
+	if *s3CreateResp1.MessageType != "classic" {
+		t.Errorf("bad message_type: %q", *s3CreateResp1.MessageType)
 	}
-	if s3CreateResp1.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", s3CreateResp1.Placement)
+	if *s3CreateResp1.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *s3CreateResp1.Placement)
 	}
-	if s3CreateResp1.ResponseCondition != "" {
-		t.Errorf("bad response_condition: %q", s3CreateResp1.ResponseCondition)
+	if *s3CreateResp1.ResponseCondition != "" {
+		t.Errorf("bad response_condition: %q", *s3CreateResp1.ResponseCondition)
 	}
-	if s3CreateResp1.PublicKey != pgpPublicKey() {
-		t.Errorf("bad public_key: %q", s3CreateResp1.PublicKey)
+	if *s3CreateResp1.PublicKey != pgpPublicKey() {
+		t.Errorf("bad public_key: %q", *s3CreateResp1.PublicKey)
 	}
-	if s3CreateResp1.ServerSideEncryption != S3ServerSideEncryptionKMS {
-		t.Errorf("bad server_side_encryption: %q", s3CreateResp1.ServerSideEncryption)
+	if *s3CreateResp1.ServerSideEncryption != S3ServerSideEncryptionKMS {
+		t.Errorf("bad server_side_encryption: %q", *s3CreateResp1.ServerSideEncryption)
 	}
-	if s3CreateResp1.ServerSideEncryptionKMSKeyID != "1234" {
-		t.Errorf("bad server_side_encryption_kms_key_id: %q", s3CreateResp1.ServerSideEncryptionKMSKeyID)
+	if *s3CreateResp1.ServerSideEncryptionKMSKeyID != "1234" {
+		t.Errorf("bad server_side_encryption_kms_key_id: %q", *s3CreateResp1.ServerSideEncryptionKMSKeyID)
 	}
-	if s3CreateResp1.ACL != S3AccessControlListPrivate {
-		t.Errorf("bad acl: %s", s3CreateResp1.ACL)
+	if *s3CreateResp1.ACL != S3AccessControlListPrivate {
+		t.Errorf("bad acl: %s", *s3CreateResp1.ACL)
 	}
-	if s3CreateResp1.FileMaxBytes != MiB {
-		t.Errorf("bad file_max_bytes: %q", s3CreateResp1.FileMaxBytes)
+	if *s3CreateResp1.FileMaxBytes != MiB {
+		t.Errorf("bad file_max_bytes: %q", *s3CreateResp1.FileMaxBytes)
 	}
-	if s3CreateResp2.FileMaxBytes != 10*MiB {
-		t.Errorf("bad file_max_bytes: %q", s3CreateResp2.FileMaxBytes)
+	if *s3CreateResp2.FileMaxBytes != 10*MiB {
+		t.Errorf("bad file_max_bytes: %q", *s3CreateResp2.FileMaxBytes)
 	}
-	if s3CreateResp3.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", s3CreateResp1.CompressionCodec)
+	if *s3CreateResp3.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *s3CreateResp1.CompressionCodec)
 	}
-	if s3CreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", s3CreateResp1.GzipLevel)
+	if *s3CreateResp3.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *s3CreateResp1.GzipLevel)
 	}
-	if s3CreateResp3.Redundancy != S3RedundancyStandardIA {
-		t.Errorf("bad acl: %s", s3CreateResp3.Redundancy)
+	if *s3CreateResp3.Redundancy != S3RedundancyStandardIA {
+		t.Errorf("bad acl: %s", *s3CreateResp3.Redundancy)
 	}
-	if s3CreateResp3.ACL != S3AccessControlListBucketOwnerFullControl {
-		t.Errorf("bad acl: %s", s3CreateResp3.ACL)
+	if *s3CreateResp3.ACL != S3AccessControlListBucketOwnerFullControl {
+		t.Errorf("bad acl: %s", *s3CreateResp3.ACL)
 	}
-	if s3CreateResp3.FileMaxBytes != 0 {
-		t.Errorf("bad file_max_bytes: %q", s3CreateResp3.FileMaxBytes)
+	if *s3CreateResp3.FileMaxBytes != 0 {
+		t.Errorf("bad file_max_bytes: %q", *s3CreateResp3.FileMaxBytes)
 	}
-	if s3CreateResp4.AccessKey != "" {
-		t.Errorf("bad access_key: %q", s3CreateResp4.AccessKey)
+	if s3CreateResp4.AccessKey != nil {
+		t.Errorf("bad access_key: %q", *s3CreateResp4.AccessKey)
 	}
-	if s3CreateResp4.SecretKey != "" {
-		t.Errorf("bad secret_key: %q", s3CreateResp4.SecretKey)
+	if s3CreateResp4.SecretKey != nil {
+		t.Errorf("bad secret_key: %q", *s3CreateResp4.SecretKey)
 	}
-	if s3CreateResp4.IAMRole != "arn:aws:iam::123456789012:role/S3Access" {
-		t.Errorf("bad iam_role: %q", s3CreateResp4.IAMRole)
+	if *s3CreateResp4.IAMRole != "arn:aws:iam::123456789012:role/S3Access" {
+		t.Errorf("bad iam_role: %q", *s3CreateResp4.IAMRole)
 	}
-	if s3CreateResp4.Redundancy != S3RedundancyStandard {
-		t.Errorf("bad acl: %s", s3CreateResp4.Redundancy)
+	if *s3CreateResp4.Redundancy != S3RedundancyStandard {
+		t.Errorf("bad acl: %s", *s3CreateResp4.Redundancy)
 	}
-	if s3CreateResp4.ACL != "" {
-		t.Errorf("bad acl: %s", s3CreateResp4.ACL)
+	if s3CreateResp4.ACL != nil {
+		t.Errorf("bad acl: %s", *s3CreateResp4.ACL)
 	}
-	if s3CreateResp4.FileMaxBytes != 10*MiB {
-		t.Errorf("bad file_max_bytes: %q", s3CreateResp4.FileMaxBytes)
+	if *s3CreateResp4.FileMaxBytes != 10*MiB {
+		t.Errorf("bad file_max_bytes: %q", *s3CreateResp4.FileMaxBytes)
 	}
 
 	// List
@@ -387,80 +387,80 @@ func TestClient_S3s(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if s3CreateResp1.Name != s3GetResp.Name {
-		t.Errorf("bad name: %q", s3CreateResp1.Name)
+	if *s3CreateResp1.Name != *s3GetResp.Name {
+		t.Errorf("bad name: %q", *s3CreateResp1.Name)
 	}
-	if s3CreateResp1.BucketName != s3GetResp.BucketName {
-		t.Errorf("bad bucket_name: %q", s3CreateResp1.BucketName)
+	if *s3CreateResp1.BucketName != *s3GetResp.BucketName {
+		t.Errorf("bad bucket_name: %q", *s3CreateResp1.BucketName)
 	}
-	if s3CreateResp1.AccessKey != s3GetResp.AccessKey {
-		t.Errorf("bad access_key: %q", s3CreateResp1.AccessKey)
+	if *s3CreateResp1.AccessKey != *s3GetResp.AccessKey {
+		t.Errorf("bad access_key: %q", *s3CreateResp1.AccessKey)
 	}
-	if s3CreateResp1.SecretKey != s3GetResp.SecretKey {
-		t.Errorf("bad secret_key: %q", s3CreateResp1.SecretKey)
+	if *s3CreateResp1.SecretKey != *s3GetResp.SecretKey {
+		t.Errorf("bad secret_key: %q", *s3CreateResp1.SecretKey)
 	}
 	if s3CreateResp1.IAMRole != s3GetResp.IAMRole {
-		t.Errorf("bad iam_role: %q", s3CreateResp1.IAMRole)
+		t.Errorf("bad iam_role: %q", *s3CreateResp1.IAMRole)
 	}
-	if s3CreateResp1.Domain != s3GetResp.Domain {
-		t.Errorf("bad domain: %q", s3CreateResp1.Domain)
+	if *s3CreateResp1.Domain != *s3GetResp.Domain {
+		t.Errorf("bad domain: %q", *s3CreateResp1.Domain)
 	}
-	if s3CreateResp1.Path != s3GetResp.Path {
-		t.Errorf("bad path: %q", s3CreateResp1.Path)
+	if *s3CreateResp1.Path != *s3GetResp.Path {
+		t.Errorf("bad path: %q", *s3CreateResp1.Path)
 	}
-	if s3CreateResp1.Period != s3GetResp.Period {
-		t.Errorf("bad period: %q", s3CreateResp1.Period)
+	if *s3CreateResp1.Period != *s3GetResp.Period {
+		t.Errorf("bad period: %q", *s3CreateResp1.Period)
 	}
-	if s3CreateResp1.CompressionCodec != s3GetResp.CompressionCodec {
-		t.Errorf("bad compression_codec: %q", s3CreateResp1.CompressionCodec)
+	if *s3CreateResp1.CompressionCodec != *s3GetResp.CompressionCodec {
+		t.Errorf("bad compression_codec: %q", *s3CreateResp1.CompressionCodec)
 	}
-	if s3CreateResp1.GzipLevel != s3GetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", s3CreateResp1.GzipLevel)
+	if *s3CreateResp1.GzipLevel != *s3GetResp.GzipLevel {
+		t.Errorf("bad gzip_level: %q", *s3CreateResp1.GzipLevel)
 	}
-	if s3CreateResp1.Format != s3GetResp.Format {
-		t.Errorf("bad format: %q", s3CreateResp1.Format)
+	if *s3CreateResp1.Format != *s3GetResp.Format {
+		t.Errorf("bad format: %q", *s3CreateResp1.Format)
 	}
-	if s3CreateResp1.FormatVersion != s3GetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", s3CreateResp1.FormatVersion)
+	if *s3CreateResp1.FormatVersion != *s3GetResp.FormatVersion {
+		t.Errorf("bad format_version: %q", *s3CreateResp1.FormatVersion)
 	}
-	if s3CreateResp1.TimestampFormat != s3GetResp.TimestampFormat {
-		t.Errorf("bad timestamp_format: %q", s3CreateResp1.TimestampFormat)
+	if *s3CreateResp1.TimestampFormat != *s3GetResp.TimestampFormat {
+		t.Errorf("bad timestamp_format: %q", *s3CreateResp1.TimestampFormat)
 	}
-	if s3CreateResp1.Redundancy != s3GetResp.Redundancy {
-		t.Errorf("bad redundancy: %q", s3CreateResp1.Redundancy)
+	if *s3CreateResp1.Redundancy != *s3GetResp.Redundancy {
+		t.Errorf("bad redundancy: %q", *s3CreateResp1.Redundancy)
 	}
-	if s3CreateResp1.Placement != s3GetResp.Placement {
-		t.Errorf("bad placement: %q", s3CreateResp1.Placement)
+	if *s3CreateResp1.Placement != *s3GetResp.Placement {
+		t.Errorf("bad placement: %q", *s3CreateResp1.Placement)
 	}
-	if s3CreateResp1.ResponseCondition != "" {
-		t.Errorf("bad response_condition: %q", s3CreateResp1.ResponseCondition)
+	if *s3CreateResp1.ResponseCondition != "" {
+		t.Errorf("bad response_condition: %q", *s3CreateResp1.ResponseCondition)
 	}
-	if s3CreateResp1.PublicKey != pgpPublicKey() {
-		t.Errorf("bad public_key: %q", s3CreateResp1.PublicKey)
+	if *s3CreateResp1.PublicKey != pgpPublicKey() {
+		t.Errorf("bad public_key: %q", *s3CreateResp1.PublicKey)
 	}
-	if s3CreateResp1.ServerSideEncryption != s3GetResp.ServerSideEncryption {
-		t.Errorf("bad server_side_encryption: %q", s3CreateResp1.ServerSideEncryption)
+	if *s3CreateResp1.ServerSideEncryption != *s3GetResp.ServerSideEncryption {
+		t.Errorf("bad server_side_encryption: %q", *s3CreateResp1.ServerSideEncryption)
 	}
-	if s3CreateResp1.ServerSideEncryptionKMSKeyID != s3GetResp.ServerSideEncryptionKMSKeyID {
-		t.Errorf("bad server_side_encryption_kms_key_id: %q", s3CreateResp1.ServerSideEncryptionKMSKeyID)
+	if *s3CreateResp1.ServerSideEncryptionKMSKeyID != *s3GetResp.ServerSideEncryptionKMSKeyID {
+		t.Errorf("bad server_side_encryption_kms_key_id: %q", *s3CreateResp1.ServerSideEncryptionKMSKeyID)
 	}
-	if s3CreateResp1.ACL != s3GetResp.ACL {
-		t.Errorf("bad acl: %s", s3CreateResp1.ACL)
+	if *s3CreateResp1.ACL != *s3GetResp.ACL {
+		t.Errorf("bad acl: %s", *s3CreateResp1.ACL)
 	}
 	if s3CreateResp4.AccessKey != s3GetResp2.AccessKey {
-		t.Errorf("bad access_key: %q", s3CreateResp4.AccessKey)
+		t.Errorf("bad access_key: %q", *s3CreateResp4.AccessKey)
 	}
 	if s3CreateResp4.SecretKey != s3GetResp2.SecretKey {
-		t.Errorf("bad secret_key: %q", s3CreateResp4.SecretKey)
+		t.Errorf("bad secret_key: %q", *s3CreateResp4.SecretKey)
 	}
-	if s3CreateResp4.IAMRole != s3GetResp2.IAMRole {
-		t.Errorf("bad iam_role: %q", s3CreateResp4.IAMRole)
+	if *s3CreateResp4.IAMRole != *s3GetResp2.IAMRole {
+		t.Errorf("bad iam_role: %q", *s3CreateResp4.IAMRole)
 	}
-	if s3CreateResp4.Redundancy != s3GetResp2.Redundancy {
-		t.Errorf("bad redundancy: %q", s3CreateResp4.Redundancy)
+	if *s3CreateResp4.Redundancy != *s3GetResp2.Redundancy {
+		t.Errorf("bad redundancy: %q", *s3CreateResp4.Redundancy)
 	}
 	if s3CreateResp4.ACL != s3GetResp2.ACL {
-		t.Errorf("bad acl: %s", s3CreateResp4.ACL)
+		t.Errorf("bad acl: %s", *s3CreateResp4.ACL)
 	}
 
 	// Update
@@ -554,50 +554,50 @@ func TestClient_S3s(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if s3UpdateResp1.Name != "new-test-s3" {
-		t.Errorf("bad name: %q", s3UpdateResp1.Name)
+	if *s3UpdateResp1.Name != "new-test-s3" {
+		t.Errorf("bad name: %q", *s3UpdateResp1.Name)
 	}
-	if s3UpdateResp1.PublicKey != pgpPublicKeyUpdate() {
-		t.Errorf("bad public_key: %q", s3UpdateResp1.PublicKey)
+	if *s3UpdateResp1.PublicKey != pgpPublicKeyUpdate() {
+		t.Errorf("bad public_key: %q", *s3UpdateResp1.PublicKey)
 	}
-	if s3UpdateResp1.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", s3UpdateResp1.CompressionCodec)
+	if *s3UpdateResp1.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *s3UpdateResp1.CompressionCodec)
 	}
-	if s3UpdateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", s3UpdateResp1.GzipLevel)
+	if s3UpdateResp1.GzipLevel != nil {
+		t.Errorf("bad gzip_level: %q", *s3UpdateResp1.GzipLevel)
 	}
-	if s3UpdateResp1.FileMaxBytes != 5*MiB {
-		t.Errorf("bad file_max_bytes: %q", s3UpdateResp1.FileMaxBytes)
+	if *s3UpdateResp1.FileMaxBytes != 5*MiB {
+		t.Errorf("bad file_max_bytes: %q", *s3UpdateResp1.FileMaxBytes)
 	}
-	if s3UpdateResp2.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", s3UpdateResp2.CompressionCodec)
+	if *s3UpdateResp2.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *s3UpdateResp2.CompressionCodec)
 	}
-	if s3UpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", s3UpdateResp2.GzipLevel)
+	if *s3UpdateResp2.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *s3UpdateResp2.GzipLevel)
 	}
-	if s3UpdateResp3.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", s3UpdateResp3.CompressionCodec)
+	if s3UpdateResp3.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *s3UpdateResp3.CompressionCodec)
 	}
-	if s3UpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", s3UpdateResp3.GzipLevel)
+	if *s3UpdateResp3.GzipLevel != 9 {
+		t.Errorf("bad gzip_level: %q", *s3UpdateResp3.GzipLevel)
 	}
-	if s3UpdateResp4.AccessKey != "" {
-		t.Errorf("bad access_key: %q", s3UpdateResp4.AccessKey)
+	if *s3UpdateResp4.AccessKey != "" {
+		t.Errorf("bad access_key: %q", *s3UpdateResp4.AccessKey)
 	}
-	if s3UpdateResp4.SecretKey != "" {
-		t.Errorf("bad secret_key: %q", s3UpdateResp4.SecretKey)
+	if *s3UpdateResp4.SecretKey != "" {
+		t.Errorf("bad secret_key: %q", *s3UpdateResp4.SecretKey)
 	}
-	if s3UpdateResp4.IAMRole != "arn:aws:iam::123456789012:role/S3Access" {
-		t.Errorf("bad iam_role: %q", s3UpdateResp4.IAMRole)
+	if *s3UpdateResp4.IAMRole != "arn:aws:iam::123456789012:role/S3Access" {
+		t.Errorf("bad iam_role: %q", *s3UpdateResp4.IAMRole)
 	}
-	if s3UpdateResp5.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
-		t.Errorf("bad access_key: %q", s3UpdateResp5.AccessKey)
+	if *s3UpdateResp5.AccessKey != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("bad access_key: %q", *s3UpdateResp5.AccessKey)
 	}
-	if s3UpdateResp5.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
-		t.Errorf("bad secret_key: %q", s3UpdateResp5.SecretKey)
+	if *s3UpdateResp5.SecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Errorf("bad secret_key: %q", *s3UpdateResp5.SecretKey)
 	}
-	if s3UpdateResp5.IAMRole != "" {
-		t.Errorf("bad iam_role: %q", s3UpdateResp5.IAMRole)
+	if *s3UpdateResp5.IAMRole != "" {
+		t.Errorf("bad iam_role: %q", *s3UpdateResp5.IAMRole)
 	}
 
 	// Delete

--- a/fastly/s3_test.go
+++ b/fastly/s3_test.go
@@ -20,7 +20,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/create", func(c *Client) {
 		s3CreateResp1, err = c.CreateS3(&CreateS3Input{
 			ServiceID:                    testServiceID,
-			ServiceVersion:               tv.Number,
+			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3"),
 			BucketName:                   ToPointer("bucket-name"),
 			Domain:                       ToPointer("s3.us-east-1.amazonaws.com"),
@@ -49,7 +49,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/create2", func(c *Client) {
 		s3CreateResp2, err = c.CreateS3(&CreateS3Input{
 			ServiceID:                    testServiceID,
-			ServiceVersion:               tv.Number,
+			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3-2"),
 			BucketName:                   ToPointer("bucket-name"),
 			Domain:                       ToPointer("s3.us-east-1.amazonaws.com"),
@@ -77,7 +77,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/create3", func(c *Client) {
 		s3CreateResp3, err = c.CreateS3(&CreateS3Input{
 			ServiceID:                    testServiceID,
-			ServiceVersion:               tv.Number,
+			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3-3"),
 			BucketName:                   ToPointer("bucket-name"),
 			Domain:                       ToPointer("s3.us-east-1.amazonaws.com"),
@@ -105,7 +105,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/create4", func(c *Client) {
 		s3CreateResp4, err = c.CreateS3(&CreateS3Input{
 			ServiceID:                    testServiceID,
-			ServiceVersion:               tv.Number,
+			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3-4"),
 			BucketName:                   ToPointer("bucket-name"),
 			Domain:                       ToPointer("s3.us-east-1.amazonaws.com"),
@@ -133,7 +133,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/create5", func(c *Client) {
 		_, err = c.CreateS3(&CreateS3Input{
 			ServiceID:                    testServiceID,
-			ServiceVersion:               tv.Number,
+			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3"),
 			BucketName:                   ToPointer("bucket-name"),
 			Domain:                       ToPointer("s3.us-east-1.amazonaws.com"),
@@ -162,7 +162,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/create6", func(c *Client) {
 		_, err = c.CreateS3(&CreateS3Input{
 			ServiceID:                    testServiceID,
-			ServiceVersion:               tv.Number,
+			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3"),
 			BucketName:                   ToPointer("bucket-name"),
 			Domain:                       ToPointer("s3.us-east-1.amazonaws.com"),
@@ -190,7 +190,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/create7", func(c *Client) {
 		_, err = c.CreateS3(&CreateS3Input{
 			ServiceID:                    testServiceID,
-			ServiceVersion:               tv.Number,
+			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3-2"),
 			BucketName:                   ToPointer("bucket-name"),
 			Domain:                       ToPointer("s3.us-east-1.amazonaws.com"),
@@ -220,25 +220,25 @@ func TestClient_S3s(t *testing.T) {
 		record(t, "s3s/cleanup", func(c *Client) {
 			c.DeleteS3(&DeleteS3Input{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-s3",
 			})
 
 			c.DeleteS3(&DeleteS3Input{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-s3-3",
 			})
 
 			c.DeleteS3(&DeleteS3Input{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-s3-4",
 			})
 
 			c.DeleteS3(&DeleteS3Input{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-s3",
 			})
 		})
@@ -352,7 +352,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/list", func(c *Client) {
 		s3s, err = c.ListS3s(&ListS3sInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -367,7 +367,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/get", func(c *Client) {
 		s3GetResp, err = c.GetS3(&GetS3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-s3",
 		})
 	})
@@ -379,7 +379,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/get2", func(c *Client) {
 		s3GetResp2, err = c.GetS3(&GetS3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-s3-4",
 		})
 	})
@@ -468,7 +468,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/update", func(c *Client) {
 		s3UpdateResp1, err = c.UpdateS3(&UpdateS3Input{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-s3",
 			NewName:          ToPointer("new-test-s3"),
 			PublicKey:        ToPointer(pgpPublicKeyUpdate()),
@@ -485,7 +485,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/update2", func(c *Client) {
 		s3UpdateResp2, err = c.UpdateS3(&UpdateS3Input{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-s3-2",
 			CompressionCodec: ToPointer("zstd"),
 		})
@@ -499,7 +499,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/update3", func(c *Client) {
 		s3UpdateResp3, err = c.UpdateS3(&UpdateS3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-s3-3",
 			GzipLevel:      ToPointer(9),
 		})
@@ -513,7 +513,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/update4", func(c *Client) {
 		s3UpdateResp4, err = c.UpdateS3(&UpdateS3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-s3",
 			AccessKey:      ToPointer(""),
 			SecretKey:      ToPointer(""),
@@ -529,7 +529,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/update5", func(c *Client) {
 		s3UpdateResp5, err = c.UpdateS3(&UpdateS3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-s3-4",
 			AccessKey:      ToPointer("AKIAIOSFODNN7EXAMPLE"),
 			SecretKey:      ToPointer("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
@@ -545,7 +545,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/update6", func(c *Client) {
 		_, err = c.UpdateS3(&UpdateS3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-s3",
 			IAMRole:        ToPointer("badarn"),
 		})
@@ -604,7 +604,7 @@ func TestClient_S3s(t *testing.T) {
 	record(t, "s3s/delete", func(c *Client) {
 		err = c.DeleteS3(&DeleteS3Input{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-s3",
 		})
 	})

--- a/fastly/scalyr.go
+++ b/fastly/scalyr.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,34 +10,16 @@ import (
 type Scalyr struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	Region            string     `mapstructure:"region"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	Token             string     `mapstructure:"token"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	Region            *string    `mapstructure:"region"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	Token             *string    `mapstructure:"token"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// scalyrByName is a sortable list of scalyrs.
-type scalyrsByName []*Scalyr
-
-// Len implements the sortable interface.
-func (s scalyrsByName) Len() int {
-	return len(s)
-}
-
-// Swap implements the sortable interface.
-func (s scalyrsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implements the sortable interface.
-func (s scalyrsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListScalyrsInput is used as input to the ListScalyrs function.
@@ -69,7 +50,6 @@ func (c *Client) ListScalyrs(i *ListScalyrsInput) ([]*Scalyr, error) {
 	if err := decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
-	sort.Stable(scalyrsByName(ss))
 	return ss, nil
 }
 

--- a/fastly/scalyr_test.go
+++ b/fastly/scalyr_test.go
@@ -48,23 +48,23 @@ func TestClient_Scalyrs(t *testing.T) {
 		})
 	}()
 
-	if s.Name != "test-scalyr" {
-		t.Errorf("bad name: %q", s.Name)
+	if *s.Name != "test-scalyr" {
+		t.Errorf("bad name: %q", *s.Name)
 	}
-	if s.Format != "%h %l %u %t \"%r\" %>s %b" {
-		t.Errorf("bad format: %q", s.Format)
+	if *s.Format != "%h %l %u %t \"%r\" %>s %b" {
+		t.Errorf("bad format: %q", *s.Format)
 	}
-	if s.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", s.FormatVersion)
+	if *s.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *s.FormatVersion)
 	}
-	if s.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", s.Placement)
+	if *s.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *s.Placement)
 	}
-	if s.Region != "US" {
-		t.Errorf("bad region: %q", s.Region)
+	if *s.Region != "US" {
+		t.Errorf("bad region: %q", *s.Region)
 	}
-	if s.Token != "super-secure-token" {
-		t.Errorf("bad token: %q", s.Token)
+	if *s.Token != "super-secure-token" {
+		t.Errorf("bad token: %q", *s.Token)
 	}
 
 	// List
@@ -94,23 +94,23 @@ func TestClient_Scalyrs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Name != ns.Name {
-		t.Errorf("bad name: %q", s.Name)
+	if *s.Name != *ns.Name {
+		t.Errorf("bad name: %q", *s.Name)
 	}
-	if s.Format != ns.Format {
-		t.Errorf("bad format: %q", s.Format)
+	if *s.Format != *ns.Format {
+		t.Errorf("bad format: %q", *s.Format)
 	}
-	if s.FormatVersion != ns.FormatVersion {
-		t.Errorf("bad format_version: %q", s.FormatVersion)
+	if *s.FormatVersion != *ns.FormatVersion {
+		t.Errorf("bad format_version: %q", *s.FormatVersion)
 	}
-	if s.Placement != ns.Placement {
-		t.Errorf("bad placement: %q", s.Placement)
+	if *s.Placement != *ns.Placement {
+		t.Errorf("bad placement: %q", *s.Placement)
 	}
-	if s.Region != "US" {
-		t.Errorf("bad region: %q", s.Region)
+	if *s.Region != "US" {
+		t.Errorf("bad region: %q", *s.Region)
 	}
-	if s.Token != ns.Token {
-		t.Errorf("bad token: %q", s.Token)
+	if *s.Token != *ns.Token {
+		t.Errorf("bad token: %q", *s.Token)
 	}
 
 	// Update
@@ -128,14 +128,14 @@ func TestClient_Scalyrs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if us.Name != "new-test-scalyr" {
-		t.Errorf("bad name: %q", us.Name)
+	if *us.Name != "new-test-scalyr" {
+		t.Errorf("bad name: %q", *us.Name)
 	}
-	if us.Region != "EU" {
-		t.Errorf("bad region: %q", us.Region)
+	if *us.Region != "EU" {
+		t.Errorf("bad region: %q", *us.Region)
 	}
-	if us.Token != "new-token" {
-		t.Errorf("bad token: %q", us.Token)
+	if *us.Token != "new-token" {
+		t.Errorf("bad token: %q", *us.Token)
 	}
 
 	// Delete

--- a/fastly/scalyr_test.go
+++ b/fastly/scalyr_test.go
@@ -18,7 +18,7 @@ func TestClient_Scalyrs(t *testing.T) {
 	record(t, "scalyrs/create", func(c *Client) {
 		s, err = c.CreateScalyr(&CreateScalyrInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-scalyr"),
 			Format:         ToPointer("%h %l %u %t \"%r\" %>s %b"),
 			FormatVersion:  ToPointer(2),
@@ -36,13 +36,13 @@ func TestClient_Scalyrs(t *testing.T) {
 		record(t, "scalyrs/cleanup", func(c *Client) {
 			_ = c.DeleteScalyr(&DeleteScalyrInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-scalyr",
 			})
 
 			_ = c.DeleteScalyr(&DeleteScalyrInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-scalyr",
 			})
 		})
@@ -72,7 +72,7 @@ func TestClient_Scalyrs(t *testing.T) {
 	record(t, "scalyrs/list", func(c *Client) {
 		ss, err = c.ListScalyrs(&ListScalyrsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func TestClient_Scalyrs(t *testing.T) {
 	record(t, "scalyrs/get", func(c *Client) {
 		ns, err = c.GetScalyr(&GetScalyrInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-scalyr",
 		})
 	})
@@ -118,7 +118,7 @@ func TestClient_Scalyrs(t *testing.T) {
 	record(t, "scalyrs/update", func(c *Client) {
 		us, err = c.UpdateScalyr(&UpdateScalyrInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-scalyr",
 			NewName:        ToPointer("new-test-scalyr"),
 			Region:         ToPointer("EU"),
@@ -142,7 +142,7 @@ func TestClient_Scalyrs(t *testing.T) {
 	record(t, "scalyrs/delete", func(c *Client) {
 		err = c.DeleteScalyr(&DeleteScalyrInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-scalyr",
 		})
 	})

--- a/fastly/server.go
+++ b/fastly/server.go
@@ -2,43 +2,24 @@ package fastly
 
 import (
 	"fmt"
-	"sort"
 	"time"
 )
 
 // Server represents a server response from the Fastly API.
 type Server struct {
-	Address      string     `mapstructure:"address"`
-	Comment      string     `mapstructure:"comment"`
+	Address      *string    `mapstructure:"address"`
+	Comment      *string    `mapstructure:"comment"`
 	CreatedAt    *time.Time `mapstructure:"created_at"`
 	DeletedAt    *time.Time `mapstructure:"deleted_at"`
-	Disabled     bool       `mapstructure:"disabled"`
-	ID           string     `mapstructure:"id"`
-	MaxConn      int        `mapstructure:"max_conn"`
-	OverrideHost string     `mapstructure:"override_host"`
-	PoolID       string     `mapstructure:"pool_id"`
-	Port         int        `mapstructure:"port"`
-	ServiceID    string     `mapstructure:"service_id"`
+	Disabled     *bool      `mapstructure:"disabled"`
+	ID           *string    `mapstructure:"id"`
+	MaxConn      *int       `mapstructure:"max_conn"`
+	OverrideHost *string    `mapstructure:"override_host"`
+	PoolID       *string    `mapstructure:"pool_id"`
+	Port         *int       `mapstructure:"port"`
+	ServiceID    *string    `mapstructure:"service_id"`
 	UpdatedAt    *time.Time `mapstructure:"updated_at"`
-	Weight       int        `mapstructure:"weight"`
-}
-
-// serversByAddress is a sortable list of servers.
-type serversByAddress []*Server
-
-// Len implement the sortable interface.
-func (s serversByAddress) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s serversByAddress) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s serversByAddress) Less(i, j int) bool {
-	return s[i].Address < s[j].Address
+	Weight       *int       `mapstructure:"weight"`
 }
 
 // ListServersInput is used as input to the ListServers function.
@@ -69,7 +50,6 @@ func (c *Client) ListServers(i *ListServersInput) ([]*Server, error) {
 	if err := decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
-	sort.Stable(serversByAddress(ss))
 	return ss, nil
 }
 

--- a/fastly/server_test.go
+++ b/fastly/server_test.go
@@ -47,7 +47,7 @@ func TestClient_Servers(t *testing.T) {
 			_ = c.DeleteServer(&DeleteServerInput{
 				ServiceID: testServiceID,
 				PoolID:    *testPool.ID,
-				Server:    altServer.ID,
+				Server:    *altServer.ID,
 			})
 
 			// Expected to fail as the API forbids deleting the last server in
@@ -56,19 +56,19 @@ func TestClient_Servers(t *testing.T) {
 			_ = c.DeleteServer(&DeleteServerInput{
 				ServiceID: testServiceID,
 				PoolID:    *testPool.ID,
-				Server:    server.ID,
+				Server:    *server.ID,
 			})
 		})
 	}()
 
-	if server.ServiceID != testServiceID {
-		t.Errorf("bad server service: %q", server.ServiceID)
+	if *server.ServiceID != testServiceID {
+		t.Errorf("bad server service: %q", *server.ServiceID)
 	}
-	if server.PoolID != *testPool.ID {
-		t.Errorf("bad server pool: %q", server.PoolID)
+	if *server.PoolID != *testPool.ID {
+		t.Errorf("bad server pool: %q", *server.PoolID)
 	}
-	if server.Address != "127.0.0.1" {
-		t.Errorf("bad server address: %q", server.Address)
+	if *server.Address != "127.0.0.1" {
+		t.Errorf("bad server address: %q", *server.Address)
 	}
 
 	// List
@@ -92,14 +92,14 @@ func TestClient_Servers(t *testing.T) {
 		ns, err = c.GetServer(&GetServerInput{
 			ServiceID: testServiceID,
 			PoolID:    *testPool.ID,
-			Server:    server.ID,
+			Server:    *server.ID,
 		})
 	})
-	if server.ID != ns.ID {
-		t.Errorf("bad ID: %q (%q)", server.ID, ns.ID)
+	if *server.ID != *ns.ID {
+		t.Errorf("bad ID: %q (%q)", *server.ID, *ns.ID)
 	}
-	if server.Address != ns.Address {
-		t.Errorf("bad address: %q (%q)", server.Address, ns.Address)
+	if *server.Address != *ns.Address {
+		t.Errorf("bad address: %q (%q)", *server.Address, *ns.Address)
 	}
 
 	// Update
@@ -108,7 +108,7 @@ func TestClient_Servers(t *testing.T) {
 		us, err = c.UpdateServer(&UpdateServerInput{
 			ServiceID: testServiceID,
 			PoolID:    *testPool.ID,
-			Server:    server.ID,
+			Server:    *server.ID,
 			Address:   ToPointer("0.0.0.0"),
 			Weight:    ToPointer(50),
 		})
@@ -116,10 +116,10 @@ func TestClient_Servers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if us.Address == server.Address {
-		t.Errorf("bad address: %s", us.Address)
+	if *us.Address == *server.Address {
+		t.Errorf("bad address: %s", *us.Address)
 	}
-	if us.Weight != 50 {
+	if *us.Weight != 50 {
 		t.Errorf("bad weight: %q", 50)
 	}
 
@@ -128,7 +128,7 @@ func TestClient_Servers(t *testing.T) {
 		err = c.DeleteServer(&DeleteServerInput{
 			ServiceID: testServiceID,
 			PoolID:    *testPool.ID,
-			Server:    altServer.ID,
+			Server:    *altServer.ID,
 		})
 	})
 	if err != nil {

--- a/fastly/server_test.go
+++ b/fastly/server_test.go
@@ -19,7 +19,7 @@ func TestClient_Servers(t *testing.T) {
 	record(t, "servers/create", func(c *Client) {
 		server, err = c.CreateServer(&CreateServerInput{
 			ServiceID: testServiceID,
-			PoolID:    testPool.ID,
+			PoolID:    *testPool.ID,
 			Address:   ToPointer("127.0.0.1"),
 		})
 		if err != nil {
@@ -29,7 +29,7 @@ func TestClient_Servers(t *testing.T) {
 		// additional pool server for DeleteServer usage
 		altServer, err = c.CreateServer(&CreateServerInput{
 			ServiceID: testServiceID,
-			PoolID:    testPool.ID,
+			PoolID:    *testPool.ID,
 			Address:   ToPointer("altserver.example.com"),
 		})
 		if err != nil {
@@ -46,7 +46,7 @@ func TestClient_Servers(t *testing.T) {
 			// Expected to fail as this was explicitly deleted in the test.
 			_ = c.DeleteServer(&DeleteServerInput{
 				ServiceID: testServiceID,
-				PoolID:    testPool.ID,
+				PoolID:    *testPool.ID,
 				Server:    altServer.ID,
 			})
 
@@ -55,7 +55,7 @@ func TestClient_Servers(t *testing.T) {
 			// exists as it may be associated with other versions.
 			_ = c.DeleteServer(&DeleteServerInput{
 				ServiceID: testServiceID,
-				PoolID:    testPool.ID,
+				PoolID:    *testPool.ID,
 				Server:    server.ID,
 			})
 		})
@@ -64,7 +64,7 @@ func TestClient_Servers(t *testing.T) {
 	if server.ServiceID != testServiceID {
 		t.Errorf("bad server service: %q", server.ServiceID)
 	}
-	if server.PoolID != testPool.ID {
+	if server.PoolID != *testPool.ID {
 		t.Errorf("bad server pool: %q", server.PoolID)
 	}
 	if server.Address != "127.0.0.1" {
@@ -76,7 +76,7 @@ func TestClient_Servers(t *testing.T) {
 	record(t, "servers/list", func(c *Client) {
 		ss, err = c.ListServers(&ListServersInput{
 			ServiceID: testServiceID,
-			PoolID:    testPool.ID,
+			PoolID:    *testPool.ID,
 		})
 	})
 	if err != nil {
@@ -91,7 +91,7 @@ func TestClient_Servers(t *testing.T) {
 	record(t, "servers/get", func(c *Client) {
 		ns, err = c.GetServer(&GetServerInput{
 			ServiceID: testServiceID,
-			PoolID:    testPool.ID,
+			PoolID:    *testPool.ID,
 			Server:    server.ID,
 		})
 	})
@@ -107,7 +107,7 @@ func TestClient_Servers(t *testing.T) {
 	record(t, "servers/update", func(c *Client) {
 		us, err = c.UpdateServer(&UpdateServerInput{
 			ServiceID: testServiceID,
-			PoolID:    testPool.ID,
+			PoolID:    *testPool.ID,
 			Server:    server.ID,
 			Address:   ToPointer("0.0.0.0"),
 			Weight:    ToPointer(50),
@@ -127,7 +127,7 @@ func TestClient_Servers(t *testing.T) {
 	record(t, "servers/delete", func(c *Client) {
 		err = c.DeleteServer(&DeleteServerInput{
 			ServiceID: testServiceID,
-			PoolID:    testPool.ID,
+			PoolID:    *testPool.ID,
 			Server:    altServer.ID,
 		})
 	})

--- a/fastly/server_test.go
+++ b/fastly/server_test.go
@@ -11,7 +11,7 @@ func TestClient_Servers(t *testing.T) {
 		tv = testVersion(t, c)
 	})
 
-	testPool := createTestPool(t, "servers/create_pool", testServiceID, tv.Number, "servers22")
+	testPool := createTestPool(t, "servers/create_pool", testServiceID, *tv.Number, "servers22")
 
 	// Create
 	var server *Server

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -161,8 +161,8 @@ func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
 	// We work around this by manually finding the active version number from the
 	// "versions" array in the returned JSON response.
 	for i := range s.Versions {
-		if s.Versions[i].Active {
-			s.ActiveVersion = ToPointer(s.Versions[i].Number)
+		if *s.Versions[i].Active {
+			s.ActiveVersion = s.Versions[i].Number
 			break
 		}
 	}

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -7,42 +7,42 @@ import (
 
 // Service represents a server response from the Fastly API.
 type Service struct {
-	ActiveVersion int        `mapstructure:"version"`
-	Comment       string     `mapstructure:"comment"`
+	ActiveVersion *int       `mapstructure:"version"`
+	Comment       *string    `mapstructure:"comment"`
 	CreatedAt     *time.Time `mapstructure:"created_at"`
-	CustomerID    string     `mapstructure:"customer_id"`
+	CustomerID    *string    `mapstructure:"customer_id"`
 	DeletedAt     *time.Time `mapstructure:"deleted_at"`
-	ID            string     `mapstructure:"id"`
-	Name          string     `mapstructure:"name"`
-	Type          string     `mapstructure:"type"`
+	ID            *string    `mapstructure:"id"`
+	Name          *string    `mapstructure:"name"`
+	Type          *string    `mapstructure:"type"`
 	UpdatedAt     *time.Time `mapstructure:"updated_at"`
 	Versions      []*Version `mapstructure:"versions"`
 }
 
 // ServiceDetail represents a server response from the Fastly API.
 type ServiceDetail struct {
-	ActiveVersion Version    `mapstructure:"active_version"`
-	Comment       string     `mapstructure:"comment"`
+	ActiveVersion *Version   `mapstructure:"active_version"`
+	Comment       *string    `mapstructure:"comment"`
 	CreatedAt     *time.Time `mapstructure:"created_at"`
-	CustomerID    string     `mapstructure:"customer_id"`
+	CustomerID    *string    `mapstructure:"customer_id"`
 	DeletedAt     *time.Time `mapstructure:"deleted_at"`
-	ID            string     `mapstructure:"id"`
-	Name          string     `mapstructure:"name"`
-	Type          string     `mapstructure:"type"`
+	ID            *string    `mapstructure:"id"`
+	Name          *string    `mapstructure:"name"`
+	Type          *string    `mapstructure:"type"`
 	UpdatedAt     *time.Time `mapstructure:"updated_at"`
-	Version       Version    `mapstructure:"version"`
+	Version       *Version   `mapstructure:"version"`
 	Versions      []*Version `mapstructure:"versions"`
 }
 
 // ServiceDomain represents a server response from the Fastly API.
 type ServiceDomain struct {
-	Comment        string     `mapstructure:"comment"`
+	Comment        *string    `mapstructure:"comment"`
 	CreatedAt      *time.Time `mapstructure:"created_at"`
 	DeletedAt      *time.Time `mapstructure:"deleted_at"`
-	Locked         bool       `mapstructure:"locked"`
-	Name           string     `mapstructure:"name"`
-	ServiceID      string     `mapstructure:"service_id"`
-	ServiceVersion int64      `mapstructure:"version"`
+	Locked         *bool      `mapstructure:"locked"`
+	Name           *string    `mapstructure:"name"`
+	ServiceID      *string    `mapstructure:"service_id"`
+	ServiceVersion *int64     `mapstructure:"version"`
 	UpdatedAt      *time.Time `mapstructure:"updated_at"`
 }
 
@@ -52,31 +52,39 @@ type ServiceDomainsList []*ServiceDomain
 // GetServicesInput is used as input to the GetServices function.
 type GetServicesInput struct {
 	// Direction is the direction in which to sort results.
-	Direction string
+	Direction *string
 	// Page is the current page.
-	Page int
+	Page *int
 	// PerPage is the number of records per page.
-	PerPage int
+	PerPage *int
 	// Sort is the field on which to sort.
-	Sort string
+	Sort *string
 }
 
 // GetServices returns a ListPaginator for paginating through the resources.
 func (c *Client) GetServices(i *GetServicesInput) *ListPaginator[Service] {
-	return newPaginator[Service](c, &listInput{
-		Direction: i.Direction,
-		Sort:      i.Sort,
-		Page:      i.Page,
-		PerPage:   i.PerPage,
-	}, "/service")
+	input := &listInput{}
+	if i.Direction != nil {
+		input.Direction = *i.Direction
+	}
+	if i.Sort != nil {
+		input.Sort = *i.Sort
+	}
+	if i.Page != nil {
+		input.Page = *i.Page
+	}
+	if i.PerPage != nil {
+		input.PerPage = *i.PerPage
+	}
+	return newPaginator[Service](c, input, "/service")
 }
 
 // ListServicesInput is used as input to the ListServices function.
 type ListServicesInput struct {
 	// Direction is the direction in which to sort results.
-	Direction string
+	Direction *string
 	// Sort is the field on which to sort.
-	Sort string
+	Sort *string
 }
 
 // ListServices retrieves all resources. Not suitable for large collections.
@@ -154,7 +162,7 @@ func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
 	// "versions" array in the returned JSON response.
 	for i := range s.Versions {
 		if s.Versions[i].Active {
-			s.ActiveVersion = s.Versions[i].Number
+			s.ActiveVersion = ToPointer(s.Versions[i].Number)
 			break
 		}
 	}

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -76,7 +76,7 @@ func (c *Client) GetServices(i *GetServicesInput) *ListPaginator[Service] {
 	if i.PerPage != nil {
 		input.PerPage = *i.PerPage
 	}
-	return newPaginator[Service](c, input, "/service")
+	return NewPaginator[Service](c, input, "/service")
 }
 
 // ListServicesInput is used as input to the ListServices function.

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -63,7 +63,7 @@ type GetServicesInput struct {
 
 // GetServices returns a ListPaginator for paginating through the resources.
 func (c *Client) GetServices(i *GetServicesInput) *ListPaginator[Service] {
-	input := &ListOpts{}
+	input := ListOpts{}
 	if i.Direction != nil {
 		input.Direction = *i.Direction
 	}

--- a/fastly/service.go
+++ b/fastly/service.go
@@ -63,7 +63,7 @@ type GetServicesInput struct {
 
 // GetServices returns a ListPaginator for paginating through the resources.
 func (c *Client) GetServices(i *GetServicesInput) *ListPaginator[Service] {
-	input := &listInput{}
+	input := &ListOpts{}
 	if i.Direction != nil {
 		input.Direction = *i.Direction
 	}

--- a/fastly/service_test.go
+++ b/fastly/service_test.go
@@ -125,7 +125,7 @@ func TestClient_Services(t *testing.T) {
 	if *s.Comment != *nsd.Comment {
 		t.Errorf("bad comment: %q (%q)", *s.Comment, *nsd.Comment)
 	}
-	if nsd.Version.Number == 0 {
+	if *nsd.Version.Number == 0 {
 		t.Errorf("Service Detail Version is empty: (%#v)", nsd)
 	}
 

--- a/fastly/service_test.go
+++ b/fastly/service_test.go
@@ -25,28 +25,28 @@ func TestClient_Services(t *testing.T) {
 	defer func() {
 		record(t, "services/cleanup", func(c *Client) {
 			_ = c.DeleteService(&DeleteServiceInput{
-				ID: s.ID,
+				ID: *s.ID,
 			})
 
 			_ = c.DeleteService(&DeleteServiceInput{
-				ID: s.ID,
+				ID: *s.ID,
 			})
 		})
 	}()
 
-	if s.Name != "test-service" {
-		t.Errorf("bad name: %q", s.Name)
+	if *s.Name != "test-service" {
+		t.Errorf("bad name: %q", *s.Name)
 	}
-	if s.Comment != "comment" {
-		t.Errorf("bad comment: %q", s.Comment)
+	if *s.Comment != "comment" {
+		t.Errorf("bad comment: %q", *s.Comment)
 	}
 
 	// List
 	var ss []*Service
 	record(t, "services/list", func(c *Client) {
 		ss, err = c.ListServices(&ListServicesInput{
-			Direction: "descend",
-			Sort:      "created",
+			Direction: ToPointer("descend"),
+			Sort:      ToPointer("created"),
 		})
 	})
 	if err != nil {
@@ -61,9 +61,9 @@ func TestClient_Services(t *testing.T) {
 	var paginator *ListPaginator[Service]
 	record(t, "services/list_paginator", func(c *Client) {
 		paginator = c.GetServices(&GetServicesInput{
-			Direction: "descend",
-			PerPage:   200,
-			Sort:      "created",
+			Direction: ToPointer("descend"),
+			PerPage:   ToPointer(200),
+			Sort:      ToPointer("created"),
 		})
 
 		for paginator.HasNext() {
@@ -86,47 +86,44 @@ func TestClient_Services(t *testing.T) {
 	var ns *Service
 	record(t, "services/get", func(c *Client) {
 		ns, err = c.GetService(&GetServiceInput{
-			ID: s.ID,
+			ID: *s.ID,
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Name != ns.Name {
-		t.Errorf("bad name: %q (%q)", s.Name, ns.Name)
+	if *s.Name != *ns.Name {
+		t.Errorf("bad name: %q (%q)", *s.Name, *ns.Name)
 	}
-	if s.Comment != ns.Comment {
-		t.Errorf("bad comment: %q (%q)", s.Comment, ns.Comment)
+	if *s.Comment != *ns.Comment {
+		t.Errorf("bad comment: %q (%q)", *s.Comment, *ns.Comment)
 	}
-
 	if ns.CreatedAt == nil {
 		t.Errorf("Bad created at: empty")
 	}
-
 	if ns.UpdatedAt == nil {
 		t.Errorf("Bad updated at: empty")
 	}
-
-	if ns.DeletedAt != nil {
-		t.Errorf("Bad deleted at: %s", ns.DeletedAt)
+	if s.DeletedAt != nil {
+		t.Errorf("Bad deleted at: %s", *ns.DeletedAt)
 	}
 
 	// Get Details
 	var nsd *ServiceDetail
 	record(t, "services/details", func(c *Client) {
 		nsd, err = c.GetServiceDetails(&GetServiceInput{
-			ID: s.ID,
+			ID: *s.ID,
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if s.Name != nsd.Name {
-		t.Errorf("bad name: %q (%q)", s.Name, nsd.Name)
+	if *s.Name != *nsd.Name {
+		t.Errorf("bad name: %q (%q)", *s.Name, *nsd.Name)
 	}
-	if s.Comment != nsd.Comment {
-		t.Errorf("bad comment: %q (%q)", s.Comment, nsd.Comment)
+	if *s.Comment != *nsd.Comment {
+		t.Errorf("bad comment: %q (%q)", *s.Comment, *nsd.Comment)
 	}
 	if nsd.Version.Number == 0 {
 		t.Errorf("Service Detail Version is empty: (%#v)", nsd)
@@ -142,32 +139,32 @@ func TestClient_Services(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Name != fs.Name {
-		t.Errorf("bad name: %q (%q)", s.Name, fs.Name)
+	if *s.Name != *fs.Name {
+		t.Errorf("bad name: %q (%q)", *s.Name, *fs.Name)
 	}
-	if s.Comment != fs.Comment {
-		t.Errorf("bad comment: %q (%q)", s.Comment, fs.Comment)
+	if *s.Comment != *fs.Comment {
+		t.Errorf("bad comment: %q (%q)", *s.Comment, *fs.Comment)
 	}
 
 	// Update
 	var us *Service
 	record(t, "services/update", func(c *Client) {
 		us, err = c.UpdateService(&UpdateServiceInput{
-			ServiceID: s.ID,
+			ServiceID: *s.ID,
 			Name:      ToPointer("new-test-service"),
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if us.Name != "new-test-service" {
-		t.Errorf("bad name: %q", us.Name)
+	if *us.Name != "new-test-service" {
+		t.Errorf("bad name: %q", *us.Name)
 	}
 
 	// Delete
 	record(t, "services/delete", func(c *Client) {
 		err = c.DeleteService(&DeleteServiceInput{
-			ID: s.ID,
+			ID: *s.ID,
 		})
 	})
 	if err != nil {
@@ -178,7 +175,7 @@ func TestClient_Services(t *testing.T) {
 	var ds ServiceDomainsList
 	record(t, "services/domain", func(c *Client) {
 		ds, err = c.ListServiceDomains(&ListServiceDomainInput{
-			ServiceID: s.ID,
+			ServiceID: *s.ID,
 		})
 	})
 	if err != nil {

--- a/fastly/settings.go
+++ b/fastly/settings.go
@@ -1,15 +1,17 @@
 package fastly
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Settings represents a backend response from the Fastly API.
 type Settings struct {
-	DefaultHost     string `mapstructure:"general.default_host"`
-	DefaultTTL      uint   `mapstructure:"general.default_ttl"`
-	ServiceID       string `mapstructure:"service_id"`
-	ServiceVersion  int    `mapstructure:"version"`
-	StaleIfError    bool   `mapstructure:"general.stale_if_error"`
-	StaleIfErrorTTL uint   `mapstructure:"general.stale_if_error_ttl"`
+	DefaultHost     *string `mapstructure:"general.default_host"`
+	DefaultTTL      *uint   `mapstructure:"general.default_ttl"`
+	ServiceID       *string `mapstructure:"service_id"`
+	ServiceVersion  *int    `mapstructure:"version"`
+	StaleIfError    *bool   `mapstructure:"general.stale_if_error"`
+	StaleIfErrorTTL *uint   `mapstructure:"general.stale_if_error_ttl"`
 }
 
 // GetSettingsInput is used as input to the GetSettings function.
@@ -25,7 +27,6 @@ func (c *Client) GetSettings(i *GetSettingsInput) (*Settings, error) {
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
 	}
-
 	if i.ServiceVersion == 0 {
 		return nil, ErrMissingServiceVersion
 	}
@@ -49,7 +50,7 @@ type UpdateSettingsInput struct {
 	// DefaultHost is the default host name for the version.
 	DefaultHost *string `url:"general.default_host,omitempty"`
 	// DefaultTTL is the default time-to-live (TTL) for the version.
-	DefaultTTL uint `url:"general.default_ttl"`
+	DefaultTTL *uint `url:"general.default_ttl"`
 	// ServiceID is the ID of the service (required).
 	ServiceID string
 	// ServiceVersion is the specific configuration version (required).
@@ -65,7 +66,6 @@ func (c *Client) UpdateSettings(i *UpdateSettingsInput) (*Settings, error) {
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
 	}
-
 	if i.ServiceVersion == 0 {
 		return nil, ErrMissingServiceVersion
 	}

--- a/fastly/settings_test.go
+++ b/fastly/settings_test.go
@@ -20,7 +20,7 @@ func TestClient_Settings(t *testing.T) {
 	record(t, "settings/get", func(c *Client) {
 		ns, err = c.GetSettings(&GetSettingsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -35,7 +35,7 @@ func TestClient_Settings(t *testing.T) {
 	record(t, "settings/update", func(c *Client) {
 		us, err = c.UpdateSettings(&UpdateSettingsInput{
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 			DefaultTTL:      ToPointer(uint(1800)),
 			StaleIfError:    ToPointer(true),
 			StaleIfErrorTTL: ToPointer(uint(57600)),

--- a/fastly/settings_test.go
+++ b/fastly/settings_test.go
@@ -26,7 +26,7 @@ func TestClient_Settings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ns.DefaultTTL == 0 {
+	if *ns.DefaultTTL == 0 {
 		t.Errorf("bad default_ttl: %d", ns.DefaultTTL)
 	}
 
@@ -36,7 +36,7 @@ func TestClient_Settings(t *testing.T) {
 		us, err = c.UpdateSettings(&UpdateSettingsInput{
 			ServiceID:       testServiceID,
 			ServiceVersion:  tv.Number,
-			DefaultTTL:      1800,
+			DefaultTTL:      ToPointer(uint(1800)),
 			StaleIfError:    ToPointer(true),
 			StaleIfErrorTTL: ToPointer(uint(57600)),
 		})
@@ -44,21 +44,25 @@ func TestClient_Settings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if us.DefaultTTL != 1800 {
-		t.Errorf("bad default_ttl: %d", us.DefaultTTL)
+	if *us.DefaultTTL != 1800 {
+		t.Errorf("bad default_ttl: %d", *us.DefaultTTL)
 	}
-	if !us.StaleIfError {
-		t.Errorf("bad stale_if_error: %t", us.StaleIfError)
+	if !*us.StaleIfError {
+		t.Errorf("bad stale_if_error: %t", *us.StaleIfError)
 	}
-	if us.StaleIfErrorTTL != 57600 {
-		t.Errorf("bad stale_if_error_ttl %d", us.StaleIfErrorTTL)
+	if *us.StaleIfErrorTTL != 57600 {
+		t.Errorf("bad stale_if_error_ttl %d", *us.StaleIfErrorTTL)
 	}
 }
 
 // Tests if we can update a default_ttl to 0 as reported in issue #20
 func TestClient_UpdateSettingsInput_default_ttl(t *testing.T) {
 	t.Parallel()
-	s := UpdateSettingsInput{ServiceID: "foo", ServiceVersion: 1, DefaultTTL: 0}
+	s := UpdateSettingsInput{
+		DefaultTTL:     ToPointer(uint(0)),
+		ServiceID:      "foo",
+		ServiceVersion: 1,
+	}
 
 	v, err := query.Values(s)
 	if err != nil {

--- a/fastly/sftp.go
+++ b/fastly/sftp.go
@@ -3,53 +3,34 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // SFTP represents an SFTP logging response from the Fastly API.
 type SFTP struct {
-	Address           string     `mapstructure:"address"`
-	CompressionCodec  string     `mapstructure:"compression_codec"`
+	Address           *string    `mapstructure:"address"`
+	CompressionCodec  *string    `mapstructure:"compression_codec"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	GzipLevel         int        `mapstructure:"gzip_level"`
-	MessageType       string     `mapstructure:"message_type"`
-	Name              string     `mapstructure:"name"`
-	Password          string     `mapstructure:"password"`
-	Path              string     `mapstructure:"path"`
-	Period            int        `mapstructure:"period"`
-	Placement         string     `mapstructure:"placement"`
-	Port              int        `mapstructure:"port"`
-	PublicKey         string     `mapstructure:"public_key"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	SSHKnownHosts     string     `mapstructure:"ssh_known_hosts"`
-	SecretKey         string     `mapstructure:"secret_key"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TimestampFormat   string     `mapstructure:"timestamp_format"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	GzipLevel         *int       `mapstructure:"gzip_level"`
+	MessageType       *string    `mapstructure:"message_type"`
+	Name              *string    `mapstructure:"name"`
+	Password          *string    `mapstructure:"password"`
+	Path              *string    `mapstructure:"path"`
+	Period            *int       `mapstructure:"period"`
+	Placement         *string    `mapstructure:"placement"`
+	Port              *int       `mapstructure:"port"`
+	PublicKey         *string    `mapstructure:"public_key"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	SSHKnownHosts     *string    `mapstructure:"ssh_known_hosts"`
+	SecretKey         *string    `mapstructure:"secret_key"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TimestampFormat   *string    `mapstructure:"timestamp_format"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	User              string     `mapstructure:"user"`
-}
-
-// sftpsByName is a sortable list of sftps.
-type sftpsByName []*SFTP
-
-// Len implement the sortable interface.
-func (s sftpsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s sftpsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s sftpsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	User              *string    `mapstructure:"user"`
 }
 
 // ListSFTPsInput is used as input to the ListSFTPs function.
@@ -80,7 +61,6 @@ func (c *Client) ListSFTPs(i *ListSFTPsInput) ([]*SFTP, error) {
 	if err := decodeBodyMap(resp.Body, &sftps); err != nil {
 		return nil, err
 	}
-	sort.Stable(sftpsByName(sftps))
 	return sftps, nil
 }
 

--- a/fastly/sftp_test.go
+++ b/fastly/sftp_test.go
@@ -153,70 +153,68 @@ func TestClient_SFTPs(t *testing.T) {
 		})
 	}()
 
-	if sftpCreateResp1.Name != "test-sftp" {
-		t.Errorf("bad name: %q", sftpCreateResp1.Name)
+	if *sftpCreateResp1.Name != "test-sftp" {
+		t.Errorf("bad name: %q", *sftpCreateResp1.Name)
 	}
-	if sftpCreateResp1.Address != "example.com" {
-		t.Errorf("bad address: %q", sftpCreateResp1.Address)
+	if *sftpCreateResp1.Address != "example.com" {
+		t.Errorf("bad address: %q", *sftpCreateResp1.Address)
 	}
-	if sftpCreateResp1.Port != 1234 {
-		t.Errorf("bad port: %q", sftpCreateResp1.Port)
+	if *sftpCreateResp1.Port != 1234 {
+		t.Errorf("bad port: %q", *sftpCreateResp1.Port)
 	}
-	if sftpCreateResp1.PublicKey != pgpPublicKey() {
-		t.Errorf("bad public_key: %q", sftpCreateResp1.PublicKey)
+	if *sftpCreateResp1.PublicKey != pgpPublicKey() {
+		t.Errorf("bad public_key: %q", *sftpCreateResp1.PublicKey)
 	}
-	if strings.TrimSpace(sftpCreateResp1.SecretKey) != strings.TrimSpace(privateKey()) {
-		t.Errorf("bad secret_key: %q", sftpCreateResp1.SecretKey)
+	if strings.TrimSpace(*sftpCreateResp1.SecretKey) != strings.TrimSpace(privateKey()) {
+		t.Errorf("bad secret_key: %q", *sftpCreateResp1.SecretKey)
 	}
-	if sftpCreateResp1.SSHKnownHosts != knownHosts {
-		t.Errorf("bad ssh_known_hosts: %q", sftpCreateResp1.SSHKnownHosts)
+	if *sftpCreateResp1.SSHKnownHosts != knownHosts {
+		t.Errorf("bad ssh_known_hosts: %q", *sftpCreateResp1.SSHKnownHosts)
 	}
-	if sftpCreateResp1.User != "username" {
-		t.Errorf("bad user: %q", sftpCreateResp1.User)
+	if *sftpCreateResp1.User != "username" {
+		t.Errorf("bad user: %q", *sftpCreateResp1.User)
 	}
-	if sftpCreateResp1.Password != "password" {
-		t.Errorf("bad password: %q", sftpCreateResp1.Password)
+	if *sftpCreateResp1.Password != "password" {
+		t.Errorf("bad password: %q", *sftpCreateResp1.Password)
 	}
-	if sftpCreateResp1.Path != "/dir" {
-		t.Errorf("bad path: %q", sftpCreateResp1.Path)
+	if *sftpCreateResp1.Path != "/dir" {
+		t.Errorf("bad path: %q", *sftpCreateResp1.Path)
 	}
-	if sftpCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", sftpCreateResp1.Period)
+	if *sftpCreateResp1.Period != 12 {
+		t.Errorf("bad period: %q", *sftpCreateResp1.Period)
 	}
-	if sftpCreateResp1.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", sftpCreateResp1.CompressionCodec)
+	if *sftpCreateResp1.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *sftpCreateResp1.CompressionCodec)
 	}
-	if sftpCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", sftpCreateResp1.GzipLevel)
+	if *sftpCreateResp1.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *sftpCreateResp1.GzipLevel)
 	}
-	if sftpCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", sftpCreateResp1.FormatVersion)
+	if *sftpCreateResp1.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *sftpCreateResp1.FormatVersion)
 	}
-	if sftpCreateResp1.Format != "format" {
-		t.Errorf("bad format: %q", sftpCreateResp1.Format)
+	if *sftpCreateResp1.Format != "format" {
+		t.Errorf("bad format: %q", *sftpCreateResp1.Format)
 	}
-	if sftpCreateResp1.TimestampFormat != "%Y" {
-		t.Errorf("bad timestamp_format: %q", sftpCreateResp1.TimestampFormat)
+	if *sftpCreateResp1.TimestampFormat != "%Y" {
+		t.Errorf("bad timestamp_format: %q", *sftpCreateResp1.TimestampFormat)
 	}
-	if sftpCreateResp1.MessageType != "blank" {
-		t.Errorf("bad message_type: %q", sftpCreateResp1.MessageType)
+	if *sftpCreateResp1.MessageType != "blank" {
+		t.Errorf("bad message_type: %q", *sftpCreateResp1.MessageType)
 	}
-	if sftpCreateResp1.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", sftpCreateResp1.Placement)
+	if *sftpCreateResp1.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *sftpCreateResp1.Placement)
 	}
-
-	if sftpCreateResp2.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", sftpCreateResp2.CompressionCodec)
+	if sftpCreateResp2.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *sftpCreateResp2.CompressionCodec)
 	}
-	if sftpCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", sftpCreateResp2.GzipLevel)
+	if *sftpCreateResp2.GzipLevel != 8 {
+		t.Errorf("bad gzip_level: %q", *sftpCreateResp2.GzipLevel)
 	}
-
-	if sftpCreateResp3.CompressionCodec != "snappy" {
-		t.Errorf("bad compression_codec: %q", sftpCreateResp3.CompressionCodec)
+	if *sftpCreateResp3.CompressionCodec != "snappy" {
+		t.Errorf("bad compression_codec: %q", *sftpCreateResp3.CompressionCodec)
 	}
-	if sftpCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", sftpCreateResp3.GzipLevel)
+	if *sftpCreateResp3.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *sftpCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -246,56 +244,57 @@ func TestClient_SFTPs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if sftpCreateResp1.Name != sftpGetResp.Name {
-		t.Errorf("bad name: %q", sftpCreateResp1.Name)
+
+	if *sftpCreateResp1.Name != *sftpGetResp.Name {
+		t.Errorf("bad name: %q", *sftpCreateResp1.Name)
 	}
-	if sftpCreateResp1.Address != sftpGetResp.Address {
-		t.Errorf("bad address: %q", sftpCreateResp1.Address)
+	if *sftpCreateResp1.Address != *sftpGetResp.Address {
+		t.Errorf("bad address: %q", *sftpCreateResp1.Address)
 	}
-	if sftpCreateResp1.Port != sftpGetResp.Port {
-		t.Errorf("bad port: %q", sftpCreateResp1.Port)
+	if *sftpCreateResp1.Port != *sftpGetResp.Port {
+		t.Errorf("bad port: %q", *sftpCreateResp1.Port)
 	}
-	if sftpCreateResp1.PublicKey != sftpGetResp.PublicKey {
-		t.Errorf("bad public_key: %q", sftpCreateResp1.PublicKey)
+	if *sftpCreateResp1.PublicKey != *sftpGetResp.PublicKey {
+		t.Errorf("bad public_key: %q", *sftpCreateResp1.PublicKey)
 	}
-	if sftpCreateResp1.SecretKey != sftpGetResp.SecretKey {
-		t.Errorf("bad secret_key: %q", sftpCreateResp1.SecretKey)
+	if *sftpCreateResp1.SecretKey != *sftpGetResp.SecretKey {
+		t.Errorf("bad secret_key: %q", *sftpCreateResp1.SecretKey)
 	}
-	if sftpCreateResp1.SSHKnownHosts != sftpGetResp.SSHKnownHosts {
-		t.Errorf("bad ssh_known_hosts: %q", sftpCreateResp1.SSHKnownHosts)
+	if *sftpCreateResp1.SSHKnownHosts != *sftpGetResp.SSHKnownHosts {
+		t.Errorf("bad ssh_known_hosts: %q", *sftpCreateResp1.SSHKnownHosts)
 	}
-	if sftpCreateResp1.User != sftpGetResp.User {
-		t.Errorf("bad user: %q", sftpCreateResp1.User)
+	if *sftpCreateResp1.User != *sftpGetResp.User {
+		t.Errorf("bad user: %q", *sftpCreateResp1.User)
 	}
-	if sftpCreateResp1.Password != sftpGetResp.Password {
-		t.Errorf("bad password: %q", sftpCreateResp1.Password)
+	if *sftpCreateResp1.Password != *sftpGetResp.Password {
+		t.Errorf("bad password: %q", *sftpCreateResp1.Password)
 	}
-	if sftpCreateResp1.Path != sftpGetResp.Path {
-		t.Errorf("bad path: %q", sftpCreateResp1.Path)
+	if *sftpCreateResp1.Path != *sftpGetResp.Path {
+		t.Errorf("bad path: %q", *sftpCreateResp1.Path)
 	}
-	if sftpCreateResp1.Period != sftpGetResp.Period {
-		t.Errorf("bad period: %q", sftpCreateResp1.Period)
+	if *sftpCreateResp1.Period != *sftpGetResp.Period {
+		t.Errorf("bad period: %q", *sftpCreateResp1.Period)
 	}
-	if sftpCreateResp1.CompressionCodec != sftpGetResp.CompressionCodec {
-		t.Errorf("bad compression_codec: %q", sftpCreateResp1.CompressionCodec)
+	if *sftpCreateResp1.CompressionCodec != *sftpGetResp.CompressionCodec {
+		t.Errorf("bad compression_codec: %q", *sftpCreateResp1.CompressionCodec)
 	}
-	if sftpCreateResp1.GzipLevel != sftpGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", sftpCreateResp1.GzipLevel)
+	if *sftpCreateResp1.GzipLevel != *sftpGetResp.GzipLevel {
+		t.Errorf("bad gzip_level: %q", *sftpCreateResp1.GzipLevel)
 	}
-	if sftpCreateResp1.FormatVersion != sftpGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", sftpCreateResp1.FormatVersion)
+	if *sftpCreateResp1.FormatVersion != *sftpGetResp.FormatVersion {
+		t.Errorf("bad format_version: %q", *sftpCreateResp1.FormatVersion)
 	}
-	if sftpCreateResp1.Format != sftpGetResp.Format {
-		t.Errorf("bad format: %q", sftpCreateResp1.Format)
+	if *sftpCreateResp1.Format != *sftpGetResp.Format {
+		t.Errorf("bad format: %q", *sftpCreateResp1.Format)
 	}
-	if sftpCreateResp1.TimestampFormat != sftpGetResp.TimestampFormat {
-		t.Errorf("bad timestamp_format: %q", sftpCreateResp1.TimestampFormat)
+	if *sftpCreateResp1.TimestampFormat != *sftpGetResp.TimestampFormat {
+		t.Errorf("bad timestamp_format: %q", *sftpCreateResp1.TimestampFormat)
 	}
-	if sftpCreateResp1.MessageType != "blank" {
-		t.Errorf("bad message_type: %q", sftpCreateResp1.MessageType)
+	if *sftpCreateResp1.MessageType != "blank" {
+		t.Errorf("bad message_type: %q", *sftpCreateResp1.MessageType)
 	}
-	if sftpCreateResp1.Placement != sftpGetResp.Placement {
-		t.Errorf("bad placement: %q", sftpCreateResp1.Placement)
+	if *sftpCreateResp1.Placement != *sftpGetResp.Placement {
+		t.Errorf("bad placement: %q", *sftpCreateResp1.Placement)
 	}
 
 	// Update
@@ -338,31 +337,29 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if sftpUpdateResp1.Name != "new-test-sftp" {
-		t.Errorf("bad name: %q", sftpUpdateResp1.Name)
+	if *sftpUpdateResp1.Name != "new-test-sftp" {
+		t.Errorf("bad name: %q", *sftpUpdateResp1.Name)
 	}
-	if sftpUpdateResp1.MessageType != "classic" {
-		t.Errorf("bad message_type: %q", sftpUpdateResp1.MessageType)
+	if *sftpUpdateResp1.MessageType != "classic" {
+		t.Errorf("bad message_type: %q", *sftpUpdateResp1.MessageType)
 	}
-	if sftpUpdateResp1.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", sftpUpdateResp1.CompressionCodec)
+	if sftpUpdateResp1.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *sftpUpdateResp1.CompressionCodec)
 	}
-	if sftpUpdateResp1.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", sftpUpdateResp1.GzipLevel)
+	if *sftpUpdateResp1.GzipLevel != 8 {
+		t.Errorf("bad gzip_level: %q", *sftpUpdateResp1.GzipLevel)
 	}
-
-	if sftpUpdateResp2.CompressionCodec != "zstd" {
-		t.Errorf("bad compression_codec: %q", sftpUpdateResp2.CompressionCodec)
+	if *sftpUpdateResp2.CompressionCodec != "zstd" {
+		t.Errorf("bad compression_codec: %q", *sftpUpdateResp2.CompressionCodec)
 	}
-	if sftpUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", sftpUpdateResp2.GzipLevel)
+	if *sftpUpdateResp2.GzipLevel != 0 {
+		t.Errorf("bad gzip_level: %q", *sftpUpdateResp2.GzipLevel)
 	}
-
-	if sftpUpdateResp3.CompressionCodec != "" {
-		t.Errorf("bad compression_codec: %q", sftpUpdateResp3.CompressionCodec)
+	if sftpUpdateResp3.CompressionCodec != nil {
+		t.Errorf("bad compression_codec: %q", *sftpUpdateResp3.CompressionCodec)
 	}
-	if sftpUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", sftpUpdateResp3.GzipLevel)
+	if *sftpUpdateResp3.GzipLevel != 9 {
+		t.Errorf("bad gzip_level: %q", *sftpUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/sftp_test.go
+++ b/fastly/sftp_test.go
@@ -20,7 +20,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/create", func(c *Client) {
 		sftpCreateResp1, err = c.CreateSFTP(&CreateSFTPInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-sftp"),
 			Address:          ToPointer("example.com"),
 			Port:             ToPointer(1234),
@@ -46,7 +46,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/create2", func(c *Client) {
 		sftpCreateResp2, err = c.CreateSFTP(&CreateSFTPInput{
 			ServiceID:       testServiceID,
-			ServiceVersion:  tv.Number,
+			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-sftp-2"),
 			Address:         ToPointer("example.com"),
 			Port:            ToPointer(1234),
@@ -72,7 +72,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/create3", func(c *Client) {
 		sftpCreateResp3, err = c.CreateSFTP(&CreateSFTPInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-sftp-3"),
 			Address:          ToPointer("example.com"),
 			Port:             ToPointer(1234),
@@ -100,7 +100,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/create4", func(c *Client) {
 		_, err = c.CreateSFTP(&CreateSFTPInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-sftp-4"),
 			Address:          ToPointer("example.com"),
 			Port:             ToPointer(1234),
@@ -129,25 +129,25 @@ func TestClient_SFTPs(t *testing.T) {
 		record(t, "sftps/cleanup", func(c *Client) {
 			_ = c.DeleteSFTP(&DeleteSFTPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-sftp",
 			})
 
 			_ = c.DeleteSFTP(&DeleteSFTPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-sftp-2",
 			})
 
 			_ = c.DeleteSFTP(&DeleteSFTPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-sftp-3",
 			})
 
 			_ = c.DeleteSFTP(&DeleteSFTPInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-sftp",
 			})
 		})
@@ -222,7 +222,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/list", func(c *Client) {
 		sftps, err = c.ListSFTPs(&ListSFTPsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -237,7 +237,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/get", func(c *Client) {
 		sftpGetResp, err = c.GetSFTP(&GetSFTPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-sftp",
 		})
 	})
@@ -302,7 +302,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/update", func(c *Client) {
 		sftpUpdateResp1, err = c.UpdateSFTP(&UpdateSFTPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-sftp",
 			NewName:        ToPointer("new-test-sftp"),
 			GzipLevel:      ToPointer(8),
@@ -316,7 +316,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/update2", func(c *Client) {
 		sftpUpdateResp2, err = c.UpdateSFTP(&UpdateSFTPInput{
 			ServiceID:        testServiceID,
-			ServiceVersion:   tv.Number,
+			ServiceVersion:   *tv.Number,
 			Name:             "test-sftp-2",
 			CompressionCodec: ToPointer("zstd"),
 		})
@@ -328,7 +328,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/update3", func(c *Client) {
 		sftpUpdateResp3, err = c.UpdateSFTP(&UpdateSFTPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-sftp-3",
 			GzipLevel:      ToPointer(9),
 		})
@@ -366,7 +366,7 @@ func TestClient_SFTPs(t *testing.T) {
 	record(t, "sftps/delete", func(c *Client) {
 		err = c.DeleteSFTP(&DeleteSFTPInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-sftp",
 		})
 	})

--- a/fastly/splunk.go
+++ b/fastly/splunk.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
@@ -11,41 +10,23 @@ import (
 type Splunk struct {
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	RequestMaxBytes   int        `mapstructure:"request_max_bytes"`
-	RequestMaxEntries int        `mapstructure:"request_max_entries"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TLSCACert         string     `mapstructure:"tls_ca_cert"`
-	TLSClientCert     string     `mapstructure:"tls_client_cert"`
-	TLSClientKey      string     `mapstructure:"tls_client_key"`
-	TLSHostname       string     `mapstructure:"tls_hostname"`
-	Token             string     `mapstructure:"token"`
-	URL               string     `mapstructure:"url"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	RequestMaxBytes   *int       `mapstructure:"request_max_bytes"`
+	RequestMaxEntries *int       `mapstructure:"request_max_entries"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TLSCACert         *string    `mapstructure:"tls_ca_cert"`
+	TLSClientCert     *string    `mapstructure:"tls_client_cert"`
+	TLSClientKey      *string    `mapstructure:"tls_client_key"`
+	TLSHostname       *string    `mapstructure:"tls_hostname"`
+	Token             *string    `mapstructure:"token"`
+	URL               *string    `mapstructure:"url"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	UseTLS            bool       `mapstructure:"use_tls"`
-}
-
-// splunkByName is a sortable list of splunks.
-type splunkByName []*Splunk
-
-// Len implement the sortable interface.
-func (s splunkByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s splunkByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s splunkByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	UseTLS            *bool      `mapstructure:"use_tls"`
 }
 
 // ListSplunksInput is used as input to the ListSplunks function.
@@ -76,7 +57,6 @@ func (c *Client) ListSplunks(i *ListSplunksInput) ([]*Splunk, error) {
 	if err := decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
-	sort.Stable(splunkByName(ss))
 	return ss, nil
 }
 

--- a/fastly/splunk_test.go
+++ b/fastly/splunk_test.go
@@ -76,44 +76,44 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		})
 	}()
 
-	if s.Name != "test-splunk" {
-		t.Errorf("bad name: %q", s.Name)
+	if *s.Name != "test-splunk" {
+		t.Errorf("bad name: %q", *s.Name)
 	}
-	if s.URL != "https://mysplunkendpoint.example.com/services/collector/event" {
-		t.Errorf("bad url: %q", s.URL)
+	if *s.URL != "https://mysplunkendpoint.example.com/services/collector/event" {
+		t.Errorf("bad url: %q", *s.URL)
 	}
-	if s.RequestMaxEntries != 1 {
-		t.Errorf("bad request_max_entries: %q", s.RequestMaxEntries)
+	if *s.RequestMaxEntries != 1 {
+		t.Errorf("bad request_max_entries: %q", *s.RequestMaxEntries)
 	}
-	if s.RequestMaxBytes != 1000 {
-		t.Errorf("bad request_max_bytes: %q", s.RequestMaxBytes)
+	if *s.RequestMaxBytes != 1000 {
+		t.Errorf("bad request_max_bytes: %q", *s.RequestMaxBytes)
 	}
-	if s.Format != "%h %l %u %t \"%r\" %>s %b" {
-		t.Errorf("bad format: %q", s.Format)
+	if *s.Format != "%h %l %u %t \"%r\" %>s %b" {
+		t.Errorf("bad format: %q", *s.Format)
 	}
-	if s.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", s.FormatVersion)
+	if *s.FormatVersion != 2 {
+		t.Errorf("bad format_version: %q", *s.FormatVersion)
 	}
-	if s.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", s.Placement)
+	if *s.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *s.Placement)
 	}
-	if s.Token != "super-secure-token" {
-		t.Errorf("bad token: %q", s.Token)
+	if *s.Token != "super-secure-token" {
+		t.Errorf("bad token: %q", *s.Token)
 	}
-	if !s.UseTLS {
-		t.Errorf("bad use_tls: %t", s.UseTLS)
+	if !*s.UseTLS {
+		t.Errorf("bad use_tls: %t", *s.UseTLS)
 	}
-	if s.TLSCACert != caCert {
-		t.Errorf("bad tls_ca_cert: %q", s.TLSCACert)
+	if *s.TLSCACert != caCert {
+		t.Errorf("bad tls_ca_cert: %q", *s.TLSCACert)
 	}
-	if s.TLSHostname != "example.com" {
-		t.Errorf("bad tls_hostname: %q", s.TLSHostname)
+	if *s.TLSHostname != "example.com" {
+		t.Errorf("bad tls_hostname: %q", *s.TLSHostname)
 	}
-	if s.TLSClientCert != clientCert {
-		t.Errorf("bad tls_client_cert: %q", s.TLSClientCert)
+	if *s.TLSClientCert != clientCert {
+		t.Errorf("bad tls_client_cert: %q", *s.TLSClientCert)
 	}
-	if s.TLSClientKey != clientKey {
-		t.Errorf("bad tls_client_key: %q", s.TLSClientKey)
+	if *s.TLSClientKey != clientKey {
+		t.Errorf("bad tls_client_key: %q", *s.TLSClientKey)
 	}
 
 	// List
@@ -143,44 +143,44 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Name != ns.Name {
-		t.Errorf("bad name: %q", s.Name)
+	if *s.Name != *ns.Name {
+		t.Errorf("bad name: %q", *s.Name)
 	}
-	if s.URL != ns.URL {
-		t.Errorf("bad url: %q", s.URL)
+	if *s.URL != *ns.URL {
+		t.Errorf("bad url: %q", *s.URL)
 	}
-	if s.RequestMaxEntries != ns.RequestMaxEntries {
-		t.Errorf("bad request_max_entries: %q", s.RequestMaxEntries)
+	if *s.RequestMaxEntries != *ns.RequestMaxEntries {
+		t.Errorf("bad request_max_entries: %q", *s.RequestMaxEntries)
 	}
-	if s.RequestMaxBytes != ns.RequestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", s.RequestMaxBytes)
+	if *s.RequestMaxBytes != *ns.RequestMaxBytes {
+		t.Errorf("bad request_max_bytes: %q", *s.RequestMaxBytes)
 	}
-	if s.Format != ns.Format {
-		t.Errorf("bad format: %q", s.Format)
+	if *s.Format != *ns.Format {
+		t.Errorf("bad format: %q", *s.Format)
 	}
-	if s.FormatVersion != ns.FormatVersion {
-		t.Errorf("bad format_version: %q", s.FormatVersion)
+	if *s.FormatVersion != *ns.FormatVersion {
+		t.Errorf("bad format_version: %q", *s.FormatVersion)
 	}
-	if s.Placement != ns.Placement {
-		t.Errorf("bad placement: %q", s.Placement)
+	if *s.Placement != *ns.Placement {
+		t.Errorf("bad placement: %q", *s.Placement)
 	}
-	if s.Token != ns.Token {
-		t.Errorf("bad token: %q", s.Token)
+	if *s.Token != *ns.Token {
+		t.Errorf("bad token: %q", *s.Token)
 	}
-	if s.UseTLS != ns.UseTLS {
-		t.Errorf("bad use_tls: %t", s.UseTLS)
+	if *s.UseTLS != *ns.UseTLS {
+		t.Errorf("bad use_tls: %t", *s.UseTLS)
 	}
-	if s.TLSCACert != ns.TLSCACert {
-		t.Errorf("bad tls_ca_cert: %q", s.TLSCACert)
+	if *s.TLSCACert != *ns.TLSCACert {
+		t.Errorf("bad tls_ca_cert: %q", *s.TLSCACert)
 	}
-	if s.TLSHostname != ns.TLSHostname {
-		t.Errorf("bad tls_hostname: %q", s.TLSHostname)
+	if *s.TLSHostname != *ns.TLSHostname {
+		t.Errorf("bad tls_hostname: %q", *s.TLSHostname)
 	}
-	if s.TLSClientCert != ns.TLSClientCert {
-		t.Errorf("bad tls_client_cert: %q", s.TLSClientCert)
+	if *s.TLSClientCert != *ns.TLSClientCert {
+		t.Errorf("bad tls_client_cert: %q", *s.TLSClientCert)
 	}
-	if s.TLSClientKey != ns.TLSClientKey {
-		t.Errorf("bad tls_client_key: %q", s.TLSClientKey)
+	if *s.TLSClientKey != *ns.TLSClientKey {
+		t.Errorf("bad tls_client_key: %q", *s.TLSClientKey)
 	}
 
 	// Update
@@ -196,8 +196,8 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	if err != nil {
 		t.Fatal(err)
 	}
-	if us.Name != "new-test-splunk" {
-		t.Errorf("bad name: %q", us.Name)
+	if *us.Name != "new-test-splunk" {
+		t.Errorf("bad name: %q", *us.Name)
 	}
 
 	// Delete

--- a/fastly/splunk_test.go
+++ b/fastly/splunk_test.go
@@ -39,7 +39,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "splunks/create", func(c *Client) {
 		s, err = c.CreateSplunk(&CreateSplunkInput{
 			ServiceID:         testServiceID,
-			ServiceVersion:    tv.Number,
+			ServiceVersion:    *tv.Number,
 			Name:              ToPointer("test-splunk"),
 			URL:               ToPointer("https://mysplunkendpoint.example.com/services/collector/event"),
 			RequestMaxEntries: ToPointer(1),
@@ -64,13 +64,13 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		record(t, "splunks/cleanup", func(c *Client) {
 			c.DeleteSplunk(&DeleteSplunkInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-splunk",
 			})
 
 			c.DeleteSplunk(&DeleteSplunkInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-splunk",
 			})
 		})
@@ -121,7 +121,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "splunks/list", func(c *Client) {
 		ss, err = c.ListSplunks(&ListSplunksInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -136,7 +136,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "splunks/get", func(c *Client) {
 		ns, err = c.GetSplunk(&GetSplunkInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-splunk",
 		})
 	})
@@ -188,7 +188,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "splunks/update", func(c *Client) {
 		us, err = c.UpdateSplunk(&UpdateSplunkInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-splunk",
 			NewName:        ToPointer("new-test-splunk"),
 		})
@@ -204,7 +204,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "splunks/delete", func(c *Client) {
 		err = c.DeleteSplunk(&DeleteSplunkInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-splunk",
 		})
 	})

--- a/fastly/stats.go
+++ b/fastly/stats.go
@@ -5,81 +5,89 @@ import (
 	"fmt"
 )
 
-// Stats represent metrics of a Fastly service
+// StatsResponse is a response from the service stats API endpoint.
+type StatsResponse struct {
+	Data    []*Stats          `mapstructure:"data"`
+	Message *string           `mapstructure:"msg"`
+	Meta    map[string]string `mapstructure:"meta"`
+	Status  *string           `mapstructure:"status"`
+}
+
+// Stats represent metrics of a Fastly service.
 type Stats struct {
-	AttackRequestHeaderBytes  uint64      `mapstructure:"attack_req_header_bytes"` // Total header bytes received from requests that triggered a WAF rule.
-	AttackRequestBodyBytes    uint64      `mapstructure:"attack_req_body_bytes"`   // Total body bytes received from requests that triggered a WAF rule.
-	AttackResponseSynthBytes  uint64      `mapstructure:"attack_resp_synth_bytes"` // Total bytes delivered for requests that triggered a WAF rule and returned a synthetic response.
-	BERequestBodyBytes        uint64      `mapstructure:"bereq_body_bytes"`        // Total body bytes sent to origin.
-	BERequestHeaderbytes      uint64      `mapstructure:"bereq_header_bytes"`      // Total header bytes sent to origin.
-	Bandwidth                 uint64      `mapstructure:"bandwidth"`               // Total bytes delivered (body_size + header_size).
-	BilledBodyBytes           uint64      `mapstructure:"billed_body_bytes"`
-	BilledHeaderBytes         uint64      `mapstructure:"billed_header_bytes"`
-	Errors                    uint64      `mapstructure:"errors"`                   // Number of cache errors.
-	HTTP2                     uint64      `mapstructure:"http2"`                    // Number of requests received over HTTP2.
-	HitRatio                  float64     `mapstructure:"hit_ratio"`                // Ratio of cache hits to cache misses (between 0 and 1).
-	Hits                      uint64      `mapstructure:"hits"`                     // Number of cache hits.
-	HitsTime                  float64     `mapstructure:"hits_time"`                // Total amount of time spent processing cache hits (in seconds).
-	IPv6                      uint64      `mapstructure:"ipv6"`                     // Number of requests that were received over IPv6.
-	ImageOptimizer            uint64      `mapstructure:"imgopto"`                  // Number of responses that came from the Fastly Image Optimizer service.
-	Log                       uint64      `mapstructure:"log"`                      // Number of log lines sent.
-	Miss                      uint64      `mapstructure:"miss"`                     // Number of cache misses.
+	AttackRequestHeaderBytes  *uint64     `mapstructure:"attack_req_header_bytes"` // Total header bytes received from requests that triggered a WAF rule.
+	AttackRequestBodyBytes    *uint64     `mapstructure:"attack_req_body_bytes"`   // Total body bytes received from requests that triggered a WAF rule.
+	AttackResponseSynthBytes  *uint64     `mapstructure:"attack_resp_synth_bytes"` // Total bytes delivered for requests that triggered a WAF rule and returned a synthetic response.
+	BERequestBodyBytes        *uint64     `mapstructure:"bereq_body_bytes"`        // Total body bytes sent to origin.
+	BERequestHeaderbytes      *uint64     `mapstructure:"bereq_header_bytes"`      // Total header bytes sent to origin.
+	Bandwidth                 *uint64     `mapstructure:"bandwidth"`               // Total bytes delivered (body_size + header_size).
+	BilledBodyBytes           *uint64     `mapstructure:"billed_body_bytes"`
+	BilledHeaderBytes         *uint64     `mapstructure:"billed_header_bytes"`
+	Errors                    *uint64     `mapstructure:"errors"`                   // Number of cache errors.
+	HTTP2                     *uint64     `mapstructure:"http2"`                    // Number of requests received over HTTP2.
+	HitRatio                  *float64    `mapstructure:"hit_ratio"`                // Ratio of cache hits to cache misses (between 0 and 1).
+	Hits                      *uint64     `mapstructure:"hits"`                     // Number of cache hits.
+	HitsTime                  *float64    `mapstructure:"hits_time"`                // Total amount of time spent processing cache hits (in seconds).
+	IPv6                      *uint64     `mapstructure:"ipv6"`                     // Number of requests that were received over IPv6.
+	ImageOptimizer            *uint64     `mapstructure:"imgopto"`                  // Number of responses that came from the Fastly Image Optimizer service.
+	Log                       *uint64     `mapstructure:"log"`                      // Number of log lines sent.
+	Miss                      *uint64     `mapstructure:"miss"`                     // Number of cache misses.
 	MissHistogram             map[int]int `mapstructure:"miss_histogram"`           // Number of requests to origin in time buckets of 10s of milliseconds
-	MissTime                  float64     `mapstructure:"miss_time"`                // Amount of time spent processing cache misses (in seconds).
-	OTFP                      uint64      `mapstructure:"otfp"`                     // Number of responses that came from the Fastly On-the-Fly Packager for On Demand Streaming service for video-on-demand.
-	ObjectSize100k            uint64      `mapstructure:"object_size_100k"`         // Number of objects served that were between 10KB and 100KB in size.
-	ObjectSize100m            uint64      `mapstructure:"object_size_100m"`         // Number of objects served that were between 10MB and 100MB in size.
-	ObjectSize10k             uint64      `mapstructure:"object_size_10k"`          // Number of objects served that were between 1KB and 10KB in size.
-	ObjectSize10m             uint64      `mapstructure:"object_size_10m"`          // Number of objects served that were between 1MB and 10MB in size.
-	ObjectSize1g              uint64      `mapstructure:"object_size_1g"`           // Number of objects served that were between 100MB and 1GB in size.
-	ObjectSize1k              uint64      `mapstructure:"object_size_1k"`           // Number of objects served that were under 1KB in size.
-	ObjectSize1m              uint64      `mapstructure:"object_size_1m"`           // Number of objects served that were between 100KB and 1MB in size.
-	PCI                       uint64      `mapstructure:"pci"`                      // Number of responses with the PCI flag turned on.
-	Pass                      uint64      `mapstructure:"pass"`                     // Number of requests that passed through the CDN without being cached.
-	PassTime                  float64     `mapstructure:"pass_time"`                // Amount of time spent processing cache passes (in seconds).
-	Pipe                      uint64      `mapstructure:"pipe"`                     // Optional. Pipe operations performed (legacy feature).
-	RequestBodyBytes          uint64      `mapstructure:"req_body_bytes"`           // Total body bytes received.
-	RequestHeaderBytes        uint64      `mapstructure:"req_header_bytes"`         // Total header bytes received.
-	Requests                  uint64      `mapstructure:"requests"`                 // Number of requests processed.
-	ResponseBodyBytes         uint64      `mapstructure:"resp_body_bytes"`          // Total body bytes delivered.
-	ResponseHeaderBytes       uint64      `mapstructure:"resp_header_bytes"`        // Total header bytes delivered.
-	Restarts                  uint64      `mapstructure:"restarts"`                 // Number of restarts performed.
-	Shield                    uint64      `mapstructure:"shield"`                   // Number of requests from shield to origin.
-	ShieldResponseBodyBytes   uint64      `mapstructure:"shield_resp_body_bytes"`   // Total body bytes delivered via a shield.
-	ShieldResponseHeaderBytes uint64      `mapstructure:"shield_resp_header_bytes"` // Total header bytes delivered via a shield.
-	Status1xx                 uint64      `mapstructure:"status_1xx"`               // Number of "Informational" category status codes delivered.
-	Status200                 uint64      `mapstructure:"status_200"`               // Number of responses sent with status code 200 (Success).
-	Status204                 uint64      `mapstructure:"status_204"`               // Number of responses sent with status code 204 (No Content).
-	Status206                 uint64      `mapstructure:"status_206"`               // Number of responses sent with status code 206 (Partial Content).
-	Status2xx                 uint64      `mapstructure:"status_2xx"`               // Number of "Success" status codes delivered.
-	Status301                 uint64      `mapstructure:"status_301"`               // Number of responses sent with status code 301 (Moved Permanently).
-	Status302                 uint64      `mapstructure:"status_302"`               // Number of responses sent with status code 302 (Found).
-	Status304                 uint64      `mapstructure:"status_304"`               // Number of responses sent with status code 304 (Not Modified).
-	Status3xx                 uint64      `mapstructure:"status_3xx"`               // Number of "Redirection" codes delivered.
-	Status400                 uint64      `mapstructure:"status_400"`               // Number of responses sent with status code 400 (Bad Request).
-	Status401                 uint64      `mapstructure:"status_401"`               // Number of responses sent with status code 401 (Unauthorized).
-	Status403                 uint64      `mapstructure:"status_403"`               // Number of responses sent with status code 403 (Forbidden).
-	Status404                 uint64      `mapstructure:"status_404"`               // Number of responses sent with status code 404 (Not Found).
-	Status416                 uint64      `mapstructure:"status_416"`               // Number of responses sent with status code 416 (Range Not Satisfiable).
-	Status4xx                 uint64      `mapstructure:"status_4xx"`               // Number of "Client Error" codes delivered.
-	Status500                 uint64      `mapstructure:"status_500"`               // Number of responses sent with status code 500 (Internal Server Error).
-	Status501                 uint64      `mapstructure:"status_501"`               // Number of responses sent with status code 501 (Not Implemented).
-	Status502                 uint64      `mapstructure:"status_502"`               // Number of responses sent with status code 502 (Bad Gateway).
-	Status503                 uint64      `mapstructure:"status_503"`               // Number of responses sent with status code 503 (Service Unavailable).
-	Status504                 uint64      `mapstructure:"status_504"`               // Number of responses sent with status code 504 (Gateway Timeout).
-	Status505                 uint64      `mapstructure:"status_505"`               // Number of responses sent with status code 505 (HTTP Version Not Supported).
-	Status5xx                 uint64      `mapstructure:"status_5xx"`               // Number of "Server Error" codes delivered.
-	Synth                     uint64      `mapstructure:"synth"`                    // Number of requests that returned synth response.
-	TLS                       uint64      `mapstructure:"tls"`                      // Number of requests that were received over TLS.
-	TLSv10                    uint64      `mapstructure:"tls_v10"`                  // Number of requests received over TLS 1.0.
-	TLSv11                    uint64      `mapstructure:"tls_v11"`                  // Number of requests received over TLS 1.`.
-	TLSv12                    uint64      `mapstructure:"tls_v12"`                  // Number of requests received over TLS 1.2.
-	TLSv13                    uint64      `mapstructure:"tls_v13"`                  // Number of requests received over TLS 1.3.
-	Uncachable                uint64      `mapstructure:"uncachable"`               // Number of requests that were designated uncachable.
-	Video                     uint64      `mapstructure:"video"`                    // Number of responses with the video segment or video manifest MIME type (i.e., application/x-mpegurl, application/vnd.apple.mpegurl, application/f4m, application/dash+xml, application/vnd.ms-sstr+xml, ideo/mp2t, audio/aac, video/f4f, video/x-flv, video/mp4, audio/mp4).
-	WAFBlocked                uint64      `mapstructure:"waf_blocked"`              // Number of requests that triggered a WAF rule and were blocked.
-	WAFLogged                 uint64      `mapstructure:"waf_logged"`               // Number of requests that triggered a WAF rule and were logged.
-	WAFPassed                 uint64      `mapstructure:"waf_passed"`               // Number of requests that triggered a WAF rule and were passed.
+	MissTime                  *float64    `mapstructure:"miss_time"`                // Amount of time spent processing cache misses (in seconds).
+	OTFP                      *uint64     `mapstructure:"otfp"`                     // Number of responses that came from the Fastly On-the-Fly Packager for On Demand Streaming service for video-on-demand.
+	ObjectSize100k            *uint64     `mapstructure:"object_size_100k"`         // Number of objects served that were between 10KB and 100KB in size.
+	ObjectSize100m            *uint64     `mapstructure:"object_size_100m"`         // Number of objects served that were between 10MB and 100MB in size.
+	ObjectSize10k             *uint64     `mapstructure:"object_size_10k"`          // Number of objects served that were between 1KB and 10KB in size.
+	ObjectSize10m             *uint64     `mapstructure:"object_size_10m"`          // Number of objects served that were between 1MB and 10MB in size.
+	ObjectSize1g              *uint64     `mapstructure:"object_size_1g"`           // Number of objects served that were between 100MB and 1GB in size.
+	ObjectSize1k              *uint64     `mapstructure:"object_size_1k"`           // Number of objects served that were under 1KB in size.
+	ObjectSize1m              *uint64     `mapstructure:"object_size_1m"`           // Number of objects served that were between 100KB and 1MB in size.
+	PCI                       *uint64     `mapstructure:"pci"`                      // Number of responses with the PCI flag turned on.
+	Pass                      *uint64     `mapstructure:"pass"`                     // Number of requests that passed through the CDN without being cached.
+	PassTime                  *float64    `mapstructure:"pass_time"`                // Amount of time spent processing cache passes (in seconds).
+	Pipe                      *uint64     `mapstructure:"pipe"`                     // Optional. Pipe operations performed (legacy feature).
+	RequestBodyBytes          *uint64     `mapstructure:"req_body_bytes"`           // Total body bytes received.
+	RequestHeaderBytes        *uint64     `mapstructure:"req_header_bytes"`         // Total header bytes received.
+	Requests                  *uint64     `mapstructure:"requests"`                 // Number of requests processed.
+	ResponseBodyBytes         *uint64     `mapstructure:"resp_body_bytes"`          // Total body bytes delivered.
+	ResponseHeaderBytes       *uint64     `mapstructure:"resp_header_bytes"`        // Total header bytes delivered.
+	Restarts                  *uint64     `mapstructure:"restarts"`                 // Number of restarts performed.
+	Shield                    *uint64     `mapstructure:"shield"`                   // Number of requests from shield to origin.
+	ShieldResponseBodyBytes   *uint64     `mapstructure:"shield_resp_body_bytes"`   // Total body bytes delivered via a shield.
+	ShieldResponseHeaderBytes *uint64     `mapstructure:"shield_resp_header_bytes"` // Total header bytes delivered via a shield.
+	Status1xx                 *uint64     `mapstructure:"status_1xx"`               // Number of "Informational" category status codes delivered.
+	Status200                 *uint64     `mapstructure:"status_200"`               // Number of responses sent with status code 200 (Success).
+	Status204                 *uint64     `mapstructure:"status_204"`               // Number of responses sent with status code 204 (No Content).
+	Status206                 *uint64     `mapstructure:"status_206"`               // Number of responses sent with status code 206 (Partial Content).
+	Status2xx                 *uint64     `mapstructure:"status_2xx"`               // Number of "Success" status codes delivered.
+	Status301                 *uint64     `mapstructure:"status_301"`               // Number of responses sent with status code 301 (Moved Permanently).
+	Status302                 *uint64     `mapstructure:"status_302"`               // Number of responses sent with status code 302 (Found).
+	Status304                 *uint64     `mapstructure:"status_304"`               // Number of responses sent with status code 304 (Not Modified).
+	Status3xx                 *uint64     `mapstructure:"status_3xx"`               // Number of "Redirection" codes delivered.
+	Status400                 *uint64     `mapstructure:"status_400"`               // Number of responses sent with status code 400 (Bad Request).
+	Status401                 *uint64     `mapstructure:"status_401"`               // Number of responses sent with status code 401 (Unauthorized).
+	Status403                 *uint64     `mapstructure:"status_403"`               // Number of responses sent with status code 403 (Forbidden).
+	Status404                 *uint64     `mapstructure:"status_404"`               // Number of responses sent with status code 404 (Not Found).
+	Status416                 *uint64     `mapstructure:"status_416"`               // Number of responses sent with status code 416 (Range Not Satisfiable).
+	Status4xx                 *uint64     `mapstructure:"status_4xx"`               // Number of "Client Error" codes delivered.
+	Status500                 *uint64     `mapstructure:"status_500"`               // Number of responses sent with status code 500 (Internal Server Error).
+	Status501                 *uint64     `mapstructure:"status_501"`               // Number of responses sent with status code 501 (Not Implemented).
+	Status502                 *uint64     `mapstructure:"status_502"`               // Number of responses sent with status code 502 (Bad Gateway).
+	Status503                 *uint64     `mapstructure:"status_503"`               // Number of responses sent with status code 503 (Service Unavailable).
+	Status504                 *uint64     `mapstructure:"status_504"`               // Number of responses sent with status code 504 (Gateway Timeout).
+	Status505                 *uint64     `mapstructure:"status_505"`               // Number of responses sent with status code 505 (HTTP Version Not Supported).
+	Status5xx                 *uint64     `mapstructure:"status_5xx"`               // Number of "Server Error" codes delivered.
+	Synth                     *uint64     `mapstructure:"synth"`                    // Number of requests that returned synth response.
+	TLS                       *uint64     `mapstructure:"tls"`                      // Number of requests that were received over TLS.
+	TLSv10                    *uint64     `mapstructure:"tls_v10"`                  // Number of requests received over TLS 1.0.
+	TLSv11                    *uint64     `mapstructure:"tls_v11"`                  // Number of requests received over TLS 1.`.
+	TLSv12                    *uint64     `mapstructure:"tls_v12"`                  // Number of requests received over TLS 1.2.
+	TLSv13                    *uint64     `mapstructure:"tls_v13"`                  // Number of requests received over TLS 1.3.
+	Uncachable                *uint64     `mapstructure:"uncachable"`               // Number of requests that were designated uncachable.
+	Video                     *uint64     `mapstructure:"video"`                    // Number of responses with the video segment or video manifest MIME type (i.e., application/x-mpegurl, application/vnd.apple.mpegurl, application/f4m, application/dash+xml, application/vnd.ms-sstr+xml, ideo/mp2t, audio/aac, video/f4f, video/x-flv, video/mp4, audio/mp4).
+	WAFBlocked                *uint64     `mapstructure:"waf_blocked"`              // Number of requests that triggered a WAF rule and were blocked.
+	WAFLogged                 *uint64     `mapstructure:"waf_logged"`               // Number of requests that triggered a WAF rule and were logged.
+	WAFPassed                 *uint64     `mapstructure:"waf_passed"`               // Number of requests that triggered a WAF rule and were passed.
 }
 
 // GetStatsInput is an input to the GetStats function.
@@ -88,33 +96,17 @@ type Stats struct {
 // Allowed values for the fields are described at https://developer.fastly.com/reference/api/metrics-stats/
 type GetStatsInput struct {
 	// By is the duration of sample windows.
-	By string
+	By *string
 	// Field is the name of the stats field.
-	Field string
+	Field *string
 	// From is the timestamp that defines the start of the window for which to fetch statistics, including the timestamp itself.
-	From string
+	From *string
 	// Region limits query to a specific geographic region.
-	Region string
+	Region *string
 	// Service is the ID of the service.
-	Service string
+	Service *string
 	// To is the timestamp that defines the end of the window for which to fetch statistics.
-	To string
-}
-
-// StatsResponse is a response from the service stats API endpoint
-type StatsResponse struct {
-	Data    []*Stats          `mapstructure:"data"`
-	Message string            `mapstructure:"msg"`
-	Meta    map[string]string `mapstructure:"meta"`
-	Status  string            `mapstructure:"status"`
-}
-
-// StatsFieldResponse is a response from the service stats/field API endpoint
-type StatsFieldResponse struct {
-	Data    map[string][]*Stats `mapstructure:"data"`
-	Message string              `mapstructure:"msg"`
-	Meta    map[string]string   `mapstructure:"meta"`
-	Status  string              `mapstructure:"status"`
+	To *string
 }
 
 // GetStats retrieves the specified resource.
@@ -129,6 +121,14 @@ func (c *Client) GetStats(i *GetStatsInput) (*StatsResponse, error) {
 		return nil, err
 	}
 	return sr, nil
+}
+
+// StatsFieldResponse is a response from the service stats/field API endpoint.
+type StatsFieldResponse struct {
+	Data    map[string][]*Stats `mapstructure:"data"`
+	Message *string             `mapstructure:"msg"`
+	Meta    map[string]string   `mapstructure:"meta"`
+	Status  *string             `mapstructure:"status"`
 }
 
 // GetStatsField retrieves the specified resource.
@@ -148,23 +148,30 @@ func (c *Client) GetStatsField(i *GetStatsInput) (*StatsFieldResponse, error) {
 // GetStatsJSON fetches stats and decodes the response directly to the JSON struct dst.
 func (c *Client) GetStatsJSON(i *GetStatsInput, dst interface{}) error {
 	p := "/stats"
-
-	if i.Service != "" {
-		p = fmt.Sprintf("%s/service/%s", p, i.Service)
+	if i.Service != nil {
+		p = fmt.Sprintf("%s/service/%s", p, *i.Service)
+	}
+	if i.Field != nil {
+		p = fmt.Sprintf("%s/field/%s", p, *i.Field)
 	}
 
-	if i.Field != "" {
-		p = fmt.Sprintf("%s/field/%s", p, i.Field)
+	ro := &RequestOptions{
+		Params: map[string]string{},
+	}
+	if i.By != nil {
+		ro.Params["by"] = *i.By
+	}
+	if i.From != nil {
+		ro.Params["from"] = *i.From
+	}
+	if i.Region != nil {
+		ro.Params["region"] = *i.Region
+	}
+	if i.To != nil {
+		ro.Params["to"] = *i.To
 	}
 
-	r, err := c.Get(p, &RequestOptions{
-		Params: map[string]string{
-			"from":   i.From,
-			"to":     i.To,
-			"by":     i.By,
-			"region": i.Region,
-		},
-	})
+	r, err := c.Get(p, ro)
 	if err != nil {
 		return err
 	}
@@ -173,55 +180,56 @@ func (c *Client) GetStatsJSON(i *GetStatsInput, dst interface{}) error {
 	return json.NewDecoder(r.Body).Decode(dst)
 }
 
-// UsageStatsResponse is a response from the account usage API endpoint
-type UsageStatsResponse struct {
-	Data    map[string]*Usage `mapstructure:"data"`
-	Message string            `mapstructure:"msg"`
-	Meta    map[string]string `mapstructure:"meta"`
-	Status  string            `mapstructure:"status"`
+// Usage represents usage data of a single service or region.
+type Usage struct {
+	Bandwidth       *uint64 `mapstructure:"bandwidth"`
+	Requests        *uint64 `mapstructure:"requests"`
+	ComputeRequests *uint64 `mapstructure:"compute_requests"`
 }
 
-// Usage represents usage data of a single service or region
-type Usage struct {
-	Bandwidth       uint64 `mapstructure:"bandwidth"`
-	Requests        uint64 `mapstructure:"requests"`
-	ComputeRequests uint64 `mapstructure:"compute_requests"`
+// UsageResponse is a response from the account usage API endpoint.
+type UsageResponse struct {
+	Data    *RegionsUsage     `mapstructure:"data"`
+	Message *string           `mapstructure:"msg"`
+	Meta    map[string]string `mapstructure:"meta"`
+	Status  *string           `mapstructure:"status"`
 }
 
 // RegionsUsage is a list of aggregated usage data by Fastly's region
 type RegionsUsage map[string]*Usage
 
-// UsageResponse is a response from the account usage API endpoint
-type UsageResponse struct {
-	Data    *RegionsUsage     `mapstructure:"data"`
-	Message string            `mapstructure:"msg"`
-	Meta    map[string]string `mapstructure:"meta"`
-	Status  string            `mapstructure:"status"`
-}
-
 // GetUsageInput is used as an input to the GetUsage function
 // Value for the input are described at https://developer.fastly.com/reference/api/metrics-stats/
 type GetUsageInput struct {
 	// By is the duration of sample windows.
-	By string
+	By *string
 	// From is the timestamp that defines the start of the window for which to fetch statistics, including the timestamp itself.
-	From string
+	From *string
 	// Region limits query to a specific geographic region.
-	Region string
+	Region *string
 	// To is the timestamp that defines the end of the window for which to fetch statistics.
-	To string
+	To *string
 }
 
 // GetUsage returns usage information aggregated across all Fastly services and grouped by region.
 func (c *Client) GetUsage(i *GetUsageInput) (*UsageResponse, error) {
-	r, err := c.Get("/stats/usage", &RequestOptions{
-		Params: map[string]string{
-			"from":   i.From,
-			"to":     i.To,
-			"by":     i.By,
-			"region": i.Region,
-		},
-	})
+	ro := &RequestOptions{
+		Params: map[string]string{},
+	}
+	if i.By != nil {
+		ro.Params["by"] = *i.By
+	}
+	if i.From != nil {
+		ro.Params["from"] = *i.From
+	}
+	if i.Region != nil {
+		ro.Params["region"] = *i.Region
+	}
+	if i.To != nil {
+		ro.Params["to"] = *i.To
+	}
+
+	r, err := c.Get("/stats/usage", ro)
 	if err != nil {
 		return nil, err
 	}
@@ -238,9 +246,9 @@ func (c *Client) GetUsage(i *GetUsageInput) (*UsageResponse, error) {
 // UsageByServiceResponse is a response from the account usage API endpoint
 type UsageByServiceResponse struct {
 	Data    *ServicesByRegionsUsage `mapstructure:"data"`
-	Message string                  `mapstructure:"msg"`
+	Message *string                 `mapstructure:"msg"`
 	Meta    map[string]string       `mapstructure:"meta"`
-	Status  string                  `mapstructure:"status"`
+	Status  *string                 `mapstructure:"status"`
 }
 
 // ServicesUsage is a list of usage data by a service
@@ -252,14 +260,23 @@ type ServicesByRegionsUsage map[string]*ServicesUsage
 // GetUsageByService returns usage information aggregated by service and
 // grouped by service and region.
 func (c *Client) GetUsageByService(i *GetUsageInput) (*UsageByServiceResponse, error) {
-	r, err := c.Get("/stats/usage_by_service", &RequestOptions{
-		Params: map[string]string{
-			"from":   i.From,
-			"to":     i.To,
-			"by":     i.By,
-			"region": i.Region,
-		},
-	})
+	ro := &RequestOptions{
+		Params: map[string]string{},
+	}
+	if i.By != nil {
+		ro.Params["by"] = *i.By
+	}
+	if i.From != nil {
+		ro.Params["from"] = *i.From
+	}
+	if i.Region != nil {
+		ro.Params["region"] = *i.Region
+	}
+	if i.To != nil {
+		ro.Params["to"] = *i.To
+	}
+
+	r, err := c.Get("/stats/usage_by_service", ro)
 	if err != nil {
 		return nil, err
 	}
@@ -276,9 +293,9 @@ func (c *Client) GetUsageByService(i *GetUsageInput) (*UsageByServiceResponse, e
 // RegionsResponse is a response from Fastly regions API endpoint
 type RegionsResponse struct {
 	Data    []string          `mapstructure:"data"`
-	Message string            `mapstructure:"msg"`
+	Message *string           `mapstructure:"msg"`
 	Meta    map[string]string `mapstructure:"meta"`
-	Status  string            `mapstructure:"status"`
+	Status  *string           `mapstructure:"status"`
 }
 
 // GetRegions returns a list of Fastly regions

--- a/fastly/stats_test.go
+++ b/fastly/stats_test.go
@@ -10,11 +10,11 @@ func TestClient_GetStats(t *testing.T) {
 	var err error
 	record(t, "stats/service_stats", func(c *Client) {
 		_, err = c.GetStats(&GetStatsInput{
-			Service: testServiceID,
-			From:    "10 days ago",
-			To:      "now",
-			By:      "minute",
-			Region:  "europe",
+			Service: ToPointer(testServiceID),
+			From:    ToPointer("10 days ago"),
+			To:      ToPointer("now"),
+			By:      ToPointer("minute"),
+			Region:  ToPointer("europe"),
 		})
 	})
 	if err != nil {
@@ -28,11 +28,11 @@ func TestClient_GetStats_ByField(t *testing.T) {
 	var err error
 	record(t, "stats/service_stats_by_field", func(c *Client) {
 		_, err = c.GetStatsField(&GetStatsInput{
-			Field:  "bandwidth",
-			From:   "1 hour ago",
-			To:     "now",
-			By:     "minute",
-			Region: "europe",
+			Field:  ToPointer("bandwidth"),
+			From:   ToPointer("1 hour ago"),
+			To:     ToPointer("now"),
+			By:     ToPointer("minute"),
+			Region: ToPointer("europe"),
 		})
 	})
 	if err != nil {
@@ -46,12 +46,12 @@ func TestClient_GetStats_ByFieldAndService(t *testing.T) {
 	var err error
 	record(t, "stats/service_stats_by_field_and_service", func(c *Client) {
 		_, err = c.GetStats(&GetStatsInput{
-			Service: testServiceID,
-			Field:   "bandwidth",
-			From:    "10 days ago",
-			To:      "now",
-			By:      "day",
-			Region:  "usa",
+			Service: ToPointer(testServiceID),
+			Field:   ToPointer("bandwidth"),
+			From:    ToPointer("10 days ago"),
+			To:      ToPointer("now"),
+			By:      ToPointer("day"),
+			Region:  ToPointer("usa"),
 		})
 	})
 	if err != nil {
@@ -69,11 +69,11 @@ func TestClient_GetStatsJSON(t *testing.T) {
 	var err error
 	record(t, "stats/service_stats", func(c *Client) {
 		err = c.GetStatsJSON(&GetStatsInput{
-			Service: testServiceID,
-			From:    "10 days ago",
-			To:      "now",
-			By:      "minute",
-			Region:  "europe",
+			Service: ToPointer(testServiceID),
+			From:    ToPointer("10 days ago"),
+			To:      ToPointer("now"),
+			By:      ToPointer("minute"),
+			Region:  ToPointer("europe"),
 		}, &ret)
 	})
 	if err != nil {
@@ -103,10 +103,10 @@ func TestClient_GetRegionsUsage(t *testing.T) {
 	var err error
 	record(t, "stats/regions_usage", func(c *Client) {
 		_, err = c.GetUsage(&GetUsageInput{
-			From:   "10 days ago",
-			To:     "now",
-			By:     "minute",
-			Region: "usa",
+			From:   ToPointer("10 days ago"),
+			To:     ToPointer("now"),
+			By:     ToPointer("minute"),
+			Region: ToPointer("usa"),
 		})
 	})
 	if err != nil {
@@ -120,10 +120,10 @@ func TestClient_GetServicesByRegionsUsage(t *testing.T) {
 	var err error
 	record(t, "stats/services_usage", func(c *Client) {
 		_, err = c.GetUsageByService(&GetUsageInput{
-			From:   "10 days ago",
-			To:     "now",
-			By:     "minute",
-			Region: "usa",
+			From:   ToPointer("10 days ago"),
+			To:     ToPointer("now"),
+			By:     ToPointer("minute"),
+			Region: ToPointer("usa"),
 		})
 	})
 	if err != nil {

--- a/fastly/sumologic.go
+++ b/fastly/sumologic.go
@@ -3,43 +3,24 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Sumologic represents a sumologic response from the Fastly API.
 type Sumologic struct {
-	Address           string     `mapstructure:"address"`
+	Address           *string    `mapstructure:"address"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	MessageType       string     `mapstructure:"message_type"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	URL               string     `mapstructure:"url"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	MessageType       *string    `mapstructure:"message_type"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	URL               *string    `mapstructure:"url"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-}
-
-// sumologicsByName is a sortable list of sumologics.
-type sumologicsByName []*Sumologic
-
-// Len implement the sortable interface.
-func (s sumologicsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s sumologicsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s sumologicsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListSumologicsInput is used as input to the ListSumologics function.
@@ -70,7 +51,6 @@ func (c *Client) ListSumologics(i *ListSumologicsInput) ([]*Sumologic, error) {
 	if err := decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
-	sort.Stable(sumologicsByName(ss))
 	return ss, nil
 }
 
@@ -164,7 +144,7 @@ type UpdateSumologicInput struct {
 	FormatVersion *int `url:"format_version,omitempty"`
 	// MessageType is how the message should be formatted (classic, loggly, logplex, blank).
 	MessageType *string `url:"message_type,omitempty"`
-	// Name is the name of the sumologic to update.
+	// Name is the name of the sumologic to update (required).
 	Name string `url:"-"`
 	// NewName is the new name for the resource.
 	NewName *string `url:"name,omitempty"`

--- a/fastly/sumologic_test.go
+++ b/fastly/sumologic_test.go
@@ -48,23 +48,23 @@ func TestClient_Sumologics(t *testing.T) {
 		})
 	}()
 
-	if s.Name != "test-sumologic" {
-		t.Errorf("bad name: %q", s.Name)
+	if *s.Name != "test-sumologic" {
+		t.Errorf("bad name: %q", *s.Name)
 	}
-	if s.URL != "https://foo.sumologic.com" {
-		t.Errorf("bad url: %q", s.URL)
+	if *s.URL != "https://foo.sumologic.com" {
+		t.Errorf("bad url: %q", *s.URL)
 	}
-	if s.Format != "format" {
-		t.Errorf("bad format: %q", s.Format)
+	if *s.Format != "format" {
+		t.Errorf("bad format: %q", *s.Format)
 	}
-	if s.FormatVersion != 1 {
-		t.Errorf("bad format version: %q", s.FormatVersion)
+	if *s.FormatVersion != 1 {
+		t.Errorf("bad format version: %q", *s.FormatVersion)
 	}
-	if s.MessageType != "classic" {
-		t.Errorf("bad message type: %q", s.MessageType)
+	if *s.MessageType != "classic" {
+		t.Errorf("bad message type: %q", *s.MessageType)
 	}
-	if s.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", s.Placement)
+	if *s.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *s.Placement)
 	}
 
 	// List
@@ -94,23 +94,23 @@ func TestClient_Sumologics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Name != ns.Name {
-		t.Errorf("bad name: %q", s.Name)
+	if *s.Name != *ns.Name {
+		t.Errorf("bad name: %q", *s.Name)
 	}
-	if s.URL != ns.URL {
-		t.Errorf("bad url: %q", s.URL)
+	if *s.URL != *ns.URL {
+		t.Errorf("bad url: %q", *s.URL)
 	}
-	if s.Format != ns.Format {
-		t.Errorf("bad format: %q", s.Format)
+	if *s.Format != *ns.Format {
+		t.Errorf("bad format: %q", *s.Format)
 	}
-	if s.FormatVersion != ns.FormatVersion {
-		t.Errorf("bad format version: %q", s.FormatVersion)
+	if *s.FormatVersion != *ns.FormatVersion {
+		t.Errorf("bad format version: %q", *s.FormatVersion)
 	}
-	if s.MessageType != ns.MessageType {
-		t.Errorf("bad message type: %q", s.MessageType)
+	if *s.MessageType != *ns.MessageType {
+		t.Errorf("bad message type: %q", *s.MessageType)
 	}
-	if s.Placement != ns.Placement {
-		t.Errorf("bad placement: %q", s.Placement)
+	if *s.Placement != *ns.Placement {
+		t.Errorf("bad placement: %q", *s.Placement)
 	}
 
 	// Update
@@ -126,8 +126,8 @@ func TestClient_Sumologics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if us.Name != "new-test-sumologic" {
-		t.Errorf("bad name: %q", us.Name)
+	if *us.Name != "new-test-sumologic" {
+		t.Errorf("bad name: %q", *us.Name)
 	}
 
 	// Delete

--- a/fastly/sumologic_test.go
+++ b/fastly/sumologic_test.go
@@ -18,7 +18,7 @@ func TestClient_Sumologics(t *testing.T) {
 	record(t, "sumologics/create", func(c *Client) {
 		s, err = c.CreateSumologic(&CreateSumologicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-sumologic"),
 			URL:            ToPointer("https://foo.sumologic.com"),
 			Format:         ToPointer("format"),
@@ -36,13 +36,13 @@ func TestClient_Sumologics(t *testing.T) {
 		record(t, "sumologics/cleanup", func(c *Client) {
 			_ = c.DeleteSumologic(&DeleteSumologicInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-sumologic",
 			})
 
 			_ = c.DeleteSumologic(&DeleteSumologicInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-sumologic",
 			})
 		})
@@ -72,7 +72,7 @@ func TestClient_Sumologics(t *testing.T) {
 	record(t, "sumologics/list", func(c *Client) {
 		ss, err = c.ListSumologics(&ListSumologicsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func TestClient_Sumologics(t *testing.T) {
 	record(t, "sumologics/get", func(c *Client) {
 		ns, err = c.GetSumologic(&GetSumologicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-sumologic",
 		})
 	})
@@ -118,7 +118,7 @@ func TestClient_Sumologics(t *testing.T) {
 	record(t, "sumologics/update", func(c *Client) {
 		us, err = c.UpdateSumologic(&UpdateSumologicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-sumologic",
 			NewName:        ToPointer("new-test-sumologic"),
 		})
@@ -134,7 +134,7 @@ func TestClient_Sumologics(t *testing.T) {
 	record(t, "sumologics/delete", func(c *Client) {
 		err = c.DeleteSumologic(&DeleteSumologicInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-sumologic",
 		})
 	})

--- a/fastly/syslog.go
+++ b/fastly/syslog.go
@@ -3,51 +3,32 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // Syslog represents a syslog response from the Fastly API.
 type Syslog struct {
-	Address           string     `mapstructure:"address"`
+	Address           *string    `mapstructure:"address"`
 	CreatedAt         *time.Time `mapstructure:"created_at"`
 	DeletedAt         *time.Time `mapstructure:"deleted_at"`
-	Format            string     `mapstructure:"format"`
-	FormatVersion     int        `mapstructure:"format_version"`
-	Hostname          string     `mapstructure:"hostname"`
-	IPV4              string     `mapstructure:"ipv4"`
-	MessageType       string     `mapstructure:"message_type"`
-	Name              string     `mapstructure:"name"`
-	Placement         string     `mapstructure:"placement"`
-	Port              int        `mapstructure:"port"`
-	ResponseCondition string     `mapstructure:"response_condition"`
-	ServiceID         string     `mapstructure:"service_id"`
-	ServiceVersion    int        `mapstructure:"version"`
-	TLSCACert         string     `mapstructure:"tls_ca_cert"`
-	TLSClientCert     string     `mapstructure:"tls_client_cert"`
-	TLSClientKey      string     `mapstructure:"tls_client_key"`
-	TLSHostname       string     `mapstructure:"tls_hostname"`
-	Token             string     `mapstructure:"token"`
+	Format            *string    `mapstructure:"format"`
+	FormatVersion     *int       `mapstructure:"format_version"`
+	Hostname          *string    `mapstructure:"hostname"`
+	IPV4              *string    `mapstructure:"ipv4"`
+	MessageType       *string    `mapstructure:"message_type"`
+	Name              *string    `mapstructure:"name"`
+	Placement         *string    `mapstructure:"placement"`
+	Port              *int       `mapstructure:"port"`
+	ResponseCondition *string    `mapstructure:"response_condition"`
+	ServiceID         *string    `mapstructure:"service_id"`
+	ServiceVersion    *int       `mapstructure:"version"`
+	TLSCACert         *string    `mapstructure:"tls_ca_cert"`
+	TLSClientCert     *string    `mapstructure:"tls_client_cert"`
+	TLSClientKey      *string    `mapstructure:"tls_client_key"`
+	TLSHostname       *string    `mapstructure:"tls_hostname"`
+	Token             *string    `mapstructure:"token"`
 	UpdatedAt         *time.Time `mapstructure:"updated_at"`
-	UseTLS            bool       `mapstructure:"use_tls"`
-}
-
-// syslogsByName is a sortable list of syslogs.
-type syslogsByName []*Syslog
-
-// Len implement the sortable interface.
-func (s syslogsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s syslogsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s syslogsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	UseTLS            *bool      `mapstructure:"use_tls"`
 }
 
 // ListSyslogsInput is used as input to the ListSyslogs function.
@@ -78,7 +59,6 @@ func (c *Client) ListSyslogs(i *ListSyslogsInput) ([]*Syslog, error) {
 	if err := decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
-	sort.Stable(syslogsByName(ss))
 	return ss, nil
 }
 

--- a/fastly/syslog_test.go
+++ b/fastly/syslog_test.go
@@ -77,47 +77,47 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		})
 	}()
 
-	if s.Name != "test-syslog" {
-		t.Errorf("bad name: %q", s.Name)
+	if *s.Name != "test-syslog" {
+		t.Errorf("bad name: %q", *s.Name)
 	}
-	if s.Address != "example.com" {
-		t.Errorf("bad address: %q", s.Address)
+	if *s.Address != "example.com" {
+		t.Errorf("bad address: %q", *s.Address)
 	}
-	if s.Hostname != "example.com" {
-		t.Errorf("bad hostname: %q", s.Hostname)
+	if *s.Hostname != "example.com" {
+		t.Errorf("bad hostname: %q", *s.Hostname)
 	}
-	if s.Port != 1234 {
-		t.Errorf("bad port: %q", s.Port)
+	if *s.Port != 1234 {
+		t.Errorf("bad port: %q", *s.Port)
 	}
-	if !s.UseTLS {
-		t.Errorf("bad use_tls: %t", s.UseTLS)
+	if !*s.UseTLS {
+		t.Errorf("bad use_tls: %t", *s.UseTLS)
 	}
-	if s.TLSCACert != caCert {
-		t.Errorf("bad tls_ca_cert: %q", s.TLSCACert)
+	if *s.TLSCACert != caCert {
+		t.Errorf("bad tls_ca_cert: %q", *s.TLSCACert)
 	}
-	if s.TLSHostname != "example.com" {
-		t.Errorf("bad tls_hostname: %q", s.TLSHostname)
+	if *s.TLSHostname != "example.com" {
+		t.Errorf("bad tls_hostname: %q", *s.TLSHostname)
 	}
-	if s.TLSClientCert != clientCert {
-		t.Errorf("bad tls_client_cert: %q", s.TLSClientCert)
+	if *s.TLSClientCert != clientCert {
+		t.Errorf("bad tls_client_cert: %q", *s.TLSClientCert)
 	}
-	if s.TLSClientKey != clientKey {
-		t.Errorf("bad tls_client_key: %q", s.TLSClientKey)
+	if *s.TLSClientKey != clientKey {
+		t.Errorf("bad tls_client_key: %q", *s.TLSClientKey)
 	}
-	if s.Token != "abcd1234" {
-		t.Errorf("bad token: %q", s.Token)
+	if *s.Token != "abcd1234" {
+		t.Errorf("bad token: %q", *s.Token)
 	}
-	if s.Format != "format" {
-		t.Errorf("bad format: %q", s.Format)
+	if *s.Format != "format" {
+		t.Errorf("bad format: %q", *s.Format)
 	}
-	if s.FormatVersion != 2 {
-		t.Errorf("bad format_version: %d", s.FormatVersion)
+	if *s.FormatVersion != 2 {
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
-	if s.MessageType != "classic" {
-		t.Errorf("bad message_type: %s", s.MessageType)
+	if *s.MessageType != "classic" {
+		t.Errorf("bad message_type: %s", *s.MessageType)
 	}
-	if s.Placement != "waf_debug" {
-		t.Errorf("bad placement: %q", s.Placement)
+	if *s.Placement != "waf_debug" {
+		t.Errorf("bad placement: %q", *s.Placement)
 	}
 
 	// List
@@ -147,47 +147,47 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.Name != ns.Name {
-		t.Errorf("bad name: %q", s.Name)
+	if *s.Name != *ns.Name {
+		t.Errorf("bad name: %q", *s.Name)
 	}
-	if s.Address != ns.Address {
-		t.Errorf("bad address: %q", s.Address)
+	if *s.Address != *ns.Address {
+		t.Errorf("bad address: %q", *s.Address)
 	}
-	if s.Hostname != ns.Hostname {
-		t.Errorf("bad hostname: %q", s.Hostname)
+	if *s.Hostname != *ns.Hostname {
+		t.Errorf("bad hostname: %q", *s.Hostname)
 	}
-	if s.Port != ns.Port {
-		t.Errorf("bad port: %q", s.Port)
+	if *s.Port != *ns.Port {
+		t.Errorf("bad port: %q", *s.Port)
 	}
-	if s.UseTLS != ns.UseTLS {
-		t.Errorf("bad use_tls: %t", s.UseTLS)
+	if *s.UseTLS != *ns.UseTLS {
+		t.Errorf("bad use_tls: %t", *s.UseTLS)
 	}
-	if s.TLSCACert != ns.TLSCACert {
-		t.Errorf("bad tls_ca_cert: %q", s.TLSCACert)
+	if *s.TLSCACert != *ns.TLSCACert {
+		t.Errorf("bad tls_ca_cert: %q", *s.TLSCACert)
 	}
-	if s.TLSHostname != ns.TLSHostname {
-		t.Errorf("bad tls_hostname: %q", s.TLSHostname)
+	if *s.TLSHostname != *ns.TLSHostname {
+		t.Errorf("bad tls_hostname: %q", *s.TLSHostname)
 	}
-	if s.TLSClientCert != ns.TLSClientCert {
-		t.Errorf("bad tls_client_cert: %q", s.TLSClientCert)
+	if *s.TLSClientCert != *ns.TLSClientCert {
+		t.Errorf("bad tls_client_cert: %q", *s.TLSClientCert)
 	}
-	if s.TLSClientKey != ns.TLSClientKey {
-		t.Errorf("bad tls_client_key: %q", s.TLSClientKey)
+	if *s.TLSClientKey != *ns.TLSClientKey {
+		t.Errorf("bad tls_client_key: %q", *s.TLSClientKey)
 	}
-	if s.Token != ns.Token {
-		t.Errorf("bad token: %q", s.Token)
+	if *s.Token != *ns.Token {
+		t.Errorf("bad token: %q", *s.Token)
 	}
-	if s.Format != ns.Format {
-		t.Errorf("bad format: %q", s.Format)
+	if *s.Format != *ns.Format {
+		t.Errorf("bad format: %q", *s.Format)
 	}
-	if s.FormatVersion != ns.FormatVersion {
-		t.Errorf("bad format_version: %q", s.FormatVersion)
+	if *s.FormatVersion != *ns.FormatVersion {
+		t.Errorf("bad format_version: %q", *s.FormatVersion)
 	}
-	if s.MessageType != ns.MessageType {
-		t.Errorf("bad message_type: %q", s.MessageType)
+	if *s.MessageType != *ns.MessageType {
+		t.Errorf("bad message_type: %q", *s.MessageType)
 	}
-	if s.Placement != ns.Placement {
-		t.Errorf("bad placement: %q", s.Placement)
+	if *s.Placement != *ns.Placement {
+		t.Errorf("bad placement: %q", *s.Placement)
 	}
 
 	// Update
@@ -204,12 +204,12 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	if err != nil {
 		t.Fatal(err)
 	}
-	if us.Name != "new-test-syslog" {
-		t.Errorf("bad name: %q", us.Name)
+	if *us.Name != "new-test-syslog" {
+		t.Errorf("bad name: %q", *us.Name)
 	}
 
-	if us.FormatVersion != 2 {
-		t.Errorf("bad format_version: %d", us.FormatVersion)
+	if *us.FormatVersion != 2 {
+		t.Errorf("bad format_version: %d", *us.FormatVersion)
 	}
 
 	// Delete

--- a/fastly/syslog_test.go
+++ b/fastly/syslog_test.go
@@ -39,7 +39,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "syslogs/create", func(c *Client) {
 		s, err = c.CreateSyslog(&CreateSyslogInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-syslog"),
 			Address:        ToPointer("example.com"),
 			Hostname:       ToPointer("example.com"),
@@ -65,13 +65,13 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		record(t, "syslogs/cleanup", func(c *Client) {
 			c.DeleteSyslog(&DeleteSyslogInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-syslog",
 			})
 
 			c.DeleteSyslog(&DeleteSyslogInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-syslog",
 			})
 		})
@@ -125,7 +125,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "syslogs/list", func(c *Client) {
 		ss, err = c.ListSyslogs(&ListSyslogsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -140,7 +140,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "syslogs/get", func(c *Client) {
 		ns, err = c.GetSyslog(&GetSyslogInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-syslog",
 		})
 	})
@@ -195,7 +195,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "syslogs/update", func(c *Client) {
 		us, err = c.UpdateSyslog(&UpdateSyslogInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-syslog",
 			NewName:        ToPointer("new-test-syslog"),
 			FormatVersion:  ToPointer(2),
@@ -216,7 +216,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	record(t, "syslogs/delete", func(c *Client) {
 		err = c.DeleteSyslog(&DeleteSyslogInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-syslog",
 		})
 	})

--- a/fastly/tls_subscription_test.go
+++ b/fastly/tls_subscription_test.go
@@ -1,6 +1,8 @@
 package fastly
 
-import "testing"
+import (
+	"testing"
+)
 
 const fixtureBase = "tls_subscription/"
 
@@ -37,7 +39,7 @@ func TestClient_TLSSubscription(t *testing.T) {
 	record(t, fixtureBase+"domains/create", func(c *Client) {
 		_, err = c.CreateDomain(&CreateDomainInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer(domain1),
 			Comment:        ToPointer("comment"),
 		})
@@ -49,7 +51,7 @@ func TestClient_TLSSubscription(t *testing.T) {
 	record(t, fixtureBase+"domains/create2", func(c *Client) {
 		_, err = c.CreateDomain(&CreateDomainInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer(domain2),
 			Comment:        ToPointer("comment"),
 		})
@@ -64,7 +66,7 @@ func TestClient_TLSSubscription(t *testing.T) {
 	record(t, fixtureBase+"activate_version", func(c *Client) {
 		_, err = c.ActivateVersion(&ActivateVersionInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {

--- a/fastly/token.go
+++ b/fastly/token.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"net/http"
-	"sort"
 	"time"
 )
 
@@ -24,34 +23,16 @@ const (
 // Token represents an API token which are used to authenticate requests to the
 // Fastly API.
 type Token struct {
-	AccessToken string     `mapstructure:"access_token"`
-	CreatedAt   *time.Time `mapstructure:"created_at"`
-	ExpiresAt   *time.Time `mapstructure:"expires_at"`
-	ID          string     `mapstructure:"id"`
-	IP          string     `mapstructure:"ip"`
-	LastUsedAt  *time.Time `mapstructure:"last_used_at"`
-	Name        string     `mapstructure:"name"`
-	Scope       TokenScope `mapstructure:"scope"`
-	Services    []string   `mapstructure:"services"`
-	UserID      string     `mapstructure:"user_id"`
-}
-
-// tokensByName is a sortable list of tokens.
-type tokensByName []*Token
-
-// Len implement the sortable interface.
-func (s tokensByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s tokensByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s tokensByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
+	AccessToken *string     `mapstructure:"access_token"`
+	CreatedAt   *time.Time  `mapstructure:"created_at"`
+	ExpiresAt   *time.Time  `mapstructure:"expires_at"`
+	ID          *string     `mapstructure:"id"`
+	IP          *string     `mapstructure:"ip"`
+	LastUsedAt  *time.Time  `mapstructure:"last_used_at"`
+	Name        *string     `mapstructure:"name"`
+	Scope       *TokenScope `mapstructure:"scope"`
+	Services    []string    `mapstructure:"services"`
+	UserID      *string     `mapstructure:"user_id"`
 }
 
 // ListTokensInput is used as input to the ListTokens function.
@@ -71,7 +52,6 @@ func (c *Client) ListTokens(i *ListTokensInput) ([]*Token, error) {
 	if err := decodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
-	sort.Stable(tokensByName(t))
 	return t, nil
 }
 
@@ -98,7 +78,6 @@ func (c *Client) ListCustomerTokens(i *ListCustomerTokensInput) ([]*Token, error
 	if err := decodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
-	sort.Stable(tokensByName(t))
 	return t, nil
 }
 
@@ -126,15 +105,15 @@ type CreateTokenInput struct {
 	// ExpiresAt is a time-stamp (UTC) of when the token will expire
 	ExpiresAt *time.Time `url:"expires_at,omitempty"`
 	// Name is the name of the token.
-	Name string `url:"name,omitempty"`
+	Name *string `url:"name,omitempty"`
 	// Password is the token password.
-	Password string `url:"password,omitempty"`
+	Password *string `url:"password,omitempty"`
 	// Scope is a space-delimited list of authorization scope (global, purge_select, purge_all, global).
-	Scope TokenScope `url:"scope,omitempty"`
+	Scope *TokenScope `url:"scope,omitempty"`
 	// Services is a list of alphanumeric strings identifying services. If no services are specified, the token will have access to all services on the account.
 	Services []string `url:"services,brackets,omitempty"`
 	// Username is the email of the user the token is assigned to.
-	Username string `url:"username,omitempty"`
+	Username *string `url:"username,omitempty"`
 }
 
 // CreateToken creates a new resource.

--- a/fastly/token_test.go
+++ b/fastly/token_test.go
@@ -1,6 +1,8 @@
 package fastly
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestClient_ListTokens(t *testing.T) {
 	t.Parallel()
@@ -54,10 +56,10 @@ func TestClient_CreateToken(t *testing.T) {
 	t.Parallel()
 
 	input := &CreateTokenInput{
-		Name:     "my-test-token",
-		Scope:    "global",
-		Username: "XXXXXXXXXXXXXXXXXXXXXX",
-		Password: "XXXXXXXXXXXXXXXXXXXXXX",
+		Name:     ToPointer("my-test-token"),
+		Scope:    ToPointer(GlobalScope),
+		Username: ToPointer("XXXXXXXXXXXXXXXXXXXXXX"),
+		Password: ToPointer("XXXXXXXXXXXXXXXXXXXXXX"),
 	}
 
 	var token *Token
@@ -69,12 +71,11 @@ func TestClient_CreateToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if token.Name != input.Name {
-		t.Errorf("returned invalid name, got %s, want %s", token.Name, input.Name)
+	if *token.Name != *input.Name {
+		t.Errorf("returned invalid name, got %s, want %s", *token.Name, *input.Name)
 	}
-
-	if token.Scope != input.Scope {
-		t.Errorf("returned invalid scope, got %s, want %s", token.Scope, input.Scope)
+	if *token.Scope != *input.Scope {
+		t.Errorf("returned invalid scope, got %s, want %s", *token.Scope, *input.Scope)
 	}
 }
 
@@ -113,10 +114,10 @@ func TestClient_CreateAndBulkDeleteTokens(t *testing.T) {
 
 	record(t, "tokens/create_and_bulk_delete", func(c *Client) {
 		token1, err := c.CreateToken(&CreateTokenInput{
-			Name:     "my-test-token-1",
-			Scope:    "global",
-			Username: "testing@fastly.com",
-			Password: "foobar",
+			Name:     ToPointer("my-test-token-1"),
+			Scope:    ToPointer(GlobalScope),
+			Username: ToPointer("testing@fastly.com"),
+			Password: ToPointer("foobar"),
 			Services: []string{"0Us63sb8R1BpWQBIhluncu", "7frORaFZvHgC6eRAJdA7kf"},
 		})
 		if err != nil {
@@ -124,10 +125,10 @@ func TestClient_CreateAndBulkDeleteTokens(t *testing.T) {
 		}
 
 		token2, err := c.CreateToken(&CreateTokenInput{
-			Name:     "my-test-token-2",
-			Scope:    "global",
-			Username: "testing@fastly.com",
-			Password: "foobar",
+			Name:     ToPointer("my-test-token-2"),
+			Scope:    ToPointer(GlobalScope),
+			Username: ToPointer("testing@fastly.com"),
+			Password: ToPointer("foobar"),
 			Services: []string{"0Us63sb8R1BpWQBIhluncu", "7frORaFZvHgC6eRAJdA7kf"},
 		})
 		if err != nil {
@@ -136,8 +137,8 @@ func TestClient_CreateAndBulkDeleteTokens(t *testing.T) {
 
 		deleteErr = c.BatchDeleteTokens(&BatchDeleteTokensInput{
 			Tokens: []*BatchToken{
-				{ID: token1.ID},
-				{ID: token2.ID},
+				{ID: *token1.ID},
+				{ID: *token2.ID},
 			},
 		})
 	})

--- a/fastly/user.go
+++ b/fastly/user.go
@@ -3,44 +3,25 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // User represents a user of the Fastly API and web interface.
 type User struct {
 	CreatedAt              *time.Time `mapstructure:"created_at"`
-	CustomerID             string     `mapstructure:"customer_id"`
+	CustomerID             *string    `mapstructure:"customer_id"`
 	DeletedAt              *time.Time `mapstructure:"deleted_at"`
-	EmailHash              string     `mapstructure:"email_hash"`
-	ID                     string     `mapstructure:"id"`
-	LimitServices          bool       `mapstructure:"limit_services"`
-	Locked                 bool       `mapstructure:"locked"`
-	Login                  string     `mapstructure:"login"`
-	Name                   string     `mapstructure:"name"`
-	RequireNewPassword     bool       `mapstructure:"require_new_password"`
-	Role                   string     `mapstructure:"role"`
-	TwoFactorAuthEnabled   bool       `mapstructure:"two_factor_auth_enabled"`
-	TwoFactorSetupRequired bool       `mapstructure:"two_factor_setup_required"`
+	EmailHash              *string    `mapstructure:"email_hash"`
+	ID                     *string    `mapstructure:"id"`
+	LimitServices          *bool      `mapstructure:"limit_services"`
+	Locked                 *bool      `mapstructure:"locked"`
+	Login                  *string    `mapstructure:"login"`
+	Name                   *string    `mapstructure:"name"`
+	RequireNewPassword     *bool      `mapstructure:"require_new_password"`
+	Role                   *string    `mapstructure:"role"`
+	TwoFactorAuthEnabled   *bool      `mapstructure:"two_factor_auth_enabled"`
+	TwoFactorSetupRequired *bool      `mapstructure:"two_factor_setup_required"`
 	UpdatedAt              *time.Time `mapstructure:"updated_at"`
-}
-
-// usersByLogin is a sortable list of users.
-type usersByName []*User
-
-// Len implement the sortable interface.
-func (s usersByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s usersByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s usersByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListCustomerUsersInput is used as input to the ListCustomerUsers function.
@@ -66,7 +47,6 @@ func (c *Client) ListCustomerUsers(i *ListCustomerUsersInput) ([]*User, error) {
 	if err := decodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
-	sort.Stable(usersByName(u))
 	return u, nil
 }
 

--- a/fastly/user_test.go
+++ b/fastly/user_test.go
@@ -44,28 +44,28 @@ func TestClient_Users(t *testing.T) {
 	defer func() {
 		record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteUser(&DeleteUserInput{
-				ID: u.ID,
+				ID: *u.ID,
 			})
 		})
 	}()
 
-	if u.Login != login {
-		t.Errorf("bad login: %v", u.Login)
+	if *u.Login != login {
+		t.Errorf("bad login: %v", *u.Login)
 	}
 
-	if u.Name != "test user" {
-		t.Errorf("bad name: %v", u.Name)
+	if *u.Name != "test user" {
+		t.Errorf("bad name: %v", *u.Name)
 	}
 
-	if u.Role != "engineer" {
-		t.Errorf("bad role: %v", u.Role)
+	if *u.Role != "engineer" {
+		t.Errorf("bad role: %v", *u.Role)
 	}
 
 	// List
 	var us []*User
 	record(t, fixtureBase+"list", func(c *Client) {
 		us, err = c.ListCustomerUsers(&ListCustomerUsersInput{
-			CustomerID: u.CustomerID,
+			CustomerID: *u.CustomerID,
 		})
 	})
 	if err != nil {
@@ -79,21 +79,21 @@ func TestClient_Users(t *testing.T) {
 	var nu *User
 	record(t, fixtureBase+"get", func(c *Client) {
 		nu, err = c.GetUser(&GetUserInput{
-			ID: u.ID,
+			ID: *u.ID,
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if u.Name != nu.Name {
-		t.Errorf("bad name: %q (%q)", u.Name, nu.Name)
+	if *u.Name != *nu.Name {
+		t.Errorf("bad name: %q (%q)", *u.Name, *nu.Name)
 	}
 
 	// Update
 	var uu *User
 	record(t, fixtureBase+"update", func(c *Client) {
 		uu, err = c.UpdateUser(&UpdateUserInput{
-			ID:   u.ID,
+			ID:   *u.ID,
 			Name: ToPointer("updated user"),
 			Role: ToPointer("superuser"),
 		})
@@ -101,11 +101,11 @@ func TestClient_Users(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uu.Name != "updated user" {
-		t.Errorf("bad name: %q", uu.Name)
+	if *uu.Name != "updated user" {
+		t.Errorf("bad name: %q", *uu.Name)
 	}
-	if uu.Role != "superuser" {
-		t.Errorf("bad role: %q", uu.Role)
+	if *uu.Role != "superuser" {
+		t.Errorf("bad role: %q", *uu.Role)
 	}
 
 	// Reset Password
@@ -114,7 +114,7 @@ func TestClient_Users(t *testing.T) {
 	// Which means you might have to manually correct the fixtures 😬
 	record(t, fixtureBase+"reset_password", func(c *Client) {
 		err = c.ResetUserPassword(&ResetUserPasswordInput{
-			Login: uu.Login,
+			Login: *uu.Login,
 		})
 	})
 	if err != nil {
@@ -124,7 +124,7 @@ func TestClient_Users(t *testing.T) {
 	// Delete
 	record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteUser(&DeleteUserInput{
-			ID: u.ID,
+			ID: *u.ID,
 		})
 	})
 	if err != nil {

--- a/fastly/vcl.go
+++ b/fastly/vcl.go
@@ -3,38 +3,19 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 // VCL represents a response about VCL from the Fastly API.
 type VCL struct {
-	Content        string     `mapstructure:"content"`
+	Content        *string    `mapstructure:"content"`
 	CreatedAt      *time.Time `mapstructure:"created_at"`
 	DeletedAt      *time.Time `mapstructure:"deleted_at"`
-	Main           bool       `mapstructure:"main"`
-	Name           string     `mapstructure:"name"`
-	ServiceID      string     `mapstructure:"service_id"`
-	ServiceVersion int        `mapstructure:"version"`
+	Main           *bool      `mapstructure:"main"`
+	Name           *string    `mapstructure:"name"`
+	ServiceID      *string    `mapstructure:"service_id"`
+	ServiceVersion *int       `mapstructure:"version"`
 	UpdatedAt      *time.Time `mapstructure:"updated_at"`
-}
-
-// vclsByName is a sortable list of VCLs.
-type vclsByName []*VCL
-
-// Len implement the sortable interface.
-func (s vclsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s vclsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s vclsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
 }
 
 // ListVCLsInput is used as input to the ListVCLs function.
@@ -65,7 +46,6 @@ func (c *Client) ListVCLs(i *ListVCLsInput) ([]*VCL, error) {
 	if err := decodeBodyMap(resp.Body, &vcls); err != nil {
 		return nil, err
 	}
-	sort.Stable(vclsByName(vcls))
 	return vcls, nil
 }
 

--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -3,67 +3,60 @@ package fastly
 import (
 	"fmt"
 	"net/url"
-	"sort"
 	"time"
 )
 
 const (
-	// SnippetTypeInit sets the type to init
+	// SnippetTypeInit sets the type to init.
 	SnippetTypeInit SnippetType = "init"
 
-	// SnippetTypeRecv sets the type to recv
+	// SnippetTypeRecv sets the type to recv.
 	SnippetTypeRecv SnippetType = "recv"
 
-	// SnippetTypeHash sets the type to hash
+	// SnippetTypeHash sets the type to hash.
 	SnippetTypeHash SnippetType = "hash"
 
-	// SnippetTypeHit sets the type to hit
+	// SnippetTypeHit sets the type to hit.
 	SnippetTypeHit SnippetType = "hit"
 
-	// SnippetTypeMiss sets the type to miss
+	// SnippetTypeMiss sets the type to miss.
 	SnippetTypeMiss SnippetType = "miss"
 
-	// SnippetTypePass sets the type to pass
+	// SnippetTypePass sets the type to pass.
 	SnippetTypePass SnippetType = "pass"
 
 	// SnippetTypeFetch sets the type to fetch
 	SnippetTypeFetch SnippetType = "fetch"
 
-	// SnippetTypeError sets the type to error
+	// SnippetTypeError sets the type to error.
 	SnippetTypeError SnippetType = "error"
 
-	// SnippetTypeDeliver sets the type to deliver
+	// SnippetTypeDeliver sets the type to deliver.
 	SnippetTypeDeliver SnippetType = "deliver"
 
-	// SnippetTypeLog sets the type to log
+	// SnippetTypeLog sets the type to log.
 	SnippetTypeLog SnippetType = "log"
 
-	// SnippetTypeNone sets the type to none
+	// SnippetTypeNone sets the type to none.
 	SnippetTypeNone SnippetType = "none"
 )
 
-// SnippetType is the type of VCL Snippet
+// SnippetType is the type of VCL Snippet.
 type SnippetType string
 
-// SnippetTypePtr is a helper function to get a pointer to string
-func SnippetTypePtr(b SnippetType) *SnippetType {
-	p := SnippetType(b)
-	return &p
-}
-
-// Snippet is the Fastly Snippet object
+// Snippet is the Fastly Snippet object.
 type Snippet struct {
-	Content        string      `mapstructure:"content"`
-	CreatedAt      *time.Time  `mapstructure:"created_at"`
-	DeletedAt      *time.Time  `mapstructure:"deleted_at"`
-	Dynamic        int         `mapstructure:"dynamic"`
-	ID             string      `mapstructure:"id"`
-	Name           string      `mapstructure:"name"`
-	Priority       int         `mapstructure:"priority"`
-	ServiceID      string      `mapstructure:"service_id"`
-	ServiceVersion int         `mapstructure:"version"`
-	Type           SnippetType `mapstructure:"type"`
-	UpdatedAt      *time.Time  `mapstructure:"updated_at"`
+	Content        *string      `mapstructure:"content"`
+	CreatedAt      *time.Time   `mapstructure:"created_at"`
+	DeletedAt      *time.Time   `mapstructure:"deleted_at"`
+	Dynamic        *int         `mapstructure:"dynamic"`
+	ID             *string      `mapstructure:"id"`
+	Name           *string      `mapstructure:"name"`
+	Priority       *int         `mapstructure:"priority"`
+	ServiceID      *string      `mapstructure:"service_id"`
+	ServiceVersion *int         `mapstructure:"version"`
+	Type           *SnippetType `mapstructure:"type"`
+	UpdatedAt      *time.Time   `mapstructure:"updated_at"`
 }
 
 // CreateSnippetInput is the input for CreateSnippet
@@ -153,10 +146,10 @@ func (c *Client) UpdateSnippet(i *UpdateSnippetInput) (*Snippet, error) {
 
 // DynamicSnippet is the object returned when updating or retrieving a Dynamic Snippet
 type DynamicSnippet struct {
-	Content   string     `mapstructure:"content"`
+	Content   *string    `mapstructure:"content"`
 	CreatedAt *time.Time `mapstructure:"created_at"`
-	ID        string     `mapstructure:"snippet_id"`
-	ServiceID string     `mapstructure:"service_id"`
+	ID        *string    `mapstructure:"snippet_id"`
+	ServiceID *string    `mapstructure:"service_id"`
 	UpdatedAt *time.Time `mapstructure:"updated_at"`
 }
 
@@ -240,24 +233,6 @@ type ListSnippetsInput struct {
 	ServiceVersion int
 }
 
-// snippetsByName is a sortable list of Snippets.
-type snippetsByName []*Snippet
-
-// Len implement the sortable interface.
-func (s snippetsByName) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s snippetsByName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s snippetsByName) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
-}
-
 // ListSnippets retrieves all resources.
 //
 // Content is not displayed for Dynmanic Snippets due to them being
@@ -281,7 +256,6 @@ func (c *Client) ListSnippets(i *ListSnippetsInput) ([]*Snippet, error) {
 	if err := decodeBodyMap(resp.Body, &snippets); err != nil {
 		return nil, err
 	}
-	sort.Stable(snippetsByName(snippets))
 	return snippets, nil
 }
 

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -31,7 +31,7 @@ func TestClient_Snippets(t *testing.T) {
 			Dynamic:        ToPointer(0),
 			Name:           ToPointer(svName),
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Type:           ToPointer(SnippetTypeFetch),
 		})
 	})
@@ -64,7 +64,7 @@ func TestClient_Snippets(t *testing.T) {
 	record(t, "vcl_snippets/create_with_all_fields", func(c *Client) {
 		cs, err = c.CreateSnippet(&CreateSnippetInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer(sdName),
 			Content:        ToPointer(vclContent),
 			Type:           ToPointer(SnippetTypeFetch),
@@ -100,7 +100,7 @@ func TestClient_Snippets(t *testing.T) {
 	record(t, "vcl_snippets/list", func(c *Client) {
 		ls, err = c.ListSnippets(&ListSnippetsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 
@@ -143,7 +143,7 @@ func TestClient_Snippets(t *testing.T) {
 	record(t, "vcl_snippets/get_versioned", func(c *Client) {
 		vs, err = c.GetSnippet(&GetSnippetInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           svName,
 		})
 	})
@@ -198,7 +198,7 @@ func TestClient_Snippets(t *testing.T) {
 	record(t, "vcl_snippets/update_versioned", func(c *Client) {
 		vs, err = c.UpdateSnippet(&UpdateSnippetInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           svName,
 			NewName:        ToPointer(svNameUpdated),
 			Priority:       ToPointer(priority),
@@ -253,7 +253,7 @@ func TestClient_Snippets(t *testing.T) {
 	record(t, "vcl_snippets/delete_versioned", func(c *Client) {
 		err = c.DeleteSnippet(&DeleteSnippetInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           svNameUpdated,
 		})
 	})
@@ -265,7 +265,7 @@ func TestClient_Snippets(t *testing.T) {
 	record(t, "vcl_snippets/delete_dynamic", func(c *Client) {
 		err = c.DeleteSnippet(&DeleteSnippetInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           sdName,
 		})
 	})

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -32,30 +32,30 @@ func TestClient_Snippets(t *testing.T) {
 			Name:           ToPointer(svName),
 			ServiceID:      testServiceID,
 			ServiceVersion: tv.Number,
-			Type:           SnippetTypePtr(SnippetTypeFetch),
+			Type:           ToPointer(SnippetTypeFetch),
 		})
 	})
 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cs.ServiceID != testServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, cs.ServiceID)
+	if *cs.ServiceID != testServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, *cs.ServiceID)
 	}
-	if cs.Name != svName {
-		t.Errorf("incorrect Name: want %v, have %q", svName, cs.Name)
+	if *cs.Name != svName {
+		t.Errorf("incorrect Name: want %v, have %q", svName, *cs.Name)
 	}
-	if cs.Priority != defaultPriority {
-		t.Errorf("incorrect Priority: want %v, have %q", defaultPriority, cs.Priority)
+	if *cs.Priority != defaultPriority {
+		t.Errorf("incorrect Priority: want %v, have %q", defaultPriority, *cs.Priority)
 	}
-	if cs.Dynamic != defaultDynamic {
-		t.Errorf("incorrect Dynamic: want %v, have %q", defaultDynamic, cs.Dynamic)
+	if *cs.Dynamic != defaultDynamic {
+		t.Errorf("incorrect Dynamic: want %v, have %q", defaultDynamic, *cs.Dynamic)
 	}
-	if cs.Content != vclContent {
-		t.Errorf("incorrect Content: want %v, have %q", vclContent, cs.Content)
+	if *cs.Content != vclContent {
+		t.Errorf("incorrect Content: want %v, have %q", vclContent, *cs.Content)
 	}
-	if cs.Type != SnippetTypeFetch {
-		t.Errorf("incorrect Name: want %v, have %q", SnippetTypeFetch, cs.Type)
+	if *cs.Type != SnippetTypeFetch {
+		t.Errorf("incorrect Name: want %v, have %q", SnippetTypeFetch, *cs.Type)
 	}
 
 	dynamic := 1
@@ -67,7 +67,7 @@ func TestClient_Snippets(t *testing.T) {
 			ServiceVersion: tv.Number,
 			Name:           ToPointer(sdName),
 			Content:        ToPointer(vclContent),
-			Type:           SnippetTypePtr(SnippetTypeFetch),
+			Type:           ToPointer(SnippetTypeFetch),
 			Dynamic:        ToPointer(dynamic),
 			Priority:       ToPointer(priority),
 		})
@@ -76,23 +76,23 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cs.ServiceID != testServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, cs.ServiceID)
+	if *cs.ServiceID != testServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, *cs.ServiceID)
 	}
-	if cs.Name != sdName {
-		t.Errorf("incorrect Name: want %v, have %q", sdName, cs.Name)
+	if *cs.Name != sdName {
+		t.Errorf("incorrect Name: want %v, have %q", sdName, *cs.Name)
 	}
-	if cs.Priority != priority {
-		t.Errorf("incorrect Priority: want %v, have %q", priority, cs.Priority)
+	if *cs.Priority != priority {
+		t.Errorf("incorrect Priority: want %v, have %q", priority, *cs.Priority)
 	}
-	if cs.Dynamic != dynamic {
-		t.Errorf("incorrect Dynamic: want %v, have %q", dynamic, cs.Dynamic)
+	if *cs.Dynamic != dynamic {
+		t.Errorf("incorrect Dynamic: want %v, have %q", dynamic, *cs.Dynamic)
 	}
-	if cs.Content != "" {
-		t.Errorf("incorrect Content: want %v, have %q", "", cs.Content) // dynamic snippets don't return content
+	if cs.Content != nil {
+		t.Errorf("incorrect Content: want %v, have %q", "", *cs.Content) // dynamic snippets don't return content
 	}
-	if cs.Type != SnippetTypeFetch {
-		t.Errorf("incorrect Name: want %v, have %q", SnippetTypeFetch, cs.Type)
+	if *cs.Type != SnippetTypeFetch {
+		t.Errorf("incorrect Name: want %v, have %q", SnippetTypeFetch, *cs.Type)
 	}
 
 	var ls []*Snippet
@@ -109,31 +109,31 @@ func TestClient_Snippets(t *testing.T) {
 	}
 
 	for _, s := range ls {
-		if s.ServiceID != testServiceID {
-			t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, s.ServiceID)
+		if *s.ServiceID != testServiceID {
+			t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, *s.ServiceID)
 		}
-		if s.Type != SnippetTypeFetch {
-			t.Errorf("incorrect Name: want %v, have %q", SnippetTypeFetch, s.Type)
+		if *s.Type != SnippetTypeFetch {
+			t.Errorf("incorrect Name: want %v, have %q", SnippetTypeFetch, *s.Type)
 		}
-		if defaultDynamic == s.Dynamic {
-			if svName != s.Name {
-				t.Errorf("incorrect Name: want %v, have %q", svName, s.Name)
+		if defaultDynamic == *s.Dynamic {
+			if svName != *s.Name {
+				t.Errorf("incorrect Name: want %v, have %q", svName, *s.Name)
 			}
-			if defaultPriority != s.Priority {
-				t.Errorf("incorrect Priority: want %v, have %q", defaultPriority, s.Priority)
+			if defaultPriority != *s.Priority {
+				t.Errorf("incorrect Priority: want %v, have %q", defaultPriority, *s.Priority)
 			}
-			if vclContent != s.Content {
-				t.Errorf("incorrect Content: want %v, have %q", vclContent, s.Content)
+			if vclContent != *s.Content {
+				t.Errorf("incorrect Content: want %v, have %q", vclContent, *s.Content)
 			}
 		} else {
-			if s.Name != sdName {
-				t.Errorf("incorrect Name: want %v, have %q", sdName, s.Name)
+			if *s.Name != sdName {
+				t.Errorf("incorrect Name: want %v, have %q", sdName, *s.Name)
 			}
-			if s.Priority != priority {
-				t.Errorf("incorrect Priority: want %v, have %q", priority, s.Priority)
+			if *s.Priority != priority {
+				t.Errorf("incorrect Priority: want %v, have %q", priority, *s.Priority)
 			}
-			if s.Content != "" {
-				t.Errorf("incorrect Content: want %v, have %q", "", s.Content) // dynamic snippets don't return content
+			if s.Content != nil {
+				t.Errorf("incorrect Content: want %v, have %q", "", *s.Content) // dynamic snippets don't return content
 			}
 		}
 	}
@@ -151,23 +151,23 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if vs.ServiceID != testServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, vs.ServiceID)
+	if *vs.ServiceID != testServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, *vs.ServiceID)
 	}
-	if vs.Name != svName {
-		t.Errorf("incorrect Name: want %v, have %q", svName, vs.Name)
+	if *vs.Name != svName {
+		t.Errorf("incorrect Name: want %v, have %q", svName, *vs.Name)
 	}
-	if vs.Priority != defaultPriority {
-		t.Errorf("incorrect Priority: want %v, have %q", defaultPriority, vs.Priority)
+	if *vs.Priority != defaultPriority {
+		t.Errorf("incorrect Priority: want %v, have %q", defaultPriority, *vs.Priority)
 	}
-	if vs.Dynamic != defaultDynamic {
-		t.Errorf("incorrect Dynamic: want %v, have %q", defaultDynamic, vs.Dynamic)
+	if *vs.Dynamic != defaultDynamic {
+		t.Errorf("incorrect Dynamic: want %v, have %q", defaultDynamic, *vs.Dynamic)
 	}
-	if vs.Content != vclContent {
-		t.Errorf("incorrect Content: want %v, have %q", vclContent, vs.Content)
+	if *vs.Content != vclContent {
+		t.Errorf("incorrect Content: want %v, have %q", vclContent, *vs.Content)
 	}
-	if vs.Type != SnippetTypeFetch {
-		t.Errorf("incorrect Name: want %v, have %q", SnippetTypeFetch, vs.Type)
+	if *vs.Type != SnippetTypeFetch {
+		t.Errorf("incorrect Name: want %v, have %q", SnippetTypeFetch, *vs.Type)
 	}
 
 	var ds *DynamicSnippet
@@ -175,21 +175,21 @@ func TestClient_Snippets(t *testing.T) {
 	record(t, "vcl_snippets/get_dynamic", func(c *Client) {
 		ds, err = c.GetDynamicSnippet(&GetDynamicSnippetInput{
 			ServiceID: testServiceID,
-			ID:        cs.ID,
+			ID:        *cs.ID,
 		})
 	})
 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ds.ServiceID != testServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, ds.ServiceID)
+	if *ds.ServiceID != testServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, *ds.ServiceID)
 	}
-	if ds.ID != cs.ID {
-		t.Errorf("incorrect ID: want %v, have %q", cs.ID, ds.ID)
+	if *ds.ID != *cs.ID {
+		t.Errorf("incorrect ID: want %v, have %q", *cs.ID, *ds.ID)
 	}
-	if ds.Content != vclContent {
-		t.Errorf("incorrect Content: want %v, have %q", vclContent, ds.Content)
+	if *ds.Content != vclContent {
+		t.Errorf("incorrect Content: want %v, have %q", vclContent, *ds.Content)
 	}
 
 	priority = 456
@@ -210,29 +210,29 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if vs.ServiceID != testServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, vs.ServiceID)
+	if *vs.ServiceID != testServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, *vs.ServiceID)
 	}
-	if vs.Name != svNameUpdated {
-		t.Errorf("incorrect Name: want %v, have %q", svNameUpdated, vs.Name)
+	if *vs.Name != svNameUpdated {
+		t.Errorf("incorrect Name: want %v, have %q", svNameUpdated, *vs.Name)
 	}
-	if vs.Priority != priority {
-		t.Errorf("incorrect Priority: want %v, have %q", priority, vs.Priority)
+	if *vs.Priority != priority {
+		t.Errorf("incorrect Priority: want %v, have %q", priority, *vs.Priority)
 	}
-	if vs.Dynamic != defaultDynamic {
-		t.Errorf("incorrect Dynamic: want %v, have %q", defaultDynamic, vs.Dynamic)
+	if *vs.Dynamic != defaultDynamic {
+		t.Errorf("incorrect Dynamic: want %v, have %q", defaultDynamic, *vs.Dynamic)
 	}
-	if vs.Content != vclContentUpdated {
-		t.Errorf("incorrect Content: want %v, have %q", vclContentUpdated, vs.Content)
+	if *vs.Content != vclContentUpdated {
+		t.Errorf("incorrect Content: want %v, have %q", vclContentUpdated, *vs.Content)
 	}
-	if vs.Type != hit {
-		t.Errorf("incorrect Name: want %v, have %q", hit, vs.Type)
+	if *vs.Type != hit {
+		t.Errorf("incorrect Name: want %v, have %q", hit, *vs.Type)
 	}
 
 	record(t, "vcl_snippets/update_dynamic", func(c *Client) {
 		ds, err = c.UpdateDynamicSnippet(&UpdateDynamicSnippetInput{
 			ServiceID: testServiceID,
-			ID:        cs.ID,
+			ID:        *cs.ID,
 			Content:   ToPointer(vclContentUpdated),
 		})
 	})
@@ -240,14 +240,14 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ds.ServiceID != testServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, ds.ServiceID)
+	if *ds.ServiceID != testServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", testServiceID, *ds.ServiceID)
 	}
-	if ds.ID != cs.ID {
-		t.Errorf("incorrect ID: want %v, have %q", cs.ID, ds.ID)
+	if *ds.ID != *cs.ID {
+		t.Errorf("incorrect ID: want %v, have %q", cs.ID, *ds.ID)
 	}
-	if ds.Content != vclContentUpdated {
-		t.Errorf("incorrect Content: want %v, have %q", vclContentUpdated, ds.Content)
+	if *ds.Content != vclContentUpdated {
+		t.Errorf("incorrect Content: want %v, have %q", vclContentUpdated, *ds.Content)
 	}
 
 	record(t, "vcl_snippets/delete_versioned", func(c *Client) {

--- a/fastly/vcl_test.go
+++ b/fastly/vcl_test.go
@@ -39,7 +39,7 @@ sub vcl_hash {
 	record(t, "vcls/create", func(c *Client) {
 		vcl, err = c.CreateVCL(&CreateVCLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-vcl"),
 			Content:        ToPointer(content),
 		})
@@ -53,13 +53,13 @@ sub vcl_hash {
 		record(t, "vcls/cleanup", func(c *Client) {
 			_ = c.DeleteVCL(&DeleteVCLInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "test-vcl",
 			})
 
 			_ = c.DeleteVCL(&DeleteVCLInput{
 				ServiceID:      testServiceID,
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				Name:           "new-test-vcl",
 			})
 		})
@@ -77,7 +77,7 @@ sub vcl_hash {
 	record(t, "vcls/list", func(c *Client) {
 		vcls, err = c.ListVCLs(&ListVCLsInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -92,7 +92,7 @@ sub vcl_hash {
 	record(t, "vcls/get", func(c *Client) {
 		nvcl, err = c.GetVCL(&GetVCLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-vcl",
 		})
 	})
@@ -111,7 +111,7 @@ sub vcl_hash {
 	record(t, "vcls/update", func(c *Client) {
 		uvcl, err = c.UpdateVCL(&UpdateVCLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "test-vcl",
 			NewName:        ToPointer("new-test-vcl"),
 		})
@@ -128,7 +128,7 @@ sub vcl_hash {
 	record(t, "vcls/activate", func(c *Client) {
 		avcl, err = c.ActivateVCL(&ActivateVCLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-vcl",
 		})
 	})
@@ -143,7 +143,7 @@ sub vcl_hash {
 	record(t, "vcls/delete", func(c *Client) {
 		err = c.DeleteVCL(&DeleteVCLInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			Name:           "new-test-vcl",
 		})
 	})

--- a/fastly/vcl_test.go
+++ b/fastly/vcl_test.go
@@ -65,11 +65,11 @@ sub vcl_hash {
 		})
 	}()
 
-	if vcl.Name != "test-vcl" {
-		t.Errorf("bad name: %q", vcl.Name)
+	if *vcl.Name != "test-vcl" {
+		t.Errorf("bad name: %q", *vcl.Name)
 	}
-	if vcl.Content != content {
-		t.Errorf("bad content: %q", vcl.Content)
+	if *vcl.Content != content {
+		t.Errorf("bad content: %q", *vcl.Content)
 	}
 
 	// List
@@ -99,11 +99,11 @@ sub vcl_hash {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if vcl.Name != nvcl.Name {
-		t.Errorf("bad name: %q", vcl.Name)
+	if *vcl.Name != *nvcl.Name {
+		t.Errorf("bad name: %q", *vcl.Name)
 	}
-	if vcl.Content != nvcl.Content {
-		t.Errorf("bad address: %q", vcl.Content)
+	if *vcl.Content != *nvcl.Content {
+		t.Errorf("bad address: %q", *vcl.Content)
 	}
 
 	// Update
@@ -119,8 +119,8 @@ sub vcl_hash {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uvcl.Name != "new-test-vcl" {
-		t.Errorf("bad name: %q", uvcl.Name)
+	if *uvcl.Name != "new-test-vcl" {
+		t.Errorf("bad name: %q", *uvcl.Name)
 	}
 
 	// Activate
@@ -135,8 +135,8 @@ sub vcl_hash {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !avcl.Main {
-		t.Errorf("bad main: %t", avcl.Main)
+	if !*avcl.Main {
+		t.Errorf("bad main: %t", *avcl.Main)
 	}
 
 	// Delete

--- a/fastly/version.go
+++ b/fastly/version.go
@@ -2,42 +2,22 @@ package fastly
 
 import (
 	"fmt"
-	"sort"
 	"time"
 )
 
 // Version represents a distinct configuration version.
 type Version struct {
-	Active    bool       `mapstructure:"active"`
-	Comment   string     `mapstructure:"comment"`
+	Active    *bool      `mapstructure:"active"`
+	Comment   *string    `mapstructure:"comment"`
 	CreatedAt *time.Time `mapstructure:"created_at"`
 	DeletedAt *time.Time `mapstructure:"deleted_at"`
-	Deployed  bool       `mapstructure:"deployed"`
-	Locked    bool       `mapstructure:"locked"`
-	Number    int        `mapstructure:"number"`
-	ServiceID string     `mapstructure:"service_id"`
-	Staging   bool       `mapstructure:"staging"`
-	Testing   bool       `mapstructure:"testing"`
+	Deployed  *bool      `mapstructure:"deployed"`
+	Locked    *bool      `mapstructure:"locked"`
+	Number    *int       `mapstructure:"number"`
+	ServiceID *string    `mapstructure:"service_id"`
+	Staging   *bool      `mapstructure:"staging"`
+	Testing   *bool      `mapstructure:"testing"`
 	UpdatedAt *time.Time `mapstructure:"updated_at"`
-}
-
-// versionsByNumber is a sortable list of versions. This is used by the version
-// `List()` function to sort the API responses.
-type versionsByNumber []*Version
-
-// Len implement the sortable interface.
-func (s versionsByNumber) Len() int {
-	return len(s)
-}
-
-// Swap implement the sortable interface.
-func (s versionsByNumber) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less implement the sortable interface.
-func (s versionsByNumber) Less(i, j int) bool {
-	return s[i].Number < s[j].Number
 }
 
 // ListVersionsInput is the input to the ListVersions function.
@@ -63,7 +43,6 @@ func (c *Client) ListVersions(i *ListVersionsInput) ([]*Version, error) {
 	if err := decodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
-	sort.Sort(versionsByNumber(e))
 
 	return e, nil
 }

--- a/fastly/version_test.go
+++ b/fastly/version_test.go
@@ -1,7 +1,6 @@
 package fastly
 
 import (
-	"sort"
 	"testing"
 )
 
@@ -24,11 +23,11 @@ func TestClient_Versions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if v.Number == 0 {
-		t.Errorf("bad number: %q", v.Number)
+	if *v.Number == 0 {
+		t.Errorf("bad number: %q", *v.Number)
 	}
-	if v.Comment != "test comment" {
-		t.Errorf("bad comment: %q", v.Comment)
+	if *v.Comment != "test comment" {
+		t.Errorf("bad comment: %q", *v.Comment)
 	}
 
 	// Unlock and let other parallel tests go!
@@ -53,17 +52,17 @@ func TestClient_Versions(t *testing.T) {
 	record(t, "versions/get", func(c *Client) {
 		nv, err = c.GetVersion(&GetVersionInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if nv.Number == 0 {
-		t.Errorf("bad number: %q", nv.Number)
+	if *nv.Number == 0 {
+		t.Errorf("bad number: %q", *nv.Number)
 	}
-	if nv.Comment != v.Comment {
-		t.Errorf("bad comment: %q", v.Comment)
+	if *nv.Comment != *v.Comment {
+		t.Errorf("bad comment: %q", *v.Comment)
 	}
 
 	// Update
@@ -71,15 +70,15 @@ func TestClient_Versions(t *testing.T) {
 	record(t, "versions/update", func(c *Client) {
 		uv, err = c.UpdateVersion(&UpdateVersionInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 			Comment:        ToPointer("new comment"),
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uv.Comment != "new comment" {
-		t.Errorf("bad comment: %q", uv.Comment)
+	if *uv.Comment != "new comment" {
+		t.Errorf("bad comment: %q", *uv.Comment)
 	}
 
 	// Lock
@@ -87,14 +86,14 @@ func TestClient_Versions(t *testing.T) {
 	record(t, "versions/lock", func(c *Client) {
 		vl, err = c.LockVersion(&LockVersionInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !vl.Locked {
-		t.Errorf("bad lock: %t", vl.Locked)
+	if !*vl.Locked {
+		t.Errorf("bad lock: %t", *vl.Locked)
 	}
 
 	// Clone
@@ -102,31 +101,17 @@ func TestClient_Versions(t *testing.T) {
 	record(t, "versions/clone", func(c *Client) {
 		cv, err = c.CloneVersion(&CloneVersionInput{
 			ServiceID:      testServiceID,
-			ServiceVersion: v.Number,
+			ServiceVersion: *v.Number,
 		})
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cv.Active {
-		t.Errorf("bad clone: %t", cv.Active)
+	if *cv.Active {
+		t.Errorf("bad clone: %t", *cv.Active)
 	}
-	if cv.Comment != uv.Comment {
-		t.Errorf("bad comment: %q", uv.Comment)
-	}
-}
-
-func TestClient_SortVersions(t *testing.T) {
-	versionsData := []*Version{
-		{Number: 1},
-		{Number: 201},
-		{Number: 10},
-		{Number: 2},
-		{Number: 197},
-	}
-	sort.Sort(versionsByNumber(versionsData))
-	if versionsData[0].Number != 1 || versionsData[1].Number != 2 || versionsData[2].Number != 10 || versionsData[3].Number != 197 || versionsData[4].Number != 201 {
-		t.Fatalf("The sort.Sort did not work properly. Got: %#v\n", versionsData)
+	if *cv.Comment != *uv.Comment {
+		t.Errorf("bad comment: %q", *uv.Comment)
 	}
 }
 

--- a/fastly/waf_active_rule_test.go
+++ b/fastly/waf_active_rule_test.go
@@ -14,16 +14,16 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 
 	tv := createTestVersion(t, fixtureBase+"/service/version", *testService.ID)
 
-	createTestLogging(t, fixtureBase+"/logging/create", *testService.ID, tv.Number)
-	defer deleteTestLogging(t, fixtureBase+"/logging/delete", *testService.ID, tv.Number)
+	createTestLogging(t, fixtureBase+"/logging/create", *testService.ID, *tv.Number)
+	defer deleteTestLogging(t, fixtureBase+"/logging/delete", *testService.ID, *tv.Number)
 
 	prefetch := "WAF_Prefetch"
-	createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ID, prefetch, tv.Number)
+	createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ID, prefetch, *tv.Number)
 
 	responseName := "WAf_Response"
-	createTestWAFResponseObject(t, fixtureBase+"/response_object/create", *testService.ID, responseName, tv.Number)
+	createTestWAFResponseObject(t, fixtureBase+"/response_object/create", *testService.ID, responseName, *tv.Number)
 
-	waf := createWAF(t, fixtureBase+"/waf/create", *testService.ID, prefetch, responseName, tv.Number)
+	waf := createWAF(t, fixtureBase+"/waf/create", *testService.ID, prefetch, responseName, *tv.Number)
 	defer deleteWAF(t, fixtureBase+"/waf/delete", waf.ID, 1)
 
 	var err error

--- a/fastly/waf_active_rule_test.go
+++ b/fastly/waf_active_rule_test.go
@@ -10,20 +10,20 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 	fixtureBase := "waf_active_rules/"
 
 	testService := createTestService(t, fixtureBase+"service/create", "service")
-	defer deleteTestService(t, fixtureBase+"/service/delete", testService.ID)
+	defer deleteTestService(t, fixtureBase+"/service/delete", *testService.ID)
 
-	tv := createTestVersion(t, fixtureBase+"/service/version", testService.ID)
+	tv := createTestVersion(t, fixtureBase+"/service/version", *testService.ID)
 
-	createTestLogging(t, fixtureBase+"/logging/create", testService.ID, tv.Number)
-	defer deleteTestLogging(t, fixtureBase+"/logging/delete", testService.ID, tv.Number)
+	createTestLogging(t, fixtureBase+"/logging/create", *testService.ID, tv.Number)
+	defer deleteTestLogging(t, fixtureBase+"/logging/delete", *testService.ID, tv.Number)
 
 	prefetch := "WAF_Prefetch"
-	createTestWAFCondition(t, fixtureBase+"/condition/create", testService.ID, prefetch, tv.Number)
+	createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ID, prefetch, tv.Number)
 
 	responseName := "WAf_Response"
-	createTestWAFResponseObject(t, fixtureBase+"/response_object/create", testService.ID, responseName, tv.Number)
+	createTestWAFResponseObject(t, fixtureBase+"/response_object/create", *testService.ID, responseName, tv.Number)
 
-	waf := createWAF(t, fixtureBase+"/waf/create", testService.ID, prefetch, responseName, tv.Number)
+	waf := createWAF(t, fixtureBase+"/waf/create", *testService.ID, prefetch, responseName, tv.Number)
 	defer deleteWAF(t, fixtureBase+"/waf/delete", waf.ID, 1)
 
 	var err error

--- a/fastly/waf_rule_exclusion_test.go
+++ b/fastly/waf_rule_exclusion_test.go
@@ -15,7 +15,7 @@ func TestClient_WAF_Rule_Exclusion_list(t *testing.T) {
 	testService, serviceVersion, responseName := createServiceForWAF(t, fixtureBase)
 	waf := createWAFWithRulesForExclusion(t, fixtureBase, testService, serviceVersion, responseName)
 
-	defer deleteTestService(t, fixtureBase+"service/delete", testService.ID)
+	defer deleteTestService(t, fixtureBase+"service/delete", *testService.ID)
 	defer deleteWAF(t, fixtureBase+"waf/delete", waf.ID, 1)
 
 	excl1In := buildWAFRuleExclusion1(waf.ID, 1)
@@ -40,7 +40,7 @@ func TestClient_WAF_Rule_Exclusion_list_filters(t *testing.T) {
 	testService, serviceVersion, responseName := createServiceForWAF(t, fixtureBase)
 	waf := createWAFWithRulesForExclusion(t, fixtureBase, testService, serviceVersion, responseName)
 
-	defer deleteTestService(t, fixtureBase+"service/delete", testService.ID)
+	defer deleteTestService(t, fixtureBase+"service/delete", *testService.ID)
 	defer deleteWAF(t, fixtureBase+"waf/delete", waf.ID, 1)
 
 	excl1In := buildWAFRuleExclusion1(waf.ID, 1)
@@ -72,7 +72,7 @@ func TestClient_WAF_Rule_Exclusion_create(t *testing.T) {
 	testService, serviceVersion, responseName := createServiceForWAF(t, fixtureBase)
 	waf := createWAFWithRulesForExclusion(t, fixtureBase, testService, serviceVersion, responseName)
 
-	defer deleteTestService(t, fixtureBase+"service/delete", testService.ID)
+	defer deleteTestService(t, fixtureBase+"service/delete", *testService.ID)
 	defer deleteWAF(t, fixtureBase+"waf/delete", waf.ID, 1)
 
 	exclIn := buildWAFRuleExclusion1(waf.ID, 1)
@@ -93,7 +93,7 @@ func TestClient_WAF_Rule_Exclusion_update(t *testing.T) {
 	testService, serviceVersion, responseName := createServiceForWAF(t, fixtureBase)
 	waf := createWAFWithRulesForExclusion(t, fixtureBase, testService, serviceVersion, responseName)
 
-	defer deleteTestService(t, fixtureBase+"service/delete", testService.ID)
+	defer deleteTestService(t, fixtureBase+"service/delete", *testService.ID)
 	defer deleteWAF(t, fixtureBase+"waf/delete", waf.ID, 1)
 
 	exclIn := buildWAFRuleExclusion1(waf.ID, 1)
@@ -117,7 +117,7 @@ func TestClient_WAF_Rule_Exclusion_delete(t *testing.T) {
 	testService, serviceVersion, responseName := createServiceForWAF(t, fixtureBase)
 	waf := createWAFWithRulesForExclusion(t, fixtureBase, testService, serviceVersion, responseName)
 
-	defer deleteTestService(t, fixtureBase+"service/delete", testService.ID)
+	defer deleteTestService(t, fixtureBase+"service/delete", *testService.ID)
 	defer deleteWAF(t, fixtureBase+"waf/delete", waf.ID, 1)
 
 	exclIn := buildWAFRuleExclusion1(waf.ID, 1)
@@ -327,7 +327,7 @@ func extractModSecID(wafRule []*WAFRule) []int {
 }
 
 func createWAFWithRulesForExclusion(t *testing.T, fixtureBase string, testService *Service, version *Version, responseName string) *WAF {
-	waf := createWAF(t, fixtureBase+"waf/create", testService.ID, "", responseName, version.Number)
+	waf := createWAF(t, fixtureBase+"waf/create", *testService.ID, "", responseName, version.Number)
 
 	var err error
 	rulesIn := buildWAFRulesForExclusion("log")
@@ -367,9 +367,9 @@ func buildWAFRulesForExclusion(status string) []*WAFActiveRule {
 
 func createServiceForWAF(t *testing.T, fixtureBase string) (*Service, *Version, string) {
 	service := createTestService(t, fixtureBase+"service/create", "service-"+strconv.Itoa(rand.Int()))
-	version := createTestVersion(t, fixtureBase+"service/version", service.ID)
+	version := createTestVersion(t, fixtureBase+"service/version", *service.ID)
 	responseName := "WAf_Response"
-	createTestWAFResponseObject(t, fixtureBase+"response_object/create", service.ID, responseName, version.Number)
+	createTestWAFResponseObject(t, fixtureBase+"response_object/create", *service.ID, responseName, version.Number)
 	return service, version, responseName
 }
 

--- a/fastly/waf_rule_exclusion_test.go
+++ b/fastly/waf_rule_exclusion_test.go
@@ -327,7 +327,7 @@ func extractModSecID(wafRule []*WAFRule) []int {
 }
 
 func createWAFWithRulesForExclusion(t *testing.T, fixtureBase string, testService *Service, version *Version, responseName string) *WAF {
-	waf := createWAF(t, fixtureBase+"waf/create", *testService.ID, "", responseName, version.Number)
+	waf := createWAF(t, fixtureBase+"waf/create", *testService.ID, "", responseName, *version.Number)
 
 	var err error
 	rulesIn := buildWAFRulesForExclusion("log")
@@ -369,7 +369,7 @@ func createServiceForWAF(t *testing.T, fixtureBase string) (*Service, *Version, 
 	service := createTestService(t, fixtureBase+"service/create", "service-"+strconv.Itoa(rand.Int()))
 	version := createTestVersion(t, fixtureBase+"service/version", *service.ID)
 	responseName := "WAf_Response"
-	createTestWAFResponseObject(t, fixtureBase+"response_object/create", *service.ID, responseName, version.Number)
+	createTestWAFResponseObject(t, fixtureBase+"response_object/create", *service.ID, responseName, *version.Number)
 	return service, version, responseName
 }
 

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -16,23 +16,23 @@ func TestClient_WAFs(t *testing.T) {
 	tv := createTestVersion(t, fixtureBase+"/service/version", *testService.ID)
 
 	prefetch := "WAF_Prefetch"
-	condition := createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ID, prefetch, tv.Number)
-	defer deleteTestCondition(t, fixtureBase+"/condition/delete", *testService.ID, prefetch, tv.Number)
+	condition := createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ID, prefetch, *tv.Number)
+	defer deleteTestCondition(t, fixtureBase+"/condition/delete", *testService.ID, prefetch, *tv.Number)
 
 	responseName := "WAF_Response"
-	ro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create", *testService.ID, responseName, tv.Number)
-	defer deleteTestResponseObject(t, fixtureBase+"/response_object/delete", *testService.ID, responseName, tv.Number)
+	ro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create", *testService.ID, responseName, *tv.Number)
+	defer deleteTestResponseObject(t, fixtureBase+"/response_object/delete", *testService.ID, responseName, *tv.Number)
 
 	responseName2 := "WAF_Response2"
-	nro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create_another", *testService.ID, responseName2, tv.Number)
-	defer deleteTestResponseObject(t, fixtureBase+"/response_object/cleanup_another", *testService.ID, responseName2, tv.Number)
+	nro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create_another", *testService.ID, responseName2, *tv.Number)
+	defer deleteTestResponseObject(t, fixtureBase+"/response_object/cleanup_another", *testService.ID, responseName2, *tv.Number)
 
 	var err error
 	var waf *WAF
 	record(t, fixtureBase+"/create", func(c *Client) {
 		waf, err = c.CreateWAF(&CreateWAFInput{
 			ServiceID:         *testService.ID,
-			ServiceVersion:    tv.Number,
+			ServiceVersion:    *tv.Number,
 			PrefetchCondition: *condition.Name,
 			Response:          *ro.Name,
 		})
@@ -46,7 +46,7 @@ func TestClient_WAFs(t *testing.T) {
 	record(t, fixtureBase+"/list", func(c *Client) {
 		wafsResp, err = c.ListWAFs(&ListWAFsInput{
 			FilterService: *testService.ID,
-			FilterVersion: tv.Number,
+			FilterVersion: *tv.Number,
 		})
 	})
 	if err != nil {
@@ -60,7 +60,7 @@ func TestClient_WAFs(t *testing.T) {
 	defer func() {
 		record(t, fixtureBase+"/cleanup", func(c *Client) {
 			_ = c.DeleteWAF(&DeleteWAFInput{
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				ID:             waf.ID,
 			})
 		})
@@ -81,7 +81,7 @@ func TestClient_WAFs(t *testing.T) {
 	record(t, fixtureBase+"/get", func(c *Client) {
 		nwaf, err = c.GetWAF(&GetWAFInput{
 			ServiceID:      *testService.ID,
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			ID:             waf.ID,
 		})
 	})
@@ -99,7 +99,7 @@ func TestClient_WAFs(t *testing.T) {
 	record(t, fixtureBase+"/update", func(c *Client) {
 		uwaf, err = c.UpdateWAF(&UpdateWAFInput{
 			ServiceID:      testService.ID,
-			ServiceVersion: &tv.Number,
+			ServiceVersion: tv.Number,
 			ID:             waf.ID,
 			Response:       nro.Name,
 		})
@@ -142,7 +142,7 @@ func TestClient_WAFs(t *testing.T) {
 	// Delete
 	record(t, fixtureBase+"/delete", func(c *Client) {
 		err = c.DeleteWAF(&DeleteWAFInput{
-			ServiceVersion: tv.Number,
+			ServiceVersion: *tv.Number,
 			ID:             waf.ID,
 		})
 	})

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -34,7 +34,7 @@ func TestClient_WAFs(t *testing.T) {
 			ServiceID:         testService.ID,
 			ServiceVersion:    tv.Number,
 			PrefetchCondition: *condition.Name,
-			Response:          ro.Name,
+			Response:          *ro.Name,
 		})
 	})
 	if err != nil {
@@ -101,7 +101,7 @@ func TestClient_WAFs(t *testing.T) {
 			ServiceID:      &testService.ID,
 			ServiceVersion: &tv.Number,
 			ID:             waf.ID,
-			Response:       &nro.Name,
+			Response:       nro.Name,
 		})
 	})
 	if err != nil {

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -11,27 +11,27 @@ func TestClient_WAFs(t *testing.T) {
 	fixtureBase := "wafs/"
 
 	testService := createTestService(t, fixtureBase+"service/create", "service2")
-	defer deleteTestService(t, fixtureBase+"/service/delete", testService.ID)
+	defer deleteTestService(t, fixtureBase+"/service/delete", *testService.ID)
 
-	tv := createTestVersion(t, fixtureBase+"/service/version", testService.ID)
+	tv := createTestVersion(t, fixtureBase+"/service/version", *testService.ID)
 
 	prefetch := "WAF_Prefetch"
-	condition := createTestWAFCondition(t, fixtureBase+"/condition/create", testService.ID, prefetch, tv.Number)
-	defer deleteTestCondition(t, fixtureBase+"/condition/delete", testService.ID, prefetch, tv.Number)
+	condition := createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ID, prefetch, tv.Number)
+	defer deleteTestCondition(t, fixtureBase+"/condition/delete", *testService.ID, prefetch, tv.Number)
 
 	responseName := "WAF_Response"
-	ro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create", testService.ID, responseName, tv.Number)
-	defer deleteTestResponseObject(t, fixtureBase+"/response_object/delete", testService.ID, responseName, tv.Number)
+	ro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create", *testService.ID, responseName, tv.Number)
+	defer deleteTestResponseObject(t, fixtureBase+"/response_object/delete", *testService.ID, responseName, tv.Number)
 
 	responseName2 := "WAF_Response2"
-	nro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create_another", testService.ID, responseName2, tv.Number)
-	defer deleteTestResponseObject(t, fixtureBase+"/response_object/cleanup_another", testService.ID, responseName2, tv.Number)
+	nro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create_another", *testService.ID, responseName2, tv.Number)
+	defer deleteTestResponseObject(t, fixtureBase+"/response_object/cleanup_another", *testService.ID, responseName2, tv.Number)
 
 	var err error
 	var waf *WAF
 	record(t, fixtureBase+"/create", func(c *Client) {
 		waf, err = c.CreateWAF(&CreateWAFInput{
-			ServiceID:         testService.ID,
+			ServiceID:         *testService.ID,
 			ServiceVersion:    tv.Number,
 			PrefetchCondition: *condition.Name,
 			Response:          *ro.Name,
@@ -45,7 +45,7 @@ func TestClient_WAFs(t *testing.T) {
 	var wafsResp *WAFResponse
 	record(t, fixtureBase+"/list", func(c *Client) {
 		wafsResp, err = c.ListWAFs(&ListWAFsInput{
-			FilterService: testService.ID,
+			FilterService: *testService.ID,
 			FilterVersion: tv.Number,
 		})
 	})
@@ -80,7 +80,7 @@ func TestClient_WAFs(t *testing.T) {
 	var nwaf *WAF
 	record(t, fixtureBase+"/get", func(c *Client) {
 		nwaf, err = c.GetWAF(&GetWAFInput{
-			ServiceID:      testService.ID,
+			ServiceID:      *testService.ID,
 			ServiceVersion: tv.Number,
 			ID:             waf.ID,
 		})
@@ -98,7 +98,7 @@ func TestClient_WAFs(t *testing.T) {
 	var uwaf *WAF
 	record(t, fixtureBase+"/update", func(c *Client) {
 		uwaf, err = c.UpdateWAF(&UpdateWAFInput{
-			ServiceID:      &testService.ID,
+			ServiceID:      testService.ID,
 			ServiceVersion: &tv.Number,
 			ID:             waf.ID,
 			Response:       nro.Name,

--- a/fastly/waf_version_test.go
+++ b/fastly/waf_version_test.go
@@ -17,23 +17,23 @@ func TestClient_WAF_Versions(t *testing.T) {
 
 	tv := createTestVersion(t, fixtureBase+"/service/version", *testService.ID)
 
-	createTestLogging(t, fixtureBase+"/logging/create", *testService.ID, tv.Number)
-	defer deleteTestLogging(t, fixtureBase+"/logging/delete", *testService.ID, tv.Number)
+	createTestLogging(t, fixtureBase+"/logging/create", *testService.ID, *tv.Number)
+	defer deleteTestLogging(t, fixtureBase+"/logging/delete", *testService.ID, *tv.Number)
 
 	prefetch := "WAF_Prefetch"
-	condition := createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ID, prefetch, tv.Number)
-	defer deleteTestCondition(t, fixtureBase+"/condition/delete", *testService.ID, prefetch, tv.Number)
+	condition := createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ID, prefetch, *tv.Number)
+	defer deleteTestCondition(t, fixtureBase+"/condition/delete", *testService.ID, prefetch, *tv.Number)
 
 	responseName := "WAf_Response"
-	ro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create", *testService.ID, responseName, tv.Number)
-	defer deleteTestResponseObject(t, fixtureBase+"/response_object/delete", *testService.ID, responseName, tv.Number)
+	ro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create", *testService.ID, responseName, *tv.Number)
+	defer deleteTestResponseObject(t, fixtureBase+"/response_object/delete", *testService.ID, responseName, *tv.Number)
 
 	var err error
 	var waf *WAF
 	record(t, fixtureBase+"/waf/create", func(c *Client) {
 		waf, err = c.CreateWAF(&CreateWAFInput{
 			ServiceID:         *testService.ID,
-			ServiceVersion:    tv.Number,
+			ServiceVersion:    *tv.Number,
 			PrefetchCondition: *condition.Name,
 			Response:          *ro.Name,
 		})
@@ -44,7 +44,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 	defer func() {
 		record(t, fixtureBase+"/waf/delete", func(c *Client) {
 			if err := c.DeleteWAF(&DeleteWAFInput{
-				ServiceVersion: tv.Number,
+				ServiceVersion: *tv.Number,
 				ID:             waf.ID,
 			}); err != nil {
 				t.Fatal(err)

--- a/fastly/waf_version_test.go
+++ b/fastly/waf_version_test.go
@@ -13,26 +13,26 @@ func TestClient_WAF_Versions(t *testing.T) {
 	fixtureBase := "waf_versions/"
 
 	testService := createTestService(t, fixtureBase+"service/create", "service3")
-	defer deleteTestService(t, fixtureBase+"/service/delete", testService.ID)
+	defer deleteTestService(t, fixtureBase+"/service/delete", *testService.ID)
 
-	tv := createTestVersion(t, fixtureBase+"/service/version", testService.ID)
+	tv := createTestVersion(t, fixtureBase+"/service/version", *testService.ID)
 
-	createTestLogging(t, fixtureBase+"/logging/create", testService.ID, tv.Number)
-	defer deleteTestLogging(t, fixtureBase+"/logging/delete", testService.ID, tv.Number)
+	createTestLogging(t, fixtureBase+"/logging/create", *testService.ID, tv.Number)
+	defer deleteTestLogging(t, fixtureBase+"/logging/delete", *testService.ID, tv.Number)
 
 	prefetch := "WAF_Prefetch"
-	condition := createTestWAFCondition(t, fixtureBase+"/condition/create", testService.ID, prefetch, tv.Number)
-	defer deleteTestCondition(t, fixtureBase+"/condition/delete", testService.ID, prefetch, tv.Number)
+	condition := createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ID, prefetch, tv.Number)
+	defer deleteTestCondition(t, fixtureBase+"/condition/delete", *testService.ID, prefetch, tv.Number)
 
 	responseName := "WAf_Response"
-	ro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create", testService.ID, responseName, tv.Number)
-	defer deleteTestResponseObject(t, fixtureBase+"/response_object/delete", testService.ID, responseName, tv.Number)
+	ro := createTestWAFResponseObject(t, fixtureBase+"/response_object/create", *testService.ID, responseName, tv.Number)
+	defer deleteTestResponseObject(t, fixtureBase+"/response_object/delete", *testService.ID, responseName, tv.Number)
 
 	var err error
 	var waf *WAF
 	record(t, fixtureBase+"/waf/create", func(c *Client) {
 		waf, err = c.CreateWAF(&CreateWAFInput{
-			ServiceID:         testService.ID,
+			ServiceID:         *testService.ID,
 			ServiceVersion:    tv.Number,
 			PrefetchCondition: *condition.Name,
 			Response:          *ro.Name,

--- a/fastly/waf_version_test.go
+++ b/fastly/waf_version_test.go
@@ -35,7 +35,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 			ServiceID:         testService.ID,
 			ServiceVersion:    tv.Number,
 			PrefetchCondition: *condition.Name,
-			Response:          ro.Name,
+			Response:          *ro.Name,
 		})
 	})
 	if err != nil {


### PR DESCRIPTION
## Problem

The `mapstructure` dependency will take a `null` from the API response and coerce it into the zero value for the associated field type. This has resulted in errors in the Fastly Terraform provider where certain fields return from the API as `null` but are coerced by go-fastly into a zero value such as `0` and then stored in Terraform state as `0`, which is incorrect behaviour (e.g. `keepalive_time` should be stored in Terraform as `null` not `0`).

## Solution

We already use pointers for Create/Update methods, we should extend this so that the entire code base consistently uses pointers (for both input and output structs alike).

Exceptions to this rule are newer APIs like those for the 'stores' (Config, KV, Secret) and any API that implements JSONAPI as I'm not confident in how pointers will be handled by the JSONAPI package (also TLS uses it and so it feels extra risky).

## Notes

I've discovered via the test suite a bunch of cases where `null` was being coerced into a type's zero value (e.g. empty string and zero mostly) and so I've updated the tests for those assertions to check for `nil` now as that's what we're expecting.

As discussed in a separate breaking PR (generic pagination), we've decided to no longer sort the APIs response data. So you'll see a bunch of struct types (across most files) that implemented the sort interface are now removed.