### PR TITLE
fix(tls_mutual_authentication): support null for ID value

### DIFF
--- a/fastly/tls_mutual_authentication.go
+++ b/fastly/tls_mutual_authentication.go
@@ -15,7 +15,7 @@ type TLSMutualAuthentication struct {
 	Activations []*TLSActivation `jsonapi:"relation,tls_activations"`
 	CreatedAt   *time.Time       `jsonapi:"attr,created_at,iso8601"`
 	Enforced    bool             `jsonapi:"attr,enforced"`
-	ID          string           `jsonapi:"primary,mutual_authentication"`
+	ID          string           `jsonapi:"primary,mutual_authentication,omitempty"`
 	Name        string           `jsonapi:"attr,name"`
 	UpdatedAt   *time.Time       `jsonapi:"attr,updated_at,iso8601"`
 }


### PR DESCRIPTION
**Problem:** While working on https://github.com/fastly/terraform-provider-fastly/pull/829 I discovered I was unable to delete mTLS without first disabling it from an TLS Activation.
**Solution:** Allow `null` to be passed to the Fastly API for the purpose of disabling mTLS.