### PR TITLE
Add support for specifying location when creating KV stores

### DIFF
--- a/fastly/fixtures/kv_store/TestClient_CreateKVStoresWithLocations/create_stores.yaml
+++ b/fastly/fixtures/kv_store/TestClient_CreateKVStoresWithLocations/create_stores.yaml
@@ -1,0 +1,167 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"TestClient_CreateKVStoresWithLocations_US"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv?location=US
+    method: POST
+  response:
+    body: '{"id":"by19id44okrxf9ui4nr93j","name":"TestClient_CreateKVStoresWithLocations_US","created_at":"2024-04-16
+      14:10:02","updated_at":"2024-04-16 14:10:02"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Apr 2024 14:10:03 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      X-Timer:
+      - S1713276598.002687,VS0,VE5008
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"name":"TestClient_CreateKVStoresWithLocations_EU"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv?location=EU
+    method: POST
+  response:
+    body: '{"id":"kkowf43t9yqupo6r7kh0cs","name":"TestClient_CreateKVStoresWithLocations_EU","created_at":"2024-04-16
+      14:10:08","updated_at":"2024-04-16 14:10:08"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Apr 2024 14:10:09 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      X-Timer:
+      - S1713276603.026026,VS0,VE6079
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"name":"TestClient_CreateKVStoresWithLocations_ASIA"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv?location=ASIA
+    method: POST
+  response:
+    body: '{"id":"afd1ypidt5tyh4e6ammjn8","name":"TestClient_CreateKVStoresWithLocations_ASIA","created_at":"2024-04-16
+      14:10:12","updated_at":"2024-04-16 14:10:12"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Apr 2024 14:10:12 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      X-Timer:
+      - S1713276609.114936,VS0,VE3619
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"name":"TestClient_CreateKVStoresWithLocations_AUS"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv?location=AUS
+    method: POST
+  response:
+    body: '{"id":"r2an4zjgv6vm7o14aqm4qt","name":"TestClient_CreateKVStoresWithLocations_AUS","created_at":"2024-04-16
+      14:10:17","updated_at":"2024-04-16 14:10:17"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Apr 2024 14:10:17 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      X-Timer:
+      - S1713276613.743388,VS0,VE4917
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/fixtures/kv_store/TestClient_CreateKVStoresWithLocations/delete_stores.yaml
+++ b/fastly/fixtures/kv_store/TestClient_CreateKVStoresWithLocations/delete_stores.yaml
@@ -1,0 +1,139 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv/by19id44okrxf9ui4nr93j
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Date:
+      - Tue, 16 Apr 2024 14:10:18 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      X-Timer:
+      - S1713276618.697733,VS0,VE1138
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv/kkowf43t9yqupo6r7kh0cs
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Date:
+      - Tue, 16 Apr 2024 14:10:20 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      X-Timer:
+      - S1713276619.847370,VS0,VE1528
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv/afd1ypidt5tyh4e6ammjn8
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Date:
+      - Tue, 16 Apr 2024 14:10:20 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      X-Timer:
+      - S1713276620.387394,VS0,VE480
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv/r2an4zjgv6vm7o14aqm4qt
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Date:
+      - Tue, 16 Apr 2024 14:10:22 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      X-Timer:
+      - S1713276621.969488,VS0,VE1111
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -24,7 +24,7 @@ type KVStore struct {
 type CreateKVStoreInput struct {
 	// Name is the name of the store to create (required).
 	Name string `json:"name"`
-	// Location is the location of the store (optional).
+	// Location is the regional location of the store (optional).
 	Location string `json:"-"`
 }
 

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -24,6 +24,8 @@ type KVStore struct {
 type CreateKVStoreInput struct {
 	// Name is the name of the store to create (required).
 	Name string `json:"name"`
+	// Location is the location of the store (optional).
+	Location string `json:"-"`
 }
 
 // CreateKVStore creates a new resource.
@@ -32,8 +34,15 @@ func (c *Client) CreateKVStore(i *CreateKVStoreInput) (*KVStore, error) {
 		return nil, ErrMissingName
 	}
 
+	ro := &RequestOptions{
+		Params: map[string]string{},
+	}
+	if i.Location != "" {
+		ro.Params["location"] = i.Location
+	}
+
 	const path = "/resources/stores/kv"
-	resp, err := c.PostJSON(path, i, nil)
+	resp, err := c.PostJSON(path, i, ro)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
:wave: This PR adds the ability to specify the location when creating a new KV store using [the API](https://www.fastly.com/documentation/reference/api/services/resources/kv-store/#create-store). I would like **terraform-provider-fastly** to support specifying the location for KV stores, and this change is a preparation for that.

Changes made:

- Added a new `Location` field to the `CreateKVStoreInput` struct.
- Updated the `CreateKVStore` method to include the location parameter in the API request if it is provided in the input struct.
- Added a new test `TestClient_CreateKVStoresWithLocations` to verify that KV stores can be created with different locations.
