### PR TITLE
feat(client): prepend custom user-agent via FASTLY_USER_AGENT env variable to user

### DIFF
--- a/fastly/client.go
+++ b/fastly/client.go
@@ -132,8 +132,8 @@ func NewClientForEndpoint(key, endpoint string) (*Client, error) {
 		client.DebugMode = true
 	}
 
-	if userAgent, ok := os.LookupEnv(UserAgentEnvVar); ok {
-		UserAgent = userAgent
+	if customUserAgent, ok := os.LookupEnv(UserAgentEnvVar); ok {
+		UserAgent = fmt.Sprintf("%s, %s", customUserAgent, UserAgent)
 	}
 
 	return client.init()

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -54,6 +54,10 @@ const DefaultRealtimeStatsEndpoint = "https://rt.fastly.com"
 // JSONMimeType is the MIME type for the JSON data format.
 const JSONMimeType = "application/json"
 
+// UserAgentEnvVar is the name of an environment variable that can be used
+// to change the User-Agent of the http requests
+const UserAgentEnvVar = "FASTLY_USER_AGENT"
+
 // ProjectURL is the url for this library.
 var ProjectURL = "github.com/fastly/go-fastly"
 
@@ -126,6 +130,10 @@ func NewClientForEndpoint(key, endpoint string) (*Client, error) {
 
 	if endpoint, ok := os.LookupEnv(DebugEnvVar); ok && endpoint == "true" {
 		client.DebugMode = true
+	}
+
+	if userAgent, ok := os.LookupEnv(UserAgentEnvVar); ok {
+		UserAgent = userAgent
 	}
 
 	return client.init()


### PR DESCRIPTION
Added the use of a new environment variable that will allow the user to prepend values to the default User-Agent of the http client. 