### PR TITLE
fix(tls_custom_activation): only error if no fields provided

### DIFF
--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -323,6 +323,11 @@ var ErrMissingProductID = NewFieldError("ProductID")
 // has an invalid Method value.
 var ErrInvalidMethod = NewFieldError("Method").Message("invalid")
 
+// ErrMissingCertificateMTLS is an error that is returned when an input struct
+// requires either a "Certificate" or "MutualAuthentication" key, but neither
+// was set.
+var ErrMissingCertificateMTLS = NewFieldError("Certificate, MutualAuthentication").Message("at least one of the available optional fields is required")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 

--- a/fastly/tls_custom_activation.go
+++ b/fastly/tls_custom_activation.go
@@ -189,8 +189,8 @@ func (c *Client) UpdateTLSActivation(i *UpdateTLSActivationInput) (*TLSActivatio
 	if i.ID == "" {
 		return nil, ErrMissingID
 	}
-	if i.Certificate == nil {
-		return nil, ErrMissingTLSCertificate
+	if i.Certificate == nil && i.MutualAuthentication == nil {
+		return nil, ErrMissingCertificateMTLS
 	}
 
 	path := fmt.Sprintf("/tls/activations/%s", i.ID)

--- a/fastly/tls_custom_activation_test.go
+++ b/fastly/tls_custom_activation_test.go
@@ -201,7 +201,7 @@ func TestClient_UpdateTLSActivation_validation(t *testing.T) {
 	_, err = testClient.UpdateTLSActivation(&UpdateTLSActivationInput{
 		ID: "ACTIVATION_ID",
 	})
-	if err != ErrMissingTLSCertificate {
+	if err != ErrMissingCertificateMTLS {
 		t.Errorf("bad error: %s", err)
 	}
 


### PR DESCRIPTION
**Problem:** Enabling mTLS will fail because of the incorrect validation check.
**Solution:** Only return an error if no fields are passed.