### PR TITLE
Fix decoding

### DIFF
--- a/fastly/config_store.go
+++ b/fastly/config_store.go
@@ -213,7 +213,7 @@ func (c *Client) ListConfigStoreServices(i *ListConfigStoreServicesInput) ([]*Se
 	defer resp.Body.Close()
 
 	var ss []*Service
-	if err = json.NewDecoder(resp.Body).Decode(&ss); err != nil {
+	if err = decodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Populate the structure correctly. Noticed by @cee-dub using the CLI.

Before:

```
fastly config-store list-services --store-id [REDACTED] --json
[
  {
    "ActiveVersion": null,
    "Comment": "",
    "CreatedAt": null,
    "CustomerID": null,
    "DeletedAt": null,
    "ServiceID": null,
    "Name": "[SOME NAME]",
    "Type": "wasm",
    "UpdatedAt": null,
    "Versions": null
  }
]
```

After:

```
[
  {
    "ActiveVersion": null,
    "Comment": "",
    "CreatedAt": "2023-02-27T15:57:35Z",
    "CustomerID": "[SOME CUSTOMER ID]",
    "DeletedAt": null,
    "ServiceID": "[SOME SERVICE ID]",
    "Name": "[SOME NAME]",
    "Type": "wasm",
    "UpdatedAt": "2023-02-27T15:57:35Z",
    "Versions": null
  }
]
```