### PR TITLE
feat: expose project_id field of scalyr logging config

### DIFF
--- a/fastly/fixtures/scalyrs/cleanup.yaml
+++ b/fastly/fixtures/scalyrs/cleanup.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/60/logging/scalyr/test-scalyr
+      - FastlyGo/9.1.0 (+github.com/fastly/go-fastly; go1.22.1)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/logging/scalyr/test-scalyr
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e test-scalyr, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 60 }''"}'
+      version =\u003e 2 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:06:21 GMT
+      - Thu, 14 Mar 2024 23:05:46 GMT
       Fastly-Ratelimit-Remaining:
-      - "9995"
+      - "995"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1710460800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -33,15 +37,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4138-MAN
+      - cache-sjc1000122-SJC
       X-Timer:
-      - S1667577981.919148,VS0,VE148
+      - S1710457547.514627,VS0,VE208
     status: 404 Not Found
     code: 404
     duration: ""
@@ -50,13 +54,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/60/logging/scalyr/new-test-scalyr
+      - FastlyGo/9.1.0 (+github.com/fastly/go-fastly; go1.22.1)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/logging/scalyr/new-test-scalyr
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find syslog ''{ deleted =\u003e
       0000-00-00 00:00:00, name =\u003e new-test-scalyr, service =\u003e 7i6HN3TK9wS159v2gPAZ8A,
-      version =\u003e 60 }''"}'
+      version =\u003e 2 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -65,11 +69,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:06:21 GMT
+      - Thu, 14 Mar 2024 23:05:46 GMT
       Fastly-Ratelimit-Remaining:
-      - "9994"
+      - "994"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1710460800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -77,15 +85,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4138-MAN
+      - cache-sjc1000122-SJC
       X-Timer:
-      - S1667577981.092441,VS0,VE146
+      - S1710457547.731162,VS0,VE158
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/scalyrs/create.yaml
+++ b/fastly/fixtures/scalyrs/create.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: format=%25h+%25l+%25u+%25t+%22%25r%22+%25%3Es+%25b&format_version=2&name=test-scalyr&placement=waf_debug&region=US&token=super-secure-token
+    body: format=%25h+%25l+%25u+%25t+%22%25r%22+%25%3Es+%25b&format_version=2&name=test-scalyr&placement=waf_debug&project_id=logplex&region=US&token=super-secure-token
     form:
       format:
       - '%h %l %u %t "%r" %>s %b'
@@ -12,6 +12,8 @@ interactions:
       - test-scalyr
       placement:
       - waf_debug
+      project_id:
+      - logplex
       region:
       - US
       token:
@@ -20,11 +22,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/60/logging/scalyr
+      - FastlyGo/9.1.0 (+github.com/fastly/go-fastly; go1.22.1)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/logging/scalyr
     method: POST
   response:
-    body: '{"format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","name":"test-scalyr","placement":"waf_debug","region":"US","token":"super-secure-token","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"60","response_condition":"","created_at":"2022-11-04T16:06:19Z","project_id":null,"deleted_at":null,"updated_at":"2022-11-04T16:06:19Z"}'
+    body: '{"format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","name":"test-scalyr","placement":"waf_debug","project_id":"logplex","region":"US","token":"super-secure-token","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"2","created_at":"2024-03-14T23:05:45Z","deleted_at":null,"updated_at":"2024-03-14T23:05:45Z","response_condition":""}'
     headers:
       Accept-Ranges:
       - bytes
@@ -33,11 +35,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:06:19 GMT
+      - Thu, 14 Mar 2024 23:05:45 GMT
       Fastly-Ratelimit-Remaining:
-      - "9998"
+      - "998"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1710460800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -45,15 +51,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-1-CONTROL-AWS, cache-man4138-MAN
+      - cache-sjc1000122-SJC
       X-Timer:
-      - S1667577979.040033,VS0,VE482
+      - S1710457545.944744,VS0,VE451
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/delete.yaml
+++ b/fastly/fixtures/scalyrs/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/60/logging/scalyr/new-test-scalyr
+      - FastlyGo/9.1.0 (+github.com/fastly/go-fastly; go1.22.1)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/logging/scalyr/new-test-scalyr
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:06:20 GMT
+      - Thu, 14 Mar 2024 23:05:46 GMT
       Fastly-Ratelimit-Remaining:
-      - "9996"
+      - "996"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1710460800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -31,15 +35,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4138-MAN
+      - cache-sjc1000122-SJC
       X-Timer:
-      - S1667577981.662628,VS0,VE220
+      - S1710457546.193359,VS0,VE304
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/get.yaml
+++ b/fastly/fixtures/scalyrs/get.yaml
@@ -6,12 +6,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/60/logging/scalyr/test-scalyr
+      - FastlyGo/9.1.0 (+github.com/fastly/go-fastly; go1.22.1)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/logging/scalyr/test-scalyr
     method: GET
   response:
-    body: '{"version":"60","region":"US","deleted_at":null,"name":"test-scalyr","created_at":"2022-11-04T16:06:19Z","format":"%h
-      %l %u %t \"%r\" %\u003es %b","service_id":"7i6HN3TK9wS159v2gPAZ8A","format_version":"2","token":"super-secure-token","response_condition":"","placement":"waf_debug","project_id":null,"updated_at":"2022-11-04T16:06:19Z"}'
+    body: '{"placement":"waf_debug","token":"super-secure-token","region":"US","response_condition":"","name":"test-scalyr","updated_at":"2024-03-14T23:05:45Z","project_id":"logplex","format_version":"2","created_at":"2024-03-14T23:05:45Z","version":"2","service_id":"7i6HN3TK9wS159v2gPAZ8A","deleted_at":null,"format":"%h
+      %l %u %t \"%r\" %\u003es %b"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -20,7 +20,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:06:20 GMT
+      - Thu, 14 Mar 2024 23:05:45 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -28,15 +32,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4138-MAN
+      - cache-sjc1000122-SJC
       X-Timer:
-      - S1667577980.906289,VS0,VE136
+      - S1710457546.615237,VS0,VE186
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/list.yaml
+++ b/fastly/fixtures/scalyrs/list.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/60/logging/scalyr
+      - FastlyGo/9.1.0 (+github.com/fastly/go-fastly; go1.22.1)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/logging/scalyr
     method: GET
   response:
-    body: '[{"deleted_at":null,"format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","region":"US","service_id":"7i6HN3TK9wS159v2gPAZ8A","token":"super-secure-token","placement":"waf_debug","created_at":"2022-11-04T16:06:19Z","updated_at":"2022-11-04T16:06:19Z","name":"test-scalyr","project_id":null,"version":"60","response_condition":""}]'
+    body: '[{"format":"%h %l %u %t \"%r\" %\u003es %b","format_version":"2","token":"super-secure-token","response_condition":"","placement":"waf_debug","name":"test-scalyr","region":"US","created_at":"2024-03-14T23:05:45Z","project_id":"logplex","deleted_at":null,"service_id":"7i6HN3TK9wS159v2gPAZ8A","version":"2","updated_at":"2024-03-14T23:05:45Z"}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:06:19 GMT
+      - Thu, 14 Mar 2024 23:05:45 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -27,15 +31,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-7-CONTROL-AWS, cache-man4138-MAN
+      - cache-sjc1000122-SJC
       X-Timer:
-      - S1667577980.561728,VS0,VE310
+      - S1710457545.405557,VS0,VE201
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/update.yaml
+++ b/fastly/fixtures/scalyrs/update.yaml
@@ -2,10 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: name=new-test-scalyr&region=EU&token=new-token
+    body: name=new-test-scalyr&project_id=app-name&region=EU&token=new-token
     form:
       name:
       - new-test-scalyr
+      project_id:
+      - app-name
       region:
       - EU
       token:
@@ -14,12 +16,12 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/60/logging/scalyr/test-scalyr
+      - FastlyGo/9.1.0 (+github.com/fastly/go-fastly; go1.22.1)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/2/logging/scalyr/test-scalyr
     method: PUT
   response:
-    body: '{"format_version":"2","created_at":"2022-11-04T16:06:19Z","response_condition":"","deleted_at":null,"token":"new-token","updated_at":"2022-11-04T16:06:19Z","project_id":null,"format":"%h
-      %l %u %t \"%r\" %\u003es %b","version":"60","region":"EU","service_id":"7i6HN3TK9wS159v2gPAZ8A","name":"new-test-scalyr","placement":"waf_debug"}'
+    body: '{"created_at":"2024-03-14T23:05:45Z","name":"new-test-scalyr","format_version":"2","format":"%h
+      %l %u %t \"%r\" %\u003es %b","placement":"waf_debug","response_condition":"","token":"new-token","version":"2","service_id":"7i6HN3TK9wS159v2gPAZ8A","project_id":"app-name","deleted_at":null,"region":"EU","updated_at":"2024-03-14T23:05:45Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -28,11 +30,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:06:20 GMT
+      - Thu, 14 Mar 2024 23:05:46 GMT
       Fastly-Ratelimit-Remaining:
-      - "9997"
+      - "997"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1710460800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -40,15 +46,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4138-MAN
+      - cache-sjc1000122-SJC
       X-Timer:
-      - S1667577980.085080,VS0,VE515
+      - S1710457546.813514,VS0,VE372
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/scalyrs/version.yaml
+++ b/fastly/fixtures/scalyrs/version.yaml
@@ -2,19 +2,17 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A
-    form:
-      ServiceID:
-      - 7i6HN3TK9wS159v2gPAZ8A
+    body: ""
+    form: {}
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+      - FastlyGo/9.1.0 (+github.com/fastly/go-fastly; go1.22.1)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":60}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":2}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +21,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 04 Nov 2022 16:06:19 GMT
+      - Thu, 14 Mar 2024 23:05:44 GMT
       Fastly-Ratelimit-Remaining:
-      - "9999"
+      - "999"
       Fastly-Ratelimit-Reset:
-      - "1667581200"
+      - "1710460800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,15 +37,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4138-MAN
+      - cache-sjc1000122-SJC
       X-Timer:
-      - S1667577979.630308,VS0,VE380
+      - S1710457545.555028,VS0,VE377
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/logging_scalyr.go
+++ b/fastly/logging_scalyr.go
@@ -14,6 +14,7 @@ type Scalyr struct {
 	FormatVersion     *int       `mapstructure:"format_version"`
 	Name              *string    `mapstructure:"name"`
 	Placement         *string    `mapstructure:"placement"`
+	ProjectID         *string    `mapstructure:"project_id"`
 	Region            *string    `mapstructure:"region"`
 	ResponseCondition *string    `mapstructure:"response_condition"`
 	ServiceID         *string    `mapstructure:"service_id"`
@@ -63,6 +64,8 @@ type CreateScalyrInput struct {
 	Name *string `url:"name,omitempty"`
 	// Placement is where in the generated VCL the logging call should be placed.
 	Placement *string `url:"placement,omitempty"`
+	// ProjectID hold the name of the logfile field sent to Scalyr.
+	ProjectID *string `url:"project_id,omitempty"`
 	// Region is the region that log data will be sent to.
 	Region *string `url:"region,omitempty"`
 	// ResponseCondition is the name of an existing condition in the configured endpoint, or leave blank to always execute.
@@ -146,6 +149,8 @@ type UpdateScalyrInput struct {
 	NewName *string `url:"name,omitempty"`
 	// Placement is where in the generated VCL the logging call should be placed.
 	Placement *string `url:"placement,omitempty"`
+	// ProjectID hold the name of the logfile field sent to Scalyr.
+	ProjectID *string `url:"project_id,omitempty"`
 	// Region is the region that log data will be sent to.
 	Region *string `url:"region,omitempty"`
 	// ResponseCondition is the name of an existing condition in the configured endpoint, or leave blank to always execute.

--- a/fastly/logging_scalyr_test.go
+++ b/fastly/logging_scalyr_test.go
@@ -23,6 +23,7 @@ func TestClient_Scalyrs(t *testing.T) {
 			Format:         ToPointer("%h %l %u %t \"%r\" %>s %b"),
 			FormatVersion:  ToPointer(2),
 			Placement:      ToPointer("waf_debug"),
+			ProjectID:      ToPointer("logplex"),
 			Region:         ToPointer("US"),
 			Token:          ToPointer("super-secure-token"),
 		})
@@ -59,6 +60,9 @@ func TestClient_Scalyrs(t *testing.T) {
 	}
 	if *s.Placement != "waf_debug" {
 		t.Errorf("bad placement: %q", *s.Placement)
+	}
+	if *s.ProjectID != "logplex" {
+		t.Errorf("bad project_id: %q", *s.Placement)
 	}
 	if *s.Region != "US" {
 		t.Errorf("bad region: %q", *s.Region)
@@ -106,6 +110,9 @@ func TestClient_Scalyrs(t *testing.T) {
 	if *s.Placement != *ns.Placement {
 		t.Errorf("bad placement: %q", *s.Placement)
 	}
+	if *s.ProjectID != *ns.ProjectID {
+		t.Errorf("bad project_id: %q", *s.ProjectID)
+	}
 	if *s.Region != "US" {
 		t.Errorf("bad region: %q", *s.Region)
 	}
@@ -121,6 +128,7 @@ func TestClient_Scalyrs(t *testing.T) {
 			ServiceVersion: *tv.Number,
 			Name:           "test-scalyr",
 			NewName:        ToPointer("new-test-scalyr"),
+			ProjectID:      ToPointer("app-name"),
 			Region:         ToPointer("EU"),
 			Token:          ToPointer("new-token"),
 		})
@@ -130,6 +138,9 @@ func TestClient_Scalyrs(t *testing.T) {
 	}
 	if *us.Name != "new-test-scalyr" {
 		t.Errorf("bad name: %q", *us.Name)
+	}
+	if *us.ProjectID != "app-name" {
+		t.Errorf("bad project_id: %q", *us.ProjectID)
 	}
 	if *us.Region != "EU" {
 		t.Errorf("bad region: %q", *us.Region)


### PR DESCRIPTION
There's a field to set the logfile sent to Scalyr, but it wasn't exposed in the API client. This adds access to the missing field.
<img width="635" alt="Screenshot 2024-03-14 at 13 18 56" src="https://github.com/fastly/go-fastly/assets/1292/0e027a2e-7dbe-42df-8bbc-925b633a4f82">
