### PR TITLE
Add ClonedFrom to PackageMetadata

### DIFF
--- a/fastly/compute_package.go
+++ b/fastly/compute_package.go
@@ -30,6 +30,7 @@ type PackageMetadata struct {
 	Language    *string  `mapstructure:"language"`
 	Name        *string  `mapstructure:"name"`
 	Size        *int64   `mapstructure:"size"`
+	ClonedFrom  *string  `mapstructure:"cloned_from"`
 }
 
 // GetPackageInput is used as input to the GetPackage function.


### PR DESCRIPTION
We recently exposed the source repo for e.g. Compute Starter Kits via
the `cloned_from` key in the PackageMetadata resource in the API. This
makes it programmatically accessible.
