### PR TITLE
feat: allow parallelization of batch put item

### DIFF
--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -511,6 +511,7 @@ func (c *Client) BatchModifyKVStoreKey(i *BatchModifyKVStoreKeyInput) error {
 		Headers: map[string]string{
 			"Content-Type": "application/x-ndjson",
 		},
+		Parallel: true,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
In the spirit of #429, I suppose there is nothing that prevents us to parallelize `BatchModifyKVStoreKey` calls. This will help us upload huge batches of data.

Note that from what've tested, huge parallelized batches seem to fail with 429 errors (but smalls are ok)