### PR TITLE
Use constants to validate KV Store location values

### DIFF
--- a/fastly/fixtures/kv_store/TestClient_CreateKVStoresWithLocations/create_stores.yaml
+++ b/fastly/fixtures/kv_store/TestClient_CreateKVStoresWithLocations/create_stores.yaml
@@ -10,12 +10,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.22.2)
     url: https://api.fastly.com/resources/stores/kv?location=US
     method: POST
   response:
-    body: '{"id":"by19id44okrxf9ui4nr93j","name":"TestClient_CreateKVStoresWithLocations_US","created_at":"2024-04-16
-      14:10:02","updated_at":"2024-04-16 14:10:02"}'
+    body: '{"id":"l0jnr80jyl0fpils4dqzvh","name":"TestClient_CreateKVStoresWithLocations_US","created_at":"2024-04-17
+      14:02:22","updated_at":"2024-04-17 14:02:22"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 14:10:03 GMT
+      - Wed, 17 Apr 2024 14:02:22 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -36,9 +36,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      - cache-nrt-rjtf7700063-NRT, cache-nrt-rjtf7700063-NRT
       X-Timer:
-      - S1713276598.002687,VS0,VE5008
+      - S1713362539.805337,VS0,VE3987
     status: 201 Created
     code: 201
     duration: ""
@@ -51,12 +51,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.22.2)
     url: https://api.fastly.com/resources/stores/kv?location=EU
     method: POST
   response:
-    body: '{"id":"kkowf43t9yqupo6r7kh0cs","name":"TestClient_CreateKVStoresWithLocations_EU","created_at":"2024-04-16
-      14:10:08","updated_at":"2024-04-16 14:10:08"}'
+    body: '{"id":"j637x7hrx3paj1qysky7cl","name":"TestClient_CreateKVStoresWithLocations_EU","created_at":"2024-04-17
+      14:02:27","updated_at":"2024-04-17 14:02:27"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 14:10:09 GMT
+      - Wed, 17 Apr 2024 14:02:27 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -77,9 +77,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      - cache-nrt-rjtf7700063-NRT, cache-nrt-rjtf7700063-NRT
       X-Timer:
-      - S1713276603.026026,VS0,VE6079
+      - S1713362543.868832,VS0,VE4762
     status: 201 Created
     code: 201
     duration: ""
@@ -92,12 +92,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.22.2)
     url: https://api.fastly.com/resources/stores/kv?location=ASIA
     method: POST
   response:
-    body: '{"id":"afd1ypidt5tyh4e6ammjn8","name":"TestClient_CreateKVStoresWithLocations_ASIA","created_at":"2024-04-16
-      14:10:12","updated_at":"2024-04-16 14:10:12"}'
+    body: '{"id":"bnkj22sjmn6ze2c97jimc3","name":"TestClient_CreateKVStoresWithLocations_ASIA","created_at":"2024-04-17
+      14:02:30","updated_at":"2024-04-17 14:02:30"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -106,7 +106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 14:10:12 GMT
+      - Wed, 17 Apr 2024 14:02:30 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -118,9 +118,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      - cache-nrt-rjtf7700063-NRT, cache-nrt-rjtf7700063-NRT
       X-Timer:
-      - S1713276609.114936,VS0,VE3619
+      - S1713362548.639648,VS0,VE3085
     status: 201 Created
     code: 201
     duration: ""
@@ -133,12 +133,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.22.2)
     url: https://api.fastly.com/resources/stores/kv?location=AUS
     method: POST
   response:
-    body: '{"id":"r2an4zjgv6vm7o14aqm4qt","name":"TestClient_CreateKVStoresWithLocations_AUS","created_at":"2024-04-16
-      14:10:17","updated_at":"2024-04-16 14:10:17"}'
+    body: '{"id":"avp2ql3vm5ia5ylal8x3wn","name":"TestClient_CreateKVStoresWithLocations_AUS","created_at":"2024-04-17
+      14:02:34","updated_at":"2024-04-17 14:02:34"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -147,7 +147,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 14:10:17 GMT
+      - Wed, 17 Apr 2024 14:02:34 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -159,9 +159,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      - cache-nrt-rjtf7700063-NRT, cache-nrt-rjtf7700063-NRT
       X-Timer:
-      - S1713276613.743388,VS0,VE4917
+      - S1713362551.736102,VS0,VE4206
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/fixtures/kv_store/TestClient_CreateKVStoresWithLocations/delete_stores.yaml
+++ b/fastly/fixtures/kv_store/TestClient_CreateKVStoresWithLocations/delete_stores.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
-    url: https://api.fastly.com/resources/stores/kv/by19id44okrxf9ui4nr93j
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv/l0jnr80jyl0fpils4dqzvh
     method: DELETE
   response:
     body: ""
@@ -17,7 +17,7 @@ interactions:
       Cache-Control:
       - no-store
       Date:
-      - Tue, 16 Apr 2024 14:10:18 GMT
+      - Wed, 17 Apr 2024 14:02:36 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -29,9 +29,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      - cache-nrt-rjtf7700063-NRT, cache-nrt-rjtf7700063-NRT
       X-Timer:
-      - S1713276618.697733,VS0,VE1138
+      - S1713362555.056922,VS0,VE1139
     status: 204 No Content
     code: 204
     duration: ""
@@ -40,8 +40,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
-    url: https://api.fastly.com/resources/stores/kv/kkowf43t9yqupo6r7kh0cs
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv/j637x7hrx3paj1qysky7cl
     method: DELETE
   response:
     body: ""
@@ -51,7 +51,7 @@ interactions:
       Cache-Control:
       - no-store
       Date:
-      - Tue, 16 Apr 2024 14:10:20 GMT
+      - Wed, 17 Apr 2024 14:02:36 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -63,9 +63,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      - cache-nrt-rjtf7700063-NRT, cache-nrt-rjtf7700063-NRT
       X-Timer:
-      - S1713276619.847370,VS0,VE1528
+      - S1713362556.204589,VS0,VE500
     status: 204 No Content
     code: 204
     duration: ""
@@ -74,8 +74,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
-    url: https://api.fastly.com/resources/stores/kv/afd1ypidt5tyh4e6ammjn8
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv/bnkj22sjmn6ze2c97jimc3
     method: DELETE
   response:
     body: ""
@@ -85,7 +85,7 @@ interactions:
       Cache-Control:
       - no-store
       Date:
-      - Tue, 16 Apr 2024 14:10:20 GMT
+      - Wed, 17 Apr 2024 14:02:38 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -97,9 +97,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      - cache-nrt-rjtf7700063-NRT, cache-nrt-rjtf7700063-NRT
       X-Timer:
-      - S1713276620.387394,VS0,VE480
+      - S1713362557.713243,VS0,VE1321
     status: 204 No Content
     code: 204
     duration: ""
@@ -108,8 +108,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.2 (+github.com/fastly/go-fastly; go1.22.2)
-    url: https://api.fastly.com/resources/stores/kv/r2an4zjgv6vm7o14aqm4qt
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/resources/stores/kv/avp2ql3vm5ia5ylal8x3wn
     method: DELETE
   response:
     body: ""
@@ -119,7 +119,7 @@ interactions:
       Cache-Control:
       - no-store
       Date:
-      - Tue, 16 Apr 2024 14:10:22 GMT
+      - Wed, 17 Apr 2024 14:02:39 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -131,9 +131,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-nrt-rjtf7700035-NRT, cache-nrt-rjtf7700035-NRT
+      - cache-nrt-rjtf7700063-NRT, cache-nrt-rjtf7700063-NRT
       X-Timer:
-      - S1713276621.969488,VS0,VE1111
+      - S1713362558.043588,VS0,VE1044
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -18,11 +18,11 @@ type KVStoreLocation string
 const (
 	// KVStoreLocationUS represents a redundancy variant.
 	KVStoreLocationUS KVStoreLocation = "US"
-	// KVStoreLocationUS represents a redundancy variant.
+	// KVStoreLocationEU represents a redundancy variant.
 	KVStoreLocationEU KVStoreLocation = "EU"
-	// KVStoreLocationUS represents a redundancy variant.
+	// KVStoreLocationASIA represents a redundancy variant.
 	KVStoreLocationASIA KVStoreLocation = "ASIA"
-	// KVStoreLocationUS represents a redundancy variant.
+	// KVStoreLocationAUS represents a redundancy variant.
 	KVStoreLocationAUS KVStoreLocation = "AUS"
 )
 

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -12,17 +12,17 @@ import (
 
 // https://developer.fastly.com/reference/api/services/resources/kv-store
 
-// KVStoreLocation represents the regional location of KV store.
+// KVStoreLocation represents the regional location of KV stores.
 type KVStoreLocation string
 
 const (
-	// KVStoreLocationUS represents a redundancy variant.
+	// KVStoreLocationUS represents a location variant.
 	KVStoreLocationUS KVStoreLocation = "US"
-	// KVStoreLocationEU represents a redundancy variant.
+	// KVStoreLocationEU represents a location variant.
 	KVStoreLocationEU KVStoreLocation = "EU"
-	// KVStoreLocationASIA represents a redundancy variant.
+	// KVStoreLocationASIA represents a location variant.
 	KVStoreLocationASIA KVStoreLocation = "ASIA"
-	// KVStoreLocationAUS represents a redundancy variant.
+	// KVStoreLocationAUS represents a location variant.
 	KVStoreLocationAUS KVStoreLocation = "AUS"
 )
 

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -12,6 +12,20 @@ import (
 
 // https://developer.fastly.com/reference/api/services/resources/kv-store
 
+// KVStoreLocation represents the regional location of KV store.
+type KVStoreLocation string
+
+const (
+	// KVStoreLocationUS represents a redundancy variant.
+	KVStoreLocationUS KVStoreLocation = "US"
+	// KVStoreLocationUS represents a redundancy variant.
+	KVStoreLocationEU KVStoreLocation = "EU"
+	// KVStoreLocationUS represents a redundancy variant.
+	KVStoreLocationASIA KVStoreLocation = "ASIA"
+	// KVStoreLocationUS represents a redundancy variant.
+	KVStoreLocationAUS KVStoreLocation = "AUS"
+)
+
 // KVStore represents an KV Store response from the Fastly API.
 type KVStore struct {
 	CreatedAt *time.Time `mapstructure:"created_at"`
@@ -25,7 +39,7 @@ type CreateKVStoreInput struct {
 	// Name is the name of the store to create (required).
 	Name string `json:"name"`
 	// Location is the regional location of the store (optional).
-	Location string `json:"-"`
+	Location *KVStoreLocation `json:"-"`
 }
 
 // CreateKVStore creates a new resource.
@@ -37,8 +51,8 @@ func (c *Client) CreateKVStore(i *CreateKVStoreInput) (*KVStore, error) {
 	ro := &RequestOptions{
 		Params: map[string]string{},
 	}
-	if i.Location != "" {
-		ro.Params["location"] = i.Location
+	if i.Location != nil {
+		ro.Params["location"] = string(*i.Location)
 	}
 
 	const path = "/resources/stores/kv"

--- a/fastly/kv_store_test.go
+++ b/fastly/kv_store_test.go
@@ -182,10 +182,10 @@ func TestClient_CreateKVStoresWithLocations(t *testing.T) {
 	)
 
 	record(t, fmt.Sprintf("kv_store/%s/create_stores", t.Name()), func(c *Client) {
-		for _, location := range []string{"US", "EU", "ASIA", "AUS"} {
+		for _, location := range []KVStoreLocation{KVStoreLocationUS, KVStoreLocationEU, KVStoreLocationASIA, KVStoreLocationAUS} {
 			ks, err = c.CreateKVStore(&CreateKVStoreInput{
 				Name:     fmt.Sprintf("%s_%s", t.Name(), location),
-				Location: location,
+				Location: &location,
 			})
 			if err != nil {
 				t.Fatalf("error creating kv store: %v", err)


### PR DESCRIPTION
This commit introduces the `KVStoreLocation` type to represent the regional location of KV stores. Constants are defined for the available KV store locations, and the `CreateKVStoreInput` struct and `CreateKVStore` method are updated to use the new type.

The test case `TestClient_CreateKVStoresWithLocations` is also modified to use the constants.