### PR TITLE
add limit_workspaces to user model

### DIFF
--- a/fastly/user.go
+++ b/fastly/user.go
@@ -13,6 +13,7 @@ type User struct {
 	DeletedAt              *time.Time `mapstructure:"deleted_at"`
 	EmailHash              *string    `mapstructure:"email_hash"`
 	LimitServices          *bool      `mapstructure:"limit_services"`
+	LimitWorkspaces        *bool      `mapstructure:"limit_workspaces"`
 	Locked                 *bool      `mapstructure:"locked"`
 	Login                  *string    `mapstructure:"login"`
 	Name                   *string    `mapstructure:"name"`


### PR DESCRIPTION
The Fastly UI needs to read the `limit_workspaces` attribute from the `GET /user/:user_id` response in order to determine whether to display the list of workspaces on the user management screen for each user