### PR TITLE
feat(tls_subscription): add `tls_certificate` attributes

### DIFF
--- a/fastly/fixtures/tls_subscription/activate_version.yaml
+++ b/fastly/fixtures/tls_subscription/activate_version.yaml
@@ -6,13 +6,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/activate
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/activate
     method: PUT
   response:
-    body: '{"testing":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","locked":true,"staging":false,"deleted_at":null,"deployed":false,"created_at":"2022-08-22T10:45:36Z","updated_at":"2022-08-22T10:45:36Z","active":true,"comment":"","number":6,"msg":"Warning:
-      No default director found\nat: (default Line 174 Pos 1)\n         if (req.http.Fastly-Temp-XFF
-      == \"\") {\n----------------------------------------------"}'
+    body: '{"staging":false,"deployed":false,"service_id":"7i6HN3TK9wS159v2gPAZ8A","locked":true,"comment":"","testing":false,"deleted_at":null,"created_at":"2024-05-07T12:51:55Z","active":true,"updated_at":"2024-05-07T12:51:56Z","number":3,"msg":"Warning:
+      No default director found\nat: (default Line 174 Pos 1)\n#--FASTLY BEREQ BEGIN\n---------------------"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +20,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 22 Aug 2022 10:45:38 GMT
+      - Tue, 07 May 2024 12:51:57 GMT
       Fastly-Ratelimit-Remaining:
-      - "4985"
+      - "9994"
       Fastly-Ratelimit-Reset:
-      - "1661166000"
+      - "1715086800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,15 +36,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165137.971061,VS0,VE1034
+      - S1715086317.646065,VS0,VE984
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/tls_subscription/cleanup.yaml
+++ b/fastly/fixtures/tls_subscription/cleanup.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/tls/subscriptions/SUBSCRIPTION_ID
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
+    url: https://api.fastly.com/tls/subscriptions/mwtZ5xuowgXsyR2nyPjuWw
     method: DELETE
   response:
     body: '{"errors":[{"title":"Not found","detail":"The subscription you requested
@@ -15,26 +15,32 @@ interactions:
     headers:
       Accept-Ranges:
       - bytes
+      Cache-Control:
+      - no-store
       Content-Length:
       - "90"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Mon, 22 Aug 2022 10:45:41 GMT
+      - Tue, 07 May 2024 12:52:02 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165141.335736,VS0,VE93
+      - S1715086323.742454,VS0,VE193
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/tls_subscription/create.yaml
+++ b/fastly/fixtures/tls_subscription/create.yaml
@@ -11,34 +11,40 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
     url: https://api.fastly.com/tls/subscriptions
     method: POST
   response:
-    body: '{"data":{"id":"SUBSCRIPTION_ID","type":"tls_subscription","attributes":{"certificate_authority":"lets-encrypt","created_at":"2022-08-22T10:45:38.000Z","state":"pending","has_active_order":true,"updated_at":"2022-08-22T10:45:38.000Z"},"relationships":{"tls_authorizations":{"data":[{"id":"bGl42zjrl7tEqlJz24ZVKw","type":"tls_authorization"}]},"tls_certificates":{"data":[]},"tls_domains":{"data":[{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}]},"common_name":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"tls_configuration":{"data":{"id":"Em77eV0D2qMAduXPtvRdKg","type":"tls_configuration"}}}},"included":[{"id":"bGl42zjrl7tEqlJz24ZVKw","type":"tls_authorization","attributes":{"challenges":[{"type":"managed-dns","record_type":"CNAME","record_name":"_acme-challenge.integ-test1.go-fastly-1.com","values":["9jwu4ypaom1vthbbvt.fastly-validations.com"]},{"type":"managed-http-cname","record_type":"CNAME","record_name":"integ-test1.go-fastly-1.com","values":["j.sni.global.fastly.net"]},{"type":"managed-http-a","record_type":"A","record_name":"integ-test1.go-fastly-1.com","values":["151.101.2.132","151.101.66.132","151.101.130.132","151.101.194.132"]}],"created_at":"2022-08-22T10:45:38.000Z","state":"pending","updated_at":"2022-08-22T10:45:38.000Z","warnings":null},"relationships":{"tls_domain":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"globalsign_email_challenge":{"data":null}}}]}'
+    body: '{"data":{"id":"mwtZ5xuowgXsyR2nyPjuWw","type":"tls_subscription","attributes":{"certificate_authority":"certainly","created_at":"2024-05-07T12:51:58.000Z","state":"pending","has_active_order":true,"updated_at":"2024-05-07T12:51:58.000Z"},"relationships":{"tls_authorizations":{"data":[{"id":"B98ZDNS55WAZ5ltYl6wZUQ","type":"tls_authorization"}]},"tls_certificates":{"data":[]},"tls_domains":{"data":[{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}]},"common_name":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"tls_configuration":{"data":{"id":"Em77eV0D2qMAduXPtvRdKg","type":"tls_configuration"}}}},"included":[{"id":"B98ZDNS55WAZ5ltYl6wZUQ","type":"tls_authorization","attributes":{"challenges":[{"type":"managed-dns","record_type":"CNAME","record_name":"_acme-challenge.integ-test1.go-fastly-1.com","values":["9jwu4ypaom1vthbbvt.fastly-validations.com"]},{"type":"managed-http-cname","record_type":"CNAME","record_name":"integ-test1.go-fastly-1.com","values":["j.sni.global.fastly.net"]},{"type":"managed-http-a","record_type":"A","record_name":"integ-test1.go-fastly-1.com","values":["151.101.2.132","151.101.66.132","151.101.130.132","151.101.194.132"]}],"created_at":"2024-05-07T12:51:58.000Z","state":"pending","updated_at":"2024-05-07T12:51:58.000Z","warnings":null},"relationships":{"tls_domain":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"globalsign_email_challenge":{"data":null},"self_managed_http_challenge":{"data":null}}}]}'
     headers:
       Accept-Ranges:
       - bytes
+      Cache-Control:
+      - no-store
       Content-Length:
-      - "1449"
+      - "1490"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Mon, 22 Aug 2022 10:45:38 GMT
+      - Tue, 07 May 2024 12:51:58 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165138.033478,VS0,VE532
+      - S1715086318.746907,VS0,VE448
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/fixtures/tls_subscription/delete.yaml
+++ b/fastly/fixtures/tls_subscription/delete.yaml
@@ -6,30 +6,36 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/tls/subscriptions/SUBSCRIPTION_ID
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
+    url: https://api.fastly.com/tls/subscriptions/mwtZ5xuowgXsyR2nyPjuWw
     method: DELETE
   response:
     body: ""
     headers:
       Accept-Ranges:
       - bytes
+      Cache-Control:
+      - no-store
       Date:
-      - Mon, 22 Aug 2022 10:45:41 GMT
+      - Tue, 07 May 2024 12:52:02 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165140.634623,VS0,VE1672
+      - S1715086320.600211,VS0,VE3116
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/fixtures/tls_subscription/domains/create.yaml
+++ b/fastly/fixtures/tls_subscription/domains/create.yaml
@@ -2,12 +2,8 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=6&comment=comment&name=integ-test1.go-fastly-1.com
+    body: comment=comment&name=integ-test1.go-fastly-1.com
     form:
-      ServiceID:
-      - 7i6HN3TK9wS159v2gPAZ8A
-      ServiceVersion:
-      - "6"
       comment:
       - comment
       name:
@@ -16,11 +12,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/domain
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/domain
     method: POST
   response:
-    body: '{"comment":"comment","name":"integ-test1.go-fastly-1.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":6,"created_at":"2022-08-22T10:45:36Z","deleted_at":null,"updated_at":"2022-08-22T10:45:36Z"}'
+    body: '{"comment":"comment","name":"integ-test1.go-fastly-1.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":3,"updated_at":"2024-05-07T12:51:56Z","created_at":"2024-05-07T12:51:56Z","deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -29,11 +25,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 22 Aug 2022 10:45:36 GMT
+      - Tue, 07 May 2024 12:51:56 GMT
       Fastly-Ratelimit-Remaining:
-      - "4987"
+      - "9996"
       Fastly-Ratelimit-Reset:
-      - "1661166000"
+      - "1715086800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,15 +41,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165136.252796,VS0,VE384
+      - S1715086316.905157,VS0,VE413
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/tls_subscription/domains/create2.yaml
+++ b/fastly/fixtures/tls_subscription/domains/create2.yaml
@@ -2,12 +2,8 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A&ServiceVersion=6&comment=comment&name=integ-test2.go-fastly-2.com
+    body: comment=comment&name=integ-test2.go-fastly-2.com
     form:
-      ServiceID:
-      - 7i6HN3TK9wS159v2gPAZ8A
-      ServiceVersion:
-      - "6"
       comment:
       - comment
       name:
@@ -16,11 +12,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/6/domain
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
+    url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version/3/domain
     method: POST
   response:
-    body: '{"comment":"comment","name":"integ-test2.go-fastly-2.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":6,"updated_at":"2022-08-22T10:45:36Z","deleted_at":null,"created_at":"2022-08-22T10:45:36Z"}'
+    body: '{"comment":"comment","name":"integ-test2.go-fastly-2.com","service_id":"7i6HN3TK9wS159v2gPAZ8A","version":3,"deleted_at":null,"updated_at":"2024-05-07T12:51:56Z","created_at":"2024-05-07T12:51:56Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -29,11 +25,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 22 Aug 2022 10:45:36 GMT
+      - Tue, 07 May 2024 12:51:56 GMT
       Fastly-Ratelimit-Remaining:
-      - "4986"
+      - "9995"
       Fastly-Ratelimit-Reset:
-      - "1661166000"
+      - "1715086800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,15 +41,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-slwdc9036-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165137.662436,VS0,VE278
+      - S1715086316.343162,VS0,VE281
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/tls_subscription/get.yaml
+++ b/fastly/fixtures/tls_subscription/get.yaml
@@ -8,34 +8,40 @@ interactions:
       Accept:
       - application/vnd.api+json
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/tls/subscriptions/SUBSCRIPTION_ID
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
+    url: https://api.fastly.com/tls/subscriptions/mwtZ5xuowgXsyR2nyPjuWw
     method: GET
   response:
-    body: '{"data":{"id":"SUBSCRIPTION_ID","type":"tls_subscription","attributes":{"certificate_authority":"lets-encrypt","created_at":"2022-08-22T10:45:38.000Z","state":"pending","has_active_order":true,"updated_at":"2022-08-22T10:45:38.000Z"},"relationships":{"tls_authorizations":{"data":[{"id":"bGl42zjrl7tEqlJz24ZVKw","type":"tls_authorization"}]},"tls_certificates":{"data":[]},"tls_domains":{"data":[{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}]},"common_name":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"tls_configuration":{"data":{"id":"Em77eV0D2qMAduXPtvRdKg","type":"tls_configuration"}}}}}'
+    body: '{"data":{"id":"mwtZ5xuowgXsyR2nyPjuWw","type":"tls_subscription","attributes":{"certificate_authority":"certainly","created_at":"2024-05-07T12:51:58.000Z","state":"pending","has_active_order":true,"updated_at":"2024-05-07T12:51:58.000Z"},"relationships":{"tls_authorizations":{"data":[{"id":"B98ZDNS55WAZ5ltYl6wZUQ","type":"tls_authorization"}]},"tls_certificates":{"data":[]},"tls_domains":{"data":[{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}]},"common_name":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"tls_configuration":{"data":{"id":"Em77eV0D2qMAduXPtvRdKg","type":"tls_configuration"}}}}}'
     headers:
       Accept-Ranges:
       - bytes
+      Cache-Control:
+      - no-store
       Content-Length:
-      - "632"
+      - "629"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Mon, 22 Aug 2022 10:45:39 GMT
+      - Tue, 07 May 2024 12:51:58 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9037-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165139.990310,VS0,VE278
+      - S1715086319.664269,VS0,VE192
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/tls_subscription/list.yaml
+++ b/fastly/fixtures/tls_subscription/list.yaml
@@ -8,34 +8,40 @@ interactions:
       Accept:
       - application/vnd.api+json
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
     url: https://api.fastly.com/tls/subscriptions
     method: GET
   response:
-    body: '{"data":[{"id":"SUBSCRIPTION_ID","type":"tls_subscription","attributes":{"certificate_authority":"lets-encrypt","created_at":"2022-08-22T10:45:38.000Z","state":"pending","has_active_order":true,"updated_at":"2022-08-22T10:45:38.000Z"},"relationships":{"tls_authorizations":{"data":[{"id":"bGl42zjrl7tEqlJz24ZVKw","type":"tls_authorization"}]},"tls_certificates":{"data":[]},"tls_domains":{"data":[{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}]},"common_name":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"tls_configuration":{"data":{"id":"Em77eV0D2qMAduXPtvRdKg","type":"tls_configuration"}}}}],"links":{"self":"https://api.fastly.com/tls/subscriptions?page%5Bnumber%5D=1\u0026page%5Bsize%5D=100","first":"https://api.fastly.com/tls/subscriptions?page%5Bnumber%5D=1\u0026page%5Bsize%5D=100","prev":null,"next":null,"last":"https://api.fastly.com/tls/subscriptions?page%5Bnumber%5D=1\u0026page%5Bsize%5D=100"},"meta":{"per_page":100,"current_page":1,"record_count":1,"total_pages":1}}'
+    body: '{"data":[{"id":"mwtZ5xuowgXsyR2nyPjuWw","type":"tls_subscription","attributes":{"certificate_authority":"certainly","created_at":"2024-05-07T12:51:58.000Z","state":"pending","has_active_order":true,"updated_at":"2024-05-07T12:51:58.000Z"},"relationships":{"tls_authorizations":{"data":[{"id":"B98ZDNS55WAZ5ltYl6wZUQ","type":"tls_authorization"}]},"tls_certificates":{"data":[]},"tls_domains":{"data":[{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}]},"common_name":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"tls_configuration":{"data":{"id":"Em77eV0D2qMAduXPtvRdKg","type":"tls_configuration"}}}}],"links":{"self":"https://api.fastly.com/tls/subscriptions?include=tls_certificates\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=100","first":"https://api.fastly.com/tls/subscriptions?include=tls_certificates\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=100","prev":null,"next":null,"last":"https://api.fastly.com/tls/subscriptions?include=tls_certificates\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=100"},"meta":{"per_page":100,"current_page":1,"record_count":1,"total_pages":1}}'
     headers:
       Accept-Ranges:
       - bytes
+      Cache-Control:
+      - no-store
       Content-Length:
-      - "1022"
+      - "1109"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Mon, 22 Aug 2022 10:45:38 GMT
+      - Tue, 07 May 2024 12:51:58 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165139.590746,VS0,VE370
+      - S1715086318.253958,VS0,VE385
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/tls_subscription/update.yaml
+++ b/fastly/fixtures/tls_subscription/update.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"data":{"type":"tls_subscription","id":"SUBSCRIPTION_ID","relationships":{"common_name":{"data":{"type":"tls_domain","id":"integ-test2.go-fastly-2.com"}},"tls_domain":{"data":[{"type":"tls_domain","id":"integ-test1.go-fastly-1.com"},{"type":"tls_domain","id":"integ-test2.go-fastly-2.com"}]}}},"included":[{"type":"tls_domain","id":"integ-test1.go-fastly-1.com","attributes":{"type":""}},{"type":"tls_domain","id":"integ-test2.go-fastly-2.com","attributes":{"type":""}}]}
+      {"data":{"type":"tls_subscription","id":"mwtZ5xuowgXsyR2nyPjuWw","relationships":{"common_name":{"data":{"type":"tls_domain","id":"integ-test2.go-fastly-2.com"}},"tls_domain":{"data":[{"type":"tls_domain","id":"integ-test1.go-fastly-1.com"},{"type":"tls_domain","id":"integ-test2.go-fastly-2.com"}]}}},"included":[{"type":"tls_domain","id":"integ-test2.go-fastly-2.com","attributes":{"type":""}},{"type":"tls_domain","id":"integ-test1.go-fastly-1.com","attributes":{"type":""}}]}
     form: {}
     headers:
       Accept:
@@ -11,34 +11,40 @@ interactions:
       Content-Type:
       - application/vnd.api+json
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/tls/subscriptions/SUBSCRIPTION_ID?force=true
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
+    url: https://api.fastly.com/tls/subscriptions/mwtZ5xuowgXsyR2nyPjuWw?force=true
     method: PATCH
   response:
-    body: '{"data":{"id":"SUBSCRIPTION_ID","type":"tls_subscription","attributes":{"certificate_authority":"lets-encrypt","created_at":"2022-08-22T10:45:38.000Z","state":"pending","has_active_order":true,"updated_at":"2022-08-22T10:45:39.000Z"},"relationships":{"tls_authorizations":{"data":[{"id":"bGl42zjrl7tEqlJz24ZVKw","type":"tls_authorization"},{"id":"CvewJbxr4LcvYm9p5gYQsA","type":"tls_authorization"}]},"tls_certificates":{"data":[]},"tls_domains":{"data":[{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"},{"id":"integ-test2.go-fastly-2.com","type":"tls_domain"}]},"common_name":{"data":{"id":"integ-test2.go-fastly-2.com","type":"tls_domain"}},"tls_configuration":{"data":{"id":"Em77eV0D2qMAduXPtvRdKg","type":"tls_configuration"}}}},"included":[{"id":"bGl42zjrl7tEqlJz24ZVKw","type":"tls_authorization","attributes":{"challenges":[{"type":"managed-dns","record_type":"CNAME","record_name":"_acme-challenge.integ-test1.go-fastly-1.com","values":["9jwu4ypaom1vthbbvt.fastly-validations.com"]},{"type":"managed-http-cname","record_type":"CNAME","record_name":"integ-test1.go-fastly-1.com","values":["j.sni.global.fastly.net"]},{"type":"managed-http-a","record_type":"A","record_name":"integ-test1.go-fastly-1.com","values":["151.101.2.132","151.101.66.132","151.101.130.132","151.101.194.132"]}],"created_at":"2022-08-22T10:45:38.000Z","state":"blocked","updated_at":"2022-08-22T10:45:39.000Z","warnings":[]},"relationships":{"tls_domain":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"globalsign_email_challenge":{"data":null}}},{"id":"CvewJbxr4LcvYm9p5gYQsA","type":"tls_authorization","attributes":{"challenges":[{"type":"managed-dns","record_type":"CNAME","record_name":"_acme-challenge.integ-test2.go-fastly-2.com","values":["t94s0ykxgurspyegdf.fastly-validations.com"]},{"type":"managed-http-cname","record_type":"CNAME","record_name":"integ-test2.go-fastly-2.com","values":["j.sni.global.fastly.net"]},{"type":"managed-http-a","record_type":"A","record_name":"integ-test2.go-fastly-2.com","values":["151.101.2.132","151.101.66.132","151.101.130.132","151.101.194.132"]}],"created_at":"2022-08-22T10:45:39.000Z","state":"pending","updated_at":"2022-08-22T10:45:39.000Z","warnings":null},"relationships":{"tls_domain":{"data":{"id":"integ-test2.go-fastly-2.com","type":"tls_domain"}},"globalsign_email_challenge":{"data":null}}}]}'
+    body: '{"data":{"id":"mwtZ5xuowgXsyR2nyPjuWw","type":"tls_subscription","attributes":{"certificate_authority":"certainly","created_at":"2024-05-07T12:51:58.000Z","state":"pending","has_active_order":true,"updated_at":"2024-05-07T12:51:59.000Z"},"relationships":{"tls_authorizations":{"data":[{"id":"6zIoBVm633HqlC31oNwcJQ","type":"tls_authorization"},{"id":"B98ZDNS55WAZ5ltYl6wZUQ","type":"tls_authorization"}]},"tls_certificates":{"data":[]},"tls_domains":{"data":[{"id":"integ-test2.go-fastly-2.com","type":"tls_domain"},{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}]},"common_name":{"data":{"id":"integ-test2.go-fastly-2.com","type":"tls_domain"}},"tls_configuration":{"data":{"id":"Em77eV0D2qMAduXPtvRdKg","type":"tls_configuration"}}}},"included":[{"id":"6zIoBVm633HqlC31oNwcJQ","type":"tls_authorization","attributes":{"challenges":[{"type":"managed-dns","record_type":"CNAME","record_name":"_acme-challenge.integ-test2.go-fastly-2.com","values":["t94s0ykxgurspyegdf.fastly-validations.com"]},{"type":"managed-http-cname","record_type":"CNAME","record_name":"integ-test2.go-fastly-2.com","values":["j.sni.global.fastly.net"]},{"type":"managed-http-a","record_type":"A","record_name":"integ-test2.go-fastly-2.com","values":["151.101.2.132","151.101.66.132","151.101.130.132","151.101.194.132"]}],"created_at":"2024-05-07T12:51:59.000Z","state":"pending","updated_at":"2024-05-07T12:51:59.000Z","warnings":null},"relationships":{"tls_domain":{"data":{"id":"integ-test2.go-fastly-2.com","type":"tls_domain"}},"globalsign_email_challenge":{"data":null},"self_managed_http_challenge":{"data":null}}},{"id":"B98ZDNS55WAZ5ltYl6wZUQ","type":"tls_authorization","attributes":{"challenges":[{"type":"managed-dns","record_type":"CNAME","record_name":"_acme-challenge.integ-test1.go-fastly-1.com","values":["9jwu4ypaom1vthbbvt.fastly-validations.com"]},{"type":"managed-http-cname","record_type":"CNAME","record_name":"integ-test1.go-fastly-1.com","values":["j.sni.global.fastly.net"]},{"type":"managed-http-a","record_type":"A","record_name":"integ-test1.go-fastly-1.com","values":["151.101.2.132","151.101.66.132","151.101.130.132","151.101.194.132"]}],"created_at":"2024-05-07T12:51:58.000Z","state":"blocked","updated_at":"2024-05-07T12:51:59.000Z","warnings":[]},"relationships":{"tls_domain":{"data":{"id":"integ-test1.go-fastly-1.com","type":"tls_domain"}},"globalsign_email_challenge":{"data":null},"self_managed_http_challenge":{"data":null}}}]}'
     headers:
       Accept-Ranges:
       - bytes
+      Cache-Control:
+      - no-store
       Content-Length:
-      - "2367"
+      - "2452"
       Content-Type:
       - application/vnd.api+json
       Date:
-      - Mon, 22 Aug 2022 10:45:39 GMT
+      - Tue, 07 May 2024 12:51:59 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Strict-Transport-Security:
       - max-age=31536000
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165139.292135,VS0,VE310
+      - S1715086319.878448,VS0,VE700
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/tls_subscription/version.yaml
+++ b/fastly/fixtures/tls_subscription/version.yaml
@@ -2,19 +2,17 @@
 version: 1
 interactions:
 - request:
-    body: ServiceID=7i6HN3TK9wS159v2gPAZ8A
-    form:
-      ServiceID:
-      - 7i6HN3TK9wS159v2gPAZ8A
+    body: ""
+    form: {}
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.4.3 (+github.com/fastly/go-fastly; go1.16.15)
+      - FastlyGo/9.3.1 (+github.com/fastly/go-fastly; go1.20.14)
     url: https://api.fastly.com/service/7i6HN3TK9wS159v2gPAZ8A/version
     method: POST
   response:
-    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":6}'
+    body: '{"service_id":"7i6HN3TK9wS159v2gPAZ8A","number":3}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +21,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 22 Aug 2022 10:45:36 GMT
+      - Tue, 07 May 2024 12:51:55 GMT
       Fastly-Ratelimit-Remaining:
-      - "4988"
+      - "9997"
       Fastly-Ratelimit-Reset:
-      - "1661166000"
+      - "1715086800"
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -35,15 +37,15 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish, 1.1 varnish
+      - 1.1 varnish
       X-Cache:
-      - MISS, MISS
+      - MISS
       X-Cache-Hits:
-      - 0, 0
+      - "0"
       X-Served-By:
-      - cache-control-slwdc9035-CONTROL-SLWDC, cache-man4139-MAN
+      - cache-lcy-eglc8600089-LCY
       X-Timer:
-      - S1661165136.844133,VS0,VE383
+      - S1715086315.422371,VS0,VE460
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/tls_subscription.go
+++ b/fastly/tls_subscription.go
@@ -25,7 +25,17 @@ type TLSSubscription struct {
 
 // TLSSubscriptionCertificate represents a subscription certificate.
 type TLSSubscriptionCertificate struct {
-	ID string `jsonapi:"primary,tls_certificate"`
+	ID                 string     `jsonapi:"primary,tls_certificate"`
+	CreatedAt          *time.Time `jsonapi:"attr,created_at,iso8601"`
+	IssuedTo           string     `jsonapi:"attr,issued_to"`
+	Issuer             string     `jsonapi:"attr,issuer"`
+	Name               string     `jsonapi:"attr,name"`
+	NotAfter           *time.Time `jsonapi:"attr,not_after,iso8601"`
+	NotBefore          *time.Time `jsonapi:"attr,not_before,iso8601"`
+	Replace            bool       `jsonapi:"attr,replace"`
+	SerialNumber       string     `jsonapi:"attr,serial_number"`
+	SignatureAlgorithm string     `jsonapi:"attr,signature_algorithm"`
+	UpdatedAt          *time.Time `jsonapi:"attr,updated_at,iso8601"`
 }
 
 // TLSAuthorizations gives information needed to verify domain ownership in
@@ -66,7 +76,7 @@ type ListTLSSubscriptionsInput struct {
 	FilterState string
 	// Limit the returned subscriptions to those that include the specific domain.
 	FilterTLSDomainsID string
-	// Include related objects. Optional, comma-separated values. Permitted values: tls_authorizations.
+	// Include related objects. Optional, comma-separated values. Permitted values: tls_authorizations, tls_authorizations.globalsign_email_challenge, tls_authorizations.self_managed_http_challenge, and tls_certificates.
 	Include string
 	// Current page.
 	PageNumber int
@@ -201,7 +211,7 @@ func domainInSlice(haystack []*TLSDomain, needle *TLSDomain) bool {
 type GetTLSSubscriptionInput struct {
 	// ID of the TLS subscription to fetch.
 	ID string
-	// Include related objects. Optional, comma-separated values. Permitted values: tls_authorizations.
+	// Include related objects. Optional, comma-separated values. Permitted values: tls_authorizations, tls_authorizations.globalsign_email_challenge, tls_authorizations.self_managed_http_challenge, and tls_certificates.
 	Include *string
 }
 


### PR DESCRIPTION
This PR exposes additional metadata for a TLS Certificate associated with a TLS Subscription.

> **NOTE:** I've regenerated the test suite fixture files but I've not validated the change beyond that because I don't own the domains defined in the code, and consequently I haven't completed the DNS challenges required to move a TLS Subscription from "pending" to "issued".