### PR TITLE
fix: Ensure that all API endpoint URLs are constructed safely.

### DIFF
--- a/fastly/account_events.go
+++ b/fastly/account_events.go
@@ -95,7 +95,8 @@ func (c *Client) GetAPIEvent(i *GetAPIEventInput) (*Event, error) {
 		return nil, ErrMissingEventID
 	}
 
-	path := fmt.Sprintf("/events/%s", i.EventID)
+	path := ToSafeURL("events", i.EventID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/acl.go
+++ b/fastly/acl.go
@@ -2,7 +2,7 @@ package fastly
 
 import (
 	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -34,7 +34,8 @@ func (c *Client) ListACLs(i *ListACLsInput) ([]*ACL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/acl", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "acl")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -67,7 +68,8 @@ func (c *Client) CreateACL(i *CreateACLInput) (*ACL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/acl", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "acl")
+
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -103,7 +105,8 @@ func (c *Client) DeleteACL(i *DeleteACLInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/acl/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "acl", i.Name)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err
@@ -142,7 +145,8 @@ func (c *Client) GetACL(i *GetACLInput) (*ACL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/acl/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "acl", i.Name)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -180,7 +184,8 @@ func (c *Client) UpdateACL(i *UpdateACLInput) (*ACL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/acl/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "acl", i.Name)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -19,8 +19,6 @@ type ACLEntry struct {
 	UpdatedAt *time.Time `mapstructure:"updated_at"`
 }
 
-const aclEntriesPath = "/service/%s/acl/%s/entries"
-
 // GetACLEntriesInput is the input parameter to GetACLEntries function.
 type GetACLEntriesInput struct {
 	// ACLID is an alphanumeric string identifying a ACL (required).
@@ -52,7 +50,7 @@ func (c *Client) GetACLEntries(i *GetACLEntriesInput) *ListPaginator[ACLEntry] {
 	if i.PerPage != nil {
 		input.PerPage = *i.PerPage
 	}
-	path := fmt.Sprintf(aclEntriesPath, i.ServiceID, i.ACLID)
+	path := ToSafeURL("service", i.ServiceID, "acl", i.ACLID, "entries")
 	return NewPaginator[ACLEntry](c, input, path)
 }
 
@@ -115,7 +113,7 @@ func (c *Client) GetACLEntry(i *GetACLEntryInput) (*ACLEntry, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.ServiceID, i.ACLID, i.EntryID)
+	path := ToSafeURL("service", i.ServiceID, "acl", i.ACLID, "entry", i.EntryID)
 
 	resp, err := c.Get(path, nil)
 	if err != nil {
@@ -156,7 +154,7 @@ func (c *Client) CreateACLEntry(i *CreateACLEntryInput) (*ACLEntry, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/acl/%s/entry", i.ServiceID, i.ACLID)
+	path := ToSafeURL("service", i.ServiceID, "acl", i.ACLID, "entry")
 
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
@@ -194,7 +192,7 @@ func (c *Client) DeleteACLEntry(i *DeleteACLEntryInput) error {
 		return ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.ServiceID, i.ACLID, i.EntryID)
+	path := ToSafeURL("service", i.ServiceID, "acl", i.ACLID, "entry", i.EntryID)
 
 	resp, err := c.Delete(path, nil)
 	if err != nil {
@@ -244,7 +242,7 @@ func (c *Client) UpdateACLEntry(i *UpdateACLEntryInput) (*ACLEntry, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/acl/%s/entry/%s", i.ServiceID, i.ACLID, i.EntryID)
+	path := ToSafeURL("service", i.ServiceID, "acl", i.ACLID, "entry", i.EntryID)
 
 	resp, err := c.RequestForm("PATCH", path, i, nil)
 	if err != nil {
@@ -299,7 +297,8 @@ func (c *Client) BatchModifyACLEntries(i *BatchModifyACLEntriesInput) error {
 		return ErrMaxExceededEntries
 	}
 
-	path := fmt.Sprintf(aclEntriesPath, i.ServiceID, i.ACLID)
+	path := ToSafeURL("service", i.ServiceID, "acl", i.ACLID, "entries")
+
 	resp, err := c.PatchJSON(path, i, nil)
 	if err != nil {
 		return err

--- a/fastly/alerts.go
+++ b/fastly/alerts.go
@@ -2,7 +2,6 @@ package fastly
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -151,7 +150,8 @@ func (c *Client) GetAlertDefinition(i *GetAlertDefinitionInput) (*AlertDefinitio
 		return nil, ErrMissingID
 	}
 
-	path := fmt.Sprintf("/alerts/definitions/%s", *i.ID)
+	path := ToSafeURL("alerts", "definitions", *i.ID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -190,7 +190,8 @@ func (c *Client) UpdateAlertDefinition(i *UpdateAlertDefinitionInput) (*AlertDef
 		return nil, ErrMissingID
 	}
 
-	path := fmt.Sprintf("/alerts/definitions/%s", *i.ID)
+	path := ToSafeURL("alerts", "definitions", *i.ID)
+
 	resp, err := c.PutJSON(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -216,7 +217,8 @@ func (c *Client) DeleteAlertDefinition(i *DeleteAlertDefinitionInput) error {
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/alerts/definitions/%s", *i.ID)
+	path := ToSafeURL("alerts", "definitions", *i.ID)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -2,7 +2,7 @@ package fastly
 
 import (
 	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -64,7 +64,8 @@ func (c *Client) ListBackends(i *ListBackendsInput) ([]*Backend, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/backend", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "backend")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -157,7 +158,8 @@ func (c *Client) CreateBackend(i *CreateBackendInput) (*Backend, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/backend", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "backend")
+
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -193,7 +195,8 @@ func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/backend/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "backend", i.Name)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -291,7 +294,8 @@ func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/backend/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "backend", i.Name)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -327,7 +331,8 @@ func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/backend/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "backend", i.Name)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/billing.go
+++ b/fastly/billing.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -68,7 +69,8 @@ func (c *Client) GetBilling(i *GetBillingInput) (*Billing, error) {
 		return nil, ErrMissingMonth
 	}
 
-	path := fmt.Sprintf("/billing/year/%d/month/%02d", i.Year, i.Month)
+	path := ToSafeURL("billing", "year", strconv.Itoa(int(i.Year)), "month", fmt.Sprintf("%02d", i.Month))
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/compute_package.go
+++ b/fastly/compute_package.go
@@ -3,8 +3,8 @@ package fastly
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
+	"strconv"
 	"time"
 )
 
@@ -107,7 +107,7 @@ func MakePackagePath(serviceID string, serviceVersion int) (string, error) {
 	if serviceVersion == 0 {
 		return "", ErrMissingServiceVersion
 	}
-	return fmt.Sprintf("/service/%s/version/%d/package", serviceID, serviceVersion), nil
+	return ToSafeURL("service", serviceID, "version", strconv.Itoa(serviceVersion), "package"), nil
 }
 
 // PopulatePackage encapsulates the decoding of returned package data.

--- a/fastly/config_store.go
+++ b/fastly/config_store.go
@@ -2,7 +2,6 @@ package fastly
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 	"time"
 )
@@ -68,7 +67,8 @@ func (c *Client) DeleteConfigStore(i *DeleteConfigStoreInput) error {
 		return ErrMissingStoreID
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s", i.StoreID)
+	path := ToSafeURL("resources", "stores", "config", i.StoreID)
+
 	resp, err := c.Delete(path, &RequestOptions{
 		Headers: map[string]string{
 			"Accept": "application/json",
@@ -97,7 +97,8 @@ func (c *Client) GetConfigStore(i *GetConfigStoreInput) (*ConfigStore, error) {
 		return nil, ErrMissingStoreID
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s", i.StoreID)
+	path := ToSafeURL("resources", "stores", "config", i.StoreID)
+
 	resp, err := c.Get(path, &RequestOptions{
 		Headers: map[string]string{
 			"Accept": "application/json",
@@ -129,7 +130,8 @@ func (c *Client) GetConfigStoreMetadata(i *GetConfigStoreMetadataInput) (*Config
 		return nil, ErrMissingStoreID
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s/info", i.StoreID)
+	path := ToSafeURL("resources", "stores", "config", i.StoreID, "info")
+
 	resp, err := c.Get(path, &RequestOptions{
 		Headers: map[string]string{
 			"Accept": "application/json",
@@ -200,7 +202,8 @@ func (c *Client) ListConfigStoreServices(i *ListConfigStoreServicesInput) ([]*Se
 		return nil, ErrMissingStoreID
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s/services", i.StoreID)
+	path := ToSafeURL("resources", "stores", "config", i.StoreID, "services")
+
 	resp, err := c.Get(path, &RequestOptions{
 		Headers: map[string]string{
 			"Accept": "application/json",
@@ -235,7 +238,8 @@ func (c *Client) UpdateConfigStore(i *UpdateConfigStoreInput) (*ConfigStore, err
 		return nil, ErrMissingStoreID
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s", i.StoreID)
+	path := ToSafeURL("resources", "stores", "config", i.StoreID)
+
 	resp, err := c.PutForm(path, i, &RequestOptions{
 		Headers: map[string]string{
 			// PutForm adds the appropriate Content-Type header.

--- a/fastly/config_store_item.go
+++ b/fastly/config_store_item.go
@@ -2,9 +2,7 @@ package fastly
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/url"
 	"sort"
 	"time"
 )
@@ -38,7 +36,8 @@ func (c *Client) CreateConfigStoreItem(i *CreateConfigStoreItemInput) (*ConfigSt
 		return nil, ErrMissingStoreID
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s/item", i.StoreID)
+	path := ToSafeURL("resources", "stores", "config", i.StoreID, "item")
+
 	resp, err := c.PostForm(path, i, &RequestOptions{
 		Headers: map[string]string{
 			// PostForm adds the appropriate Content-Type header.
@@ -76,7 +75,8 @@ func (c *Client) DeleteConfigStoreItem(i *DeleteConfigStoreItemInput) error {
 		return ErrMissingKey
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s/item/%s", i.StoreID, url.PathEscape(i.Key))
+	path := ToSafeURL("resources", "stores", "config", i.StoreID, "item", i.Key)
+
 	resp, err := c.Delete(path, &RequestOptions{
 		Headers: map[string]string{
 			"Accept": "application/json",
@@ -110,7 +110,8 @@ func (c *Client) GetConfigStoreItem(i *GetConfigStoreItemInput) (*ConfigStoreIte
 		return nil, ErrMissingKey
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s/item/%s", i.StoreID, url.PathEscape(i.Key))
+	path := ToSafeURL("resources", "stores", "config", i.StoreID, "item", i.Key)
+
 	resp, err := c.Get(path, &RequestOptions{
 		Headers: map[string]string{
 			"Accept": "application/json",
@@ -142,7 +143,8 @@ func (c *Client) ListConfigStoreItems(i *ListConfigStoreItemsInput) ([]*ConfigSt
 		return nil, ErrMissingStoreID
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s/items", i.StoreID)
+	path := ToSafeURL("resources", "stores", "config", i.StoreID, "items")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -181,7 +183,7 @@ func (c *Client) UpdateConfigStoreItem(i *UpdateConfigStoreItemInput) (*ConfigSt
 		return nil, ErrMissingKey
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s/item/%s", i.StoreID, url.PathEscape(i.Key))
+	path := ToSafeURL("resources", "stores", "config", i.StoreID, "item", i.Key)
 
 	var httpMethod string
 	if i.Upsert {
@@ -240,7 +242,8 @@ func (c *Client) BatchModifyConfigStoreItems(i *BatchModifyConfigStoreItemsInput
 		return ErrMaxExceededItems
 	}
 
-	path := fmt.Sprintf("/resources/stores/config/%s/items", i.StoreID)
+	path := ToSafeURL("resources", "stores", "config", i.StoreID, "items")
+
 	resp, err := c.PatchJSON(path, i, nil)
 	if err != nil {
 		return err

--- a/fastly/dictionary.go
+++ b/fastly/dictionary.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -35,7 +34,8 @@ func (c *Client) ListDictionaries(i *ListDictionariesInput) ([]*Dictionary, erro
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/dictionary", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "dictionary")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,8 @@ func (c *Client) CreateDictionary(i *CreateDictionaryInput) (*Dictionary, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/dictionary", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "dictionary")
+
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -106,7 +107,8 @@ func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "dictionary", i.Name)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -146,7 +148,8 @@ func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "dictionary", i.Name)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -182,7 +185,8 @@ func (c *Client) DeleteDictionary(i *DeleteDictionaryInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "dictionary", i.Name)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/dictionary_info.go
+++ b/fastly/dictionary_info.go
@@ -1,7 +1,7 @@
 package fastly
 
 import (
-	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -37,7 +37,8 @@ func (c *Client) GetDictionaryInfo(i *GetDictionaryInfoInput) (*DictionaryInfo, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s/info", i.ServiceID, i.ServiceVersion, i.DictionaryID)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "dictionary", i.DictionaryID, "info")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -2,11 +2,8 @@ package fastly
 
 import (
 	"fmt"
-	"net/url"
 	"time"
 )
-
-const dictionaryItemsPath = "/service/%s/dictionary/%s/items"
 
 // DictionaryItem represents a dictionary item response from the Fastly API.
 type DictionaryItem struct {
@@ -50,7 +47,9 @@ func (c *Client) GetDictionaryItems(i *GetDictionaryItemsInput) *ListPaginator[D
 	if i.PerPage != nil {
 		input.PerPage = *i.PerPage
 	}
-	path := fmt.Sprintf(dictionaryItemsPath, i.ServiceID, i.DictionaryID)
+
+	path := ToSafeURL("service", i.ServiceID, "dictionary", i.DictionaryID, "items")
+
 	return NewPaginator[DictionaryItem](c, input, path)
 }
 
@@ -113,7 +112,8 @@ func (c *Client) CreateDictionaryItem(i *CreateDictionaryItemInput) (*Dictionary
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/dictionary/%s/item", i.ServiceID, i.DictionaryID)
+	path := ToSafeURL("service", i.ServiceID, "dictionary", i.DictionaryID, "item")
+
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -166,7 +166,8 @@ func (c *Client) GetDictionaryItem(i *GetDictionaryItemInput) (*DictionaryItem, 
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/dictionary/%s/item/%s", i.ServiceID, i.DictionaryID, url.PathEscape(i.ItemKey))
+	path := ToSafeURL("service", i.ServiceID, "dictionary", i.DictionaryID, "item", i.ItemKey)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -204,7 +205,8 @@ func (c *Client) UpdateDictionaryItem(i *UpdateDictionaryItemInput) (*Dictionary
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/dictionary/%s/item/%s", i.ServiceID, i.DictionaryID, url.PathEscape(i.ItemKey))
+	path := ToSafeURL("service", i.ServiceID, "dictionary", i.DictionaryID, "item", i.ItemKey)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +253,8 @@ func (c *Client) BatchModifyDictionaryItems(i *BatchModifyDictionaryItemsInput) 
 		return ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf(dictionaryItemsPath, i.ServiceID, i.DictionaryID)
+	path := ToSafeURL("service", i.ServiceID, "dictionary", i.DictionaryID, "items")
+
 	resp, err := c.PatchJSON(path, i, nil)
 	if err != nil {
 		return err
@@ -284,7 +287,8 @@ func (c *Client) DeleteDictionaryItem(i *DeleteDictionaryItemInput) error {
 		return ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/dictionary/%s/item/%s", i.ServiceID, i.DictionaryID, url.PathEscape(i.ItemKey))
+	path := ToSafeURL("service", i.ServiceID, "dictionary", i.DictionaryID, "item", i.ItemKey)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/diff.go
+++ b/fastly/diff.go
@@ -1,6 +1,6 @@
 package fastly
 
-import "fmt"
+import "strconv"
 
 // Diff represents a diff of two versions as a response from the Fastly API.
 type Diff struct {
@@ -40,7 +40,8 @@ func (c *Client) GetDiff(i *GetDiffInput) (*Diff, error) {
 		return nil, ErrMissingTo
 	}
 
-	path := fmt.Sprintf("service/%s/diff/from/%d/to/%d", i.ServiceID, i.From, i.To)
+	path := ToSafeURL("service", i.ServiceID, "diff", "from", strconv.Itoa(i.From), "to", strconv.Itoa(i.To))
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/domain.go
+++ b/fastly/domain.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -36,7 +36,8 @@ func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/domain", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "domain")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -71,7 +72,8 @@ func (c *Client) CreateDomain(i *CreateDomainInput) (*Domain, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/domain", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "domain")
+
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -107,7 +109,8 @@ func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "domain", i.Name)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +150,8 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "domain", i.Name)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -183,7 +187,8 @@ func (c *Client) DeleteDomain(i *DeleteDomainInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "domain", i.Name)
+
 	_, err := c.Delete(path, nil)
 	return err
 }
@@ -210,7 +215,8 @@ func (c *Client) ValidateDomain(i *ValidateDomainInput) (*DomainValidationResult
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/domain/%s/check", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "domain", i.Name, "check")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -294,7 +300,8 @@ func (c *Client) ValidateAllDomains(i *ValidateAllDomainsInput) (results []*Doma
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/domain/check_all", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "domain", "check_all")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/health_check.go
+++ b/fastly/health_check.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -45,7 +44,8 @@ func (c *Client) ListHealthChecks(i *ListHealthChecksInput) ([]*HealthCheck, err
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/healthcheck", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "healthcheck")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -105,7 +105,8 @@ func (c *Client) CreateHealthCheck(i *CreateHealthCheckInput) (*HealthCheck, err
 	ro := new(RequestOptions)
 	ro.HealthCheckHeaders = true
 
-	path := fmt.Sprintf("/service/%s/version/%d/healthcheck", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "healthcheck")
+
 	resp, err := c.PostForm(path, i, ro)
 	if err != nil {
 		return nil, err
@@ -141,7 +142,8 @@ func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "healthcheck", i.Name)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +208,8 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 	ro := new(RequestOptions)
 	ro.HealthCheckHeaders = true
 
-	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "healthcheck", i.Name)
+
 	resp, err := c.PutForm(path, i, ro)
 	if err != nil {
 		return nil, err
@@ -242,7 +245,8 @@ func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "healthcheck", i.Name)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/helpers.go
+++ b/fastly/helpers.go
@@ -36,12 +36,16 @@ func NullString(v string) *string {
 
 // ToSafeURL produces a safe (no path traversal, no unsafe characters) URL
 // from the path components passed in.
+//
+// Unlike the normal behavior of url.JoinPath, this function skips
+// ".." components, ensuring that user-provided components cannot
+// remove code-provided components from the resulting path.
 func ToSafeURL(unsafeComponents ...string) string {
 	safeComponents := make([]string, len(unsafeComponents))
 
 	for i := range unsafeComponents {
-		if component := unsafeComponents[i]; component != ".." {
-			safeComponents[i] = url.PathEscape(component)
+		if unsafeComponents[i] != ".." {
+			safeComponents[i] = url.PathEscape(unsafeComponents[i])
 		}
 	}
 

--- a/fastly/helpers.go
+++ b/fastly/helpers.go
@@ -1,5 +1,7 @@
 package fastly
 
+import "net/url"
+
 // MultiConstraint is a generic constraint for ToPointer/ToValue.
 type MultiConstraint interface {
 	[]string | ~string | ~int | int32 | ~int64 | uint | uint8 | uint32 | uint64 | float64 | ~bool
@@ -30,4 +32,23 @@ func NullString(v string) *string {
 		return nil
 	}
 	return &v
+}
+
+// ToSafeURL produces a safe (no path traversal, no unsafe characters) URL
+// from the path components passed in.
+func ToSafeURL(components ...string) string {
+	for idx, component := range components {
+		if component == ".." {
+			components[idx] = ""
+		} else {
+			components[idx] = url.PathEscape(component)
+		}
+	}
+
+	// it is safe to ignore the error returned from JoinPath
+	// because the only time it will be non-nil is if parsing
+	// the base path fails, but that will not fail since it is
+	// a constant "/" string
+	result, _ := url.JoinPath("/", components...)
+	return result
 }

--- a/fastly/helpers.go
+++ b/fastly/helpers.go
@@ -36,19 +36,17 @@ func NullString(v string) *string {
 
 // ToSafeURL produces a safe (no path traversal, no unsafe characters) URL
 // from the path components passed in.
-func ToSafeURL(components ...string) string {
-	for idx, component := range components {
-		if component == ".." {
-			components[idx] = ""
-		} else {
-			components[idx] = url.PathEscape(component)
-		}
+func ToSafeURL(unsafeComponents ...string) string {
+	safeComponents := make([]string, len(unsafeComponents))
+
+	for i := range unsafeComponents {
+		safeComponents[i] = url.PathEscape(unsafeComponents[i])
 	}
 
 	// it is safe to ignore the error returned from JoinPath
 	// because the only time it will be non-nil is if parsing
 	// the base path fails, but that will not fail since it is
 	// a constant "/" string
-	result, _ := url.JoinPath("/", components...)
+	result, _ := url.JoinPath("/", safeComponents...)
 	return result
 }

--- a/fastly/helpers.go
+++ b/fastly/helpers.go
@@ -40,7 +40,9 @@ func ToSafeURL(unsafeComponents ...string) string {
 	safeComponents := make([]string, len(unsafeComponents))
 
 	for i := range unsafeComponents {
-		safeComponents[i] = url.PathEscape(unsafeComponents[i])
+		if component := unsafeComponents[i]; component != ".." {
+			safeComponents[i] = url.PathEscape(component)
+		}
 	}
 
 	// it is safe to ignore the error returned from JoinPath

--- a/fastly/helpers_test.go
+++ b/fastly/helpers_test.go
@@ -1,0 +1,59 @@
+package fastly
+
+import (
+	"testing"
+)
+
+func TestToSafeURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normal", func(t *testing.T) {
+		path := ToSafeURL("services", "1234", "detail")
+
+		expected := "/services/1234/detail"
+
+		if path != expected {
+			t.Errorf("expected \n\n%q\n\n to be \n\n%q\n\n", path, expected)
+		}
+	})
+
+	t.Run("suppress '.'", func(t *testing.T) {
+		path := ToSafeURL("services", ".", "detail")
+
+		expected := "/services/detail"
+
+		if path != expected {
+			t.Errorf("expected \n\n%q\n\n to be \n\n%q\n\n", path, expected)
+		}
+	})
+
+	t.Run("suppress '..'", func(t *testing.T) {
+		path := ToSafeURL("services", "..", "detail")
+
+		expected := "/detail"
+
+		if path != expected {
+			t.Errorf("expected \n\n%q\n\n to be \n\n%q\n\n", path, expected)
+		}
+	})
+
+	t.Run("encode '/'", func(t *testing.T) {
+		path := ToSafeURL("services", "1234/detail")
+
+		expected := "/services/1234%2Fdetail"
+
+		if path != expected {
+			t.Errorf("expected \n\n%q\n\n to be \n\n%q\n\n", path, expected)
+		}
+	})
+
+	t.Run("suppress empty components", func(t *testing.T) {
+		path := ToSafeURL("services", "1234", "", "detail")
+
+		expected := "/services/1234/detail"
+
+		if path != expected {
+			t.Errorf("expected \n\n%q\n\n to be \n\n%q\n\n", path, expected)
+		}
+	})
+}

--- a/fastly/helpers_test.go
+++ b/fastly/helpers_test.go
@@ -30,7 +30,7 @@ func TestToSafeURL(t *testing.T) {
 	t.Run("suppress '..'", func(t *testing.T) {
 		path := ToSafeURL("services", "..", "detail")
 
-		expected := "/detail"
+		expected := "/services/detail"
 
 		if path != expected {
 			t.Errorf("expected \n\n%q\n\n to be \n\n%q\n\n", path, expected)

--- a/fastly/image_optimizer_default_settings.go
+++ b/fastly/image_optimizer_default_settings.go
@@ -2,7 +2,7 @@ package fastly
 
 import (
 	"encoding/json"
-	"fmt"
+	"strconv"
 )
 
 // ImageOptimizerResizeFilter is a base for the different ImageOptimizerResizeFilter variants.
@@ -132,7 +132,7 @@ func (c *Client) GetImageOptimizerDefaultSettings(i *GetImageOptimizerDefaultSet
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/image_optimizer_default_settings", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "image_optimizer_default_settings")
 
 	resp, err := c.Get(path, nil)
 	if err != nil {
@@ -170,7 +170,7 @@ func (c *Client) UpdateImageOptimizerDefaultSettings(i *UpdateImageOptimizerDefa
 		return nil, ErrMissingImageOptimizerDefaultSetting
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/image_optimizer_default_settings", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "image_optimizer_default_settings")
 
 	resp, err := c.PatchJSON(path, i, nil)
 	if err != nil {

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -178,7 +178,8 @@ func (c *Client) GetKVStore(i *GetKVStoreInput) (*KVStore, error) {
 		return nil, ErrMissingStoreID
 	}
 
-	path := "/resources/stores/kv/" + i.StoreID
+	path := ToSafeURL("resources", "stores", "kv", i.StoreID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -204,7 +205,8 @@ func (c *Client) DeleteKVStore(i *DeleteKVStoreInput) error {
 		return ErrMissingStoreID
 	}
 
-	path := "/resources/stores/kv/" + i.StoreID
+	path := ToSafeURL("resources", "stores", "kv", i.StoreID)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err
@@ -282,7 +284,8 @@ func (c *Client) ListKVStoreKeys(i *ListKVStoreKeysInput) (*ListKVStoreKeysRespo
 		return nil, ErrMissingStoreID
 	}
 
-	path := "/resources/stores/kv/" + i.StoreID + "/keys"
+	path := ToSafeURL("resources", "stores", "kv", i.StoreID, "keys")
+
 	ro := new(RequestOptions)
 	ro.Params = i.formatFilters()
 
@@ -369,7 +372,8 @@ func (c *Client) GetKVStoreKey(i *GetKVStoreKeyInput) (string, error) {
 		return "", ErrMissingKey
 	}
 
-	path := "/resources/stores/kv/" + i.StoreID + "/keys/" + i.Key
+	path := ToSafeURL("resources", "stores", "kv", i.StoreID, "keys", i.Key)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return "", err
@@ -451,7 +455,8 @@ func (c *Client) InsertKVStoreKey(i *InsertKVStoreKeyInput) error {
 		ro.BodyLength = int64(len(i.Value))
 	}
 
-	path := "/resources/stores/kv/" + i.StoreID + "/keys/" + i.Key
+	path := ToSafeURL("resources", "stores", "kv", i.StoreID, "keys", i.Key)
+
 	resp, err := c.Put(path, &ro)
 	if err != nil {
 		return err
@@ -483,7 +488,8 @@ func (c *Client) DeleteKVStoreKey(i *DeleteKVStoreKeyInput) error {
 		Parallel: true, // This will allow the Fastly CLI to make bulk deletes.
 	}
 
-	path := "/resources/stores/kv/" + i.StoreID + "/keys/" + i.Key
+	path := ToSafeURL("resources", "stores", "kv", i.StoreID, "keys", i.Key)
+
 	resp, err := c.Delete(path, &ro)
 	if err != nil {
 		return err
@@ -514,7 +520,8 @@ func (c *Client) BatchModifyKVStoreKey(i *BatchModifyKVStoreKeyInput) error {
 		return ErrMissingStoreID
 	}
 
-	path := "/resources/stores/kv/" + i.StoreID + "/batch"
+	path := ToSafeURL("resources", "stores", "kv", i.StoreID, "batch")
+
 	resp, err := c.Put(path, &RequestOptions{
 		Body: bufio.NewReader(i.Body),
 		Headers: map[string]string{

--- a/fastly/load_balance_pool.go
+++ b/fastly/load_balance_pool.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -68,7 +67,8 @@ func (c *Client) ListPools(i *ListPoolsInput) ([]*Pool, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/pool", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "pool")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func (c *Client) CreatePool(i *CreatePoolInput) (*Pool, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/pool", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "pool")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -177,7 +177,8 @@ func (c *Client) GetPool(i *GetPoolInput) (*Pool, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/pool/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "pool", i.Name)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -255,7 +256,8 @@ func (c *Client) UpdatePool(i *UpdatePoolInput) (*Pool, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/pool/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "pool", i.Name)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -291,7 +293,8 @@ func (c *Client) DeletePool(i *DeletePoolInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/pool/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "pool", i.Name)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/load_balancer_director.go
+++ b/fastly/load_balancer_director.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -57,7 +56,7 @@ func (c *Client) ListDirectors(i *ListDirectorsInput) ([]*Director, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/director", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "director")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -100,7 +99,7 @@ func (c *Client) CreateDirector(i *CreateDirectorInput) (*Director, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/director", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "director")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -136,7 +135,7 @@ func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/director/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "director", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -184,7 +183,7 @@ func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/director/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "director", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -220,7 +219,7 @@ func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/director/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "director", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/load_balancer_director_backend.go
+++ b/fastly/load_balancer_director_backend.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -46,8 +45,7 @@ func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*Director
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
-		i.ServiceID, i.ServiceVersion, url.PathEscape(i.Director), url.PathEscape(i.Backend))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "director", i.Director, "backend", i.Backend)
 
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
@@ -89,8 +87,7 @@ func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBacken
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
-		i.ServiceID, i.ServiceVersion, url.PathEscape(i.Director), url.PathEscape(i.Backend))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "director", i.Director, "backend", i.Backend)
 
 	resp, err := c.Get(path, nil)
 	if err != nil {
@@ -132,8 +129,7 @@ func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
-		i.ServiceID, i.ServiceVersion, url.PathEscape(i.Director), url.PathEscape(i.Backend))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "director", i.Director, "backend", i.Backend)
 
 	resp, err := c.Delete(path, nil)
 	if err != nil {

--- a/fastly/load_balancer_server.go
+++ b/fastly/load_balancer_server.go
@@ -1,7 +1,6 @@
 package fastly
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -39,7 +38,8 @@ func (c *Client) ListServers(i *ListServersInput) ([]*Server, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/pool/%s/servers", i.ServiceID, i.PoolID)
+	path := ToSafeURL("service", i.ServiceID, "pool", i.PoolID, "servers")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -85,7 +85,8 @@ func (c *Client) CreateServer(i *CreateServerInput) (*Server, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/pool/%s/server", i.ServiceID, i.PoolID)
+	path := ToSafeURL("service", i.ServiceID, "pool", i.PoolID, "server")
+
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -121,7 +122,8 @@ func (c *Client) GetServer(i *GetServerInput) (*Server, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/pool/%s/server/%s", i.ServiceID, i.PoolID, i.Server)
+	path := ToSafeURL("service", i.ServiceID, "pool", i.PoolID, "server", i.Server)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -171,7 +173,8 @@ func (c *Client) UpdateServer(i *UpdateServerInput) (*Server, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/pool/%s/server/%s", i.ServiceID, i.PoolID, i.Server)
+	path := ToSafeURL("service", i.ServiceID, "pool", i.PoolID, "server", i.Server)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -207,7 +210,8 @@ func (c *Client) DeleteServer(i *DeleteServerInput) error {
 		return ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/pool/%s/server/%s", i.ServiceID, i.PoolID, i.Server)
+	path := ToSafeURL("service", i.ServiceID, "pool", i.PoolID, "server", i.Server)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_bigquery.go
+++ b/fastly/logging_bigquery.go
@@ -2,7 +2,7 @@ package fastly
 
 import (
 	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -44,7 +44,7 @@ func (c *Client) ListBigQueries(i *ListBigQueriesInput) ([]*BigQuery, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/bigquery", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "bigquery")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (c *Client) CreateBigQuery(i *CreateBigQueryInput) (*BigQuery, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/bigquery", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "bigquery")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ func (c *Client) GetBigQuery(i *GetBigQueryInput) (*BigQuery, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/bigquery/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "bigquery", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ func (c *Client) UpdateBigQuery(i *UpdateBigQueryInput) (*BigQuery, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/bigquery/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "bigquery", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -231,7 +231,7 @@ func (c *Client) DeleteBigQuery(i *DeleteBigQueryInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/bigquery/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "bigquery", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_blobstorage.go
+++ b/fastly/logging_blobstorage.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (c *Client) ListBlobStorages(i *ListBlobStoragesInput) ([]*BlobStorage, err
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/azureblob", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "azureblob")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *Client) CreateBlobStorage(i *CreateBlobStorageInput) (*BlobStorage, err
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/azureblob", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "azureblob")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +146,7 @@ func (c *Client) GetBlobStorage(i *GetBlobStorageInput) (*BlobStorage, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/azureblob/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "azureblob", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +214,7 @@ func (c *Client) UpdateBlobStorage(i *UpdateBlobStorageInput) (*BlobStorage, err
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/azureblob/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "azureblob", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +250,7 @@ func (c *Client) DeleteBlobStorage(i *DeleteBlobStorageInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/azureblob/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "azureblob", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_cloudfiles.go
+++ b/fastly/logging_cloudfiles.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (c *Client) ListCloudfiles(i *ListCloudfilesInput) ([]*Cloudfiles, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/cloudfiles", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "cloudfiles")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *Client) CreateCloudfiles(i *CreateCloudfilesInput) (*Cloudfiles, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/cloudfiles", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "cloudfiles")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +146,7 @@ func (c *Client) GetCloudfiles(i *GetCloudfilesInput) (*Cloudfiles, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/cloudfiles/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "cloudfiles", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +214,7 @@ func (c *Client) UpdateCloudfiles(i *UpdateCloudfilesInput) (*Cloudfiles, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/cloudfiles/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "cloudfiles", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +250,7 @@ func (c *Client) DeleteCloudfiles(i *DeleteCloudfilesInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/cloudfiles/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "cloudfiles", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_datadog.go
+++ b/fastly/logging_datadog.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -39,7 +38,7 @@ func (c *Client) ListDatadog(i *ListDatadogInput) ([]*Datadog, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/datadog", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "datadog")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -84,7 +83,7 @@ func (c *Client) CreateDatadog(i *CreateDatadogInput) (*Datadog, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/datadog", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "datadog")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +119,7 @@ func (c *Client) GetDatadog(i *GetDatadogInput) (*Datadog, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/datadog/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "datadog", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -170,7 +169,7 @@ func (c *Client) UpdateDatadog(i *UpdateDatadogInput) (*Datadog, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/datadog/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "datadog", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +205,7 @@ func (c *Client) DeleteDatadog(i *DeleteDatadogInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/datadog/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "datadog", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_digitalocean.go
+++ b/fastly/logging_digitalocean.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (c *Client) ListDigitalOceans(i *ListDigitalOceansInput) ([]*DigitalOcean, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/digitalocean", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "digitalocean")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *Client) CreateDigitalOcean(i *CreateDigitalOceanInput) (*DigitalOcean, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/digitalocean", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "digitalocean")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +146,7 @@ func (c *Client) GetDigitalOcean(i *GetDigitalOceanInput) (*DigitalOcean, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/digitalocean/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "digitalocean", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +214,7 @@ func (c *Client) UpdateDigitalOcean(i *UpdateDigitalOceanInput) (*DigitalOcean, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/digitalocean/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "digitalocean", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +250,7 @@ func (c *Client) DeleteDigitalOcean(i *DeleteDigitalOceanInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/digitalocean/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "digitalocean", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_elasticsearch.go
+++ b/fastly/logging_elasticsearch.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (c *Client) ListElasticsearch(i *ListElasticsearchInput) ([]*Elasticsearch,
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/elasticsearch", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "elasticsearch")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *Client) CreateElasticsearch(i *CreateElasticsearchInput) (*Elasticsearc
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/elasticsearch", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "elasticsearch")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +146,7 @@ func (c *Client) GetElasticsearch(i *GetElasticsearchInput) (*Elasticsearch, err
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/elasticsearch/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "elasticsearch", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -217,7 +216,7 @@ func (c *Client) UpdateElasticsearch(i *UpdateElasticsearchInput) (*Elasticsearc
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/elasticsearch/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "elasticsearch", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -254,7 +253,7 @@ func (c *Client) DeleteElasticsearch(i *DeleteElasticsearchInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/elasticsearch/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "elasticsearch", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_ftp.go
+++ b/fastly/logging_ftp.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (c *Client) ListFTPs(i *ListFTPsInput) ([]*FTP, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "ftp")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *Client) CreateFTP(i *CreateFTPInput) (*FTP, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "ftp")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +146,7 @@ func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "ftp", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +214,7 @@ func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "ftp", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +250,7 @@ func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "ftp", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_gcs.go
+++ b/fastly/logging_gcs.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (c *Client) ListGCSs(i *ListGCSsInput) ([]*GCS, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "gcs")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *Client) CreateGCS(i *CreateGCSInput) (*GCS, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "gcs")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +146,7 @@ func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "gcs", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +214,7 @@ func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "gcs", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +250,7 @@ func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "gcs", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_heroku.go
+++ b/fastly/logging_heroku.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -39,7 +38,7 @@ func (c *Client) ListHerokus(i *ListHerokusInput) ([]*Heroku, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/heroku", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "heroku")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -84,7 +83,7 @@ func (c *Client) CreateHeroku(i *CreateHerokuInput) (*Heroku, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/heroku", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "heroku")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +119,7 @@ func (c *Client) GetHeroku(i *GetHerokuInput) (*Heroku, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/heroku/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "heroku", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -170,7 +169,7 @@ func (c *Client) UpdateHeroku(i *UpdateHerokuInput) (*Heroku, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/heroku/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "heroku", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +205,7 @@ func (c *Client) DeleteHeroku(i *DeleteHerokuInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/heroku/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "heroku", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_honeycomb.go
+++ b/fastly/logging_honeycomb.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -39,7 +38,7 @@ func (c *Client) ListHoneycombs(i *ListHoneycombsInput) ([]*Honeycomb, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "honeycomb")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -84,7 +83,7 @@ func (c *Client) CreateHoneycomb(i *CreateHoneycombInput) (*Honeycomb, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "honeycomb")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +119,7 @@ func (c *Client) GetHoneycomb(i *GetHoneycombInput) (*Honeycomb, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "honeycomb", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -170,7 +169,7 @@ func (c *Client) UpdateHoneycomb(i *UpdateHoneycombInput) (*Honeycomb, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "honeycomb", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +205,7 @@ func (c *Client) DeleteHoneycomb(i *DeleteHoneycombInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/honeycomb/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "honeycomb", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_https.go
+++ b/fastly/logging_https.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -50,7 +49,7 @@ func (c *Client) ListHTTPS(i *ListHTTPSInput) ([]*HTTPS, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/https", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "https")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -117,7 +116,7 @@ func (c *Client) CreateHTTPS(i *CreateHTTPSInput) (*HTTPS, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/https", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "https")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -153,7 +152,7 @@ func (c *Client) GetHTTPS(i *GetHTTPSInput) (*HTTPS, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/https/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "https", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -226,7 +225,7 @@ func (c *Client) UpdateHTTPS(i *UpdateHTTPSInput) (*HTTPS, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/https/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "https", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -262,7 +261,7 @@ func (c *Client) DeleteHTTPS(i *DeleteHTTPSInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/https/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "https", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_kafka.go
+++ b/fastly/logging_kafka.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -51,7 +50,7 @@ func (c *Client) ListKafkas(i *ListKafkasInput) ([]*Kafka, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kafka", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kafka")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +119,7 @@ func (c *Client) CreateKafka(i *CreateKafkaInput) (*Kafka, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kafka", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kafka")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -156,7 +155,7 @@ func (c *Client) GetKafka(i *GetKafkaInput) (*Kafka, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kafka/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kafka", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -230,7 +229,7 @@ func (c *Client) UpdateKafka(i *UpdateKafkaInput) (*Kafka, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kafka/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kafka", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -266,7 +265,7 @@ func (c *Client) DeleteKafka(i *DeleteKafkaInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kafka/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kafka", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_kinesis.go
+++ b/fastly/logging_kinesis.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -42,7 +41,7 @@ func (c *Client) ListKinesis(i *ListKinesisInput) ([]*Kinesis, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kinesis", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kinesis")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -93,7 +92,7 @@ func (c *Client) CreateKinesis(i *CreateKinesisInput) (*Kinesis, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kinesis", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kinesis")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -129,7 +128,7 @@ func (c *Client) GetKinesis(i *GetKinesisInput) (*Kinesis, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kinesis/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kinesis", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -185,7 +184,7 @@ func (c *Client) UpdateKinesis(i *UpdateKinesisInput) (*Kinesis, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kinesis/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kinesis", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -221,7 +220,7 @@ func (c *Client) DeleteKinesis(i *DeleteKinesisInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/kinesis/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "kinesis", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_logentries.go
+++ b/fastly/logging_logentries.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -41,7 +40,7 @@ func (c *Client) ListLogentries(i *ListLogentriesInput) ([]*Logentries, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logentries")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -90,7 +89,7 @@ func (c *Client) CreateLogentries(i *CreateLogentriesInput) (*Logentries, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logentries")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -126,7 +125,7 @@ func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logentries", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -180,7 +179,7 @@ func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logentries", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -216,7 +215,7 @@ func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logentries", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_loggly.go
+++ b/fastly/logging_loggly.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -38,7 +37,7 @@ func (c *Client) ListLoggly(i *ListLogglyInput) ([]*Loggly, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/loggly", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "loggly")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -81,7 +80,7 @@ func (c *Client) CreateLoggly(i *CreateLogglyInput) (*Loggly, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/loggly", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "loggly")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -117,7 +116,7 @@ func (c *Client) GetLoggly(i *GetLogglyInput) (*Loggly, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/loggly/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "loggly", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -165,7 +164,7 @@ func (c *Client) UpdateLoggly(i *UpdateLogglyInput) (*Loggly, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/loggly/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "loggly", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -201,7 +200,7 @@ func (c *Client) DeleteLoggly(i *DeleteLogglyInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/loggly/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "loggly", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_logshuttle.go
+++ b/fastly/logging_logshuttle.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -39,7 +38,7 @@ func (c *Client) ListLogshuttles(i *ListLogshuttlesInput) ([]*Logshuttle, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logshuttle")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -84,7 +83,7 @@ func (c *Client) CreateLogshuttle(i *CreateLogshuttleInput) (*Logshuttle, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logshuttle")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +119,7 @@ func (c *Client) GetLogshuttle(i *GetLogshuttleInput) (*Logshuttle, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logshuttle", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -170,7 +169,7 @@ func (c *Client) UpdateLogshuttle(i *UpdateLogshuttleInput) (*Logshuttle, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logshuttle", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +205,7 @@ func (c *Client) DeleteLogshuttle(i *DeleteLogshuttleInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/logshuttle/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "logshuttle", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_newrelic.go
+++ b/fastly/logging_newrelic.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -39,7 +38,7 @@ func (c *Client) ListNewRelic(i *ListNewRelicInput) ([]*NewRelic, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelic", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelic")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -84,7 +83,7 @@ func (c *Client) CreateNewRelic(i *CreateNewRelicInput) (*NewRelic, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelic", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelic")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +119,7 @@ func (c *Client) GetNewRelic(i *GetNewRelicInput) (*NewRelic, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelic/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelic", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -170,7 +169,7 @@ func (c *Client) UpdateNewRelic(i *UpdateNewRelicInput) (*NewRelic, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelic/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelic", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +205,7 @@ func (c *Client) DeleteNewRelic(i *DeleteNewRelicInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelic/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelic", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_newrelicotlp.go
+++ b/fastly/logging_newrelicotlp.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -42,7 +41,7 @@ func (c *Client) ListNewRelicOTLP(i *ListNewRelicOTLPInput) ([]*NewRelicOTLP, er
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelicotlp", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelicotlp")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -90,7 +89,7 @@ func (c *Client) CreateNewRelicOTLP(i *CreateNewRelicOTLPInput) (*NewRelicOTLP, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelicotlp", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelicotlp")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -126,7 +125,7 @@ func (c *Client) GetNewRelicOTLP(i *GetNewRelicOTLPInput) (*NewRelicOTLP, error)
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelicotlp/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelicotlp", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -179,7 +178,7 @@ func (c *Client) UpdateNewRelicOTLP(i *UpdateNewRelicOTLPInput) (*NewRelicOTLP, 
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelicotlp/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelicotlp", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +214,7 @@ func (c *Client) DeleteNewRelicOTLP(i *DeleteNewRelicOTLPInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/newrelicotlp/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "newrelicotlp", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_openstack.go
+++ b/fastly/logging_openstack.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (c *Client) ListOpenstack(i *ListOpenstackInput) ([]*Openstack, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/openstack", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "openstack")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *Client) CreateOpenstack(i *CreateOpenstackInput) (*Openstack, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/openstack", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "openstack")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +146,7 @@ func (c *Client) GetOpenstack(i *GetOpenstackInput) (*Openstack, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/openstack/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "openstack", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +214,7 @@ func (c *Client) UpdateOpenstack(i *UpdateOpenstackInput) (*Openstack, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/openstack/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "openstack", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +250,7 @@ func (c *Client) DeleteOpenstack(i *DeleteOpenstackInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/openstack/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "openstack", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_papertrail.go
+++ b/fastly/logging_papertrail.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -39,7 +38,7 @@ func (c *Client) ListPapertrails(i *ListPapertrailsInput) ([]*Papertrail, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "papertrail")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -84,7 +83,7 @@ func (c *Client) CreatePapertrail(i *CreatePapertrailInput) (*Papertrail, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "papertrail")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +119,7 @@ func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "papertrail", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -170,7 +169,7 @@ func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "papertrail", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +205,7 @@ func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "papertrail", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_pubsub.go
+++ b/fastly/logging_pubsub.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -42,7 +41,7 @@ func (c *Client) ListPubsubs(i *ListPubsubsInput) ([]*Pubsub, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/pubsub", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "pubsub")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -93,7 +92,7 @@ func (c *Client) CreatePubsub(i *CreatePubsubInput) (*Pubsub, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/pubsub", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "pubsub")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -129,7 +128,7 @@ func (c *Client) GetPubsub(i *GetPubsubInput) (*Pubsub, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/pubsub/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "pubsub", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -185,7 +184,7 @@ func (c *Client) UpdatePubsub(i *UpdatePubsubInput) (*Pubsub, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/pubsub/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "pubsub", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -221,7 +220,7 @@ func (c *Client) DeletePubsub(i *DeletePubsubInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/pubsub/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "pubsub", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_s3.go
+++ b/fastly/logging_s3.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -102,7 +101,7 @@ func (c *Client) ListS3s(i *ListS3sInput) ([]*S3, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/s3", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "s3")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -183,7 +182,7 @@ func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
 		return nil, ErrMissingServerSideEncryptionKMSKeyID
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/s3", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "s3")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -219,7 +218,7 @@ func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "s3", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -305,7 +304,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 		return nil, ErrMissingServerSideEncryptionKMSKeyID
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "s3", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -341,7 +340,7 @@ func (c *Client) DeleteS3(i *DeleteS3Input) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "s3", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_scalyr.go
+++ b/fastly/logging_scalyr.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -40,7 +39,7 @@ func (c *Client) ListScalyrs(i *ListScalyrsInput) ([]*Scalyr, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/scalyr", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "scalyr")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -87,7 +86,7 @@ func (c *Client) CreateScalyr(i *CreateScalyrInput) (*Scalyr, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/scalyr", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "scalyr")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -123,7 +122,7 @@ func (c *Client) GetScalyr(i *GetScalyrInput) (*Scalyr, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/scalyr/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "scalyr", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -175,7 +174,7 @@ func (c *Client) UpdateScalyr(i *UpdateScalyrInput) (*Scalyr, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/scalyr/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "scalyr", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -211,7 +210,7 @@ func (c *Client) DeleteScalyr(i *DeleteScalyrInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/scalyr/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "scalyr", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_sftp.go
+++ b/fastly/logging_sftp.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -50,7 +49,7 @@ func (c *Client) ListSFTPs(i *ListSFTPsInput) ([]*SFTP, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sftp", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sftp")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -117,7 +116,7 @@ func (c *Client) CreateSFTP(i *CreateSFTPInput) (*SFTP, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sftp", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sftp")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -153,7 +152,7 @@ func (c *Client) GetSFTP(i *GetSFTPInput) (*SFTP, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sftp/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sftp", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -225,7 +224,7 @@ func (c *Client) UpdateSFTP(i *UpdateSFTPInput) (*SFTP, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sftp/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sftp", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -261,7 +260,7 @@ func (c *Client) DeleteSFTP(i *DeleteSFTPInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sftp/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sftp", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_splunk.go
+++ b/fastly/logging_splunk.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -46,7 +45,7 @@ func (c *Client) ListSplunks(i *ListSplunksInput) ([]*Splunk, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/splunk", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "splunk")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -105,7 +104,7 @@ func (c *Client) CreateSplunk(i *CreateSplunkInput) (*Splunk, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/splunk", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "splunk")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -141,7 +140,7 @@ func (c *Client) GetSplunk(i *GetSplunkInput) (*Splunk, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/splunk/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "splunk", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -205,7 +204,7 @@ func (c *Client) UpdateSplunk(i *UpdateSplunkInput) (*Splunk, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/splunk/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "splunk", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -241,7 +240,7 @@ func (c *Client) DeleteSplunk(i *DeleteSplunkInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/splunk/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "splunk", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_sumologic.go
+++ b/fastly/logging_sumologic.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -40,7 +39,7 @@ func (c *Client) ListSumologics(i *ListSumologicsInput) ([]*Sumologic, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sumologic")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -85,7 +84,7 @@ func (c *Client) CreateSumologic(i *CreateSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sumologic")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -121,7 +120,7 @@ func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sumologic", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -172,7 +171,7 @@ func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sumologic", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -208,7 +207,7 @@ func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "sumologic", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/logging_syslog.go
+++ b/fastly/logging_syslog.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (c *Client) ListSyslogs(i *ListSyslogsInput) ([]*Syslog, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "syslog")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *Client) CreateSyslog(i *CreateSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "syslog")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +146,7 @@ func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "syslog", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +214,7 @@ func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "syslog", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +250,7 @@ func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "logging", "syslog", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/managed_logging.go
+++ b/fastly/managed_logging.go
@@ -1,7 +1,6 @@
 package fastly
 
 import (
-	"fmt"
 	"net/http"
 )
 
@@ -43,7 +42,7 @@ func (c *Client) CreateManagedLogging(i *CreateManagedLoggingInput) (*ManagedLog
 	case ManagedLoggingUnset:
 		return nil, ErrMissingKind
 	case ManagedLoggingInstanceOutput:
-		path = fmt.Sprintf("/service/%s/log_stream/managed/instance_output", i.ServiceID)
+		path = ToSafeURL("service", i.ServiceID, "log_stream", "managed", "instance_output")
 	default:
 		return nil, ErrNotImplemented
 	}
@@ -88,7 +87,7 @@ func (c *Client) DeleteManagedLogging(i *DeleteManagedLoggingInput) error {
 	case ManagedLoggingUnset:
 		return ErrMissingKind
 	case ManagedLoggingInstanceOutput:
-		path = fmt.Sprintf("/service/%s/log_stream/managed/instance_output", i.ServiceID)
+		path = ToSafeURL("service", i.ServiceID, "log_stream", "managed", "instance_output")
 	default:
 		return ErrNotImplemented
 	}

--- a/fastly/notifications.go
+++ b/fastly/notifications.go
@@ -2,7 +2,6 @@ package fastly
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -126,7 +125,8 @@ func (c *Client) GetIntegration(i *GetIntegrationInput) (*Integration, error) {
 		return nil, ErrMissingID
 	}
 
-	path := fmt.Sprintf("/notifications/integrations/%s", i.ID)
+	path := ToSafeURL("notifications", "integrations", i.ID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -161,7 +161,8 @@ func (c *Client) UpdateIntegration(i *UpdateIntegrationInput) error {
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/notifications/integrations/%s", i.ID)
+	path := ToSafeURL("notifications", "integrations", i.ID)
+
 	resp, err := c.PatchJSON(path, i, nil)
 	if err != nil {
 		return err
@@ -187,7 +188,8 @@ func (c *Client) DeleteIntegration(i *DeleteIntegrationInput) error {
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/notifications/integrations/%s", i.ID)
+	path := ToSafeURL("notifications", "integrations", i.ID)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err
@@ -248,7 +250,8 @@ func (c *Client) GetWebhookSigningKey(i *GetWebhookSigningKeyInput) (*WebhookSig
 		return nil, ErrMissingIntegrationID
 	}
 
-	path := fmt.Sprintf("/notifications/integrations/%s/signingKey", i.IntegrationID)
+	path := ToSafeURL("notifications", "integrations", i.IntegrationID, "signingKey")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -274,7 +277,8 @@ func (c *Client) RotateWebhookSigningKey(i *RotateWebhookSigningKeyInput) (*Webh
 		return nil, ErrMissingIntegrationID
 	}
 
-	path := fmt.Sprintf("/notifications/integrations/%s/rotateSigningKey", i.IntegrationID)
+	path := ToSafeURL("notifications", "integrations", i.IntegrationID, "rotateSigningKey")
+
 	resp, err := c.Post(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/product_enablement.go
+++ b/fastly/product_enablement.go
@@ -1,8 +1,6 @@
 package fastly
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // ProductEnablement represents a response from the Fastly API.
 type ProductEnablement struct {
@@ -68,7 +66,8 @@ func (c *Client) GetProduct(i *ProductEnablementInput) (*ProductEnablement, erro
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/enabled-products/%s/services/%s", i.ProductID, i.ServiceID)
+	path := ToSafeURL("enabled-products", fmt.Sprint(i.ProductID), "services", i.ServiceID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -92,7 +91,8 @@ func (c *Client) EnableProduct(i *ProductEnablementInput) (*ProductEnablement, e
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/enabled-products/%s/services/%s", i.ProductID, i.ServiceID)
+	path := ToSafeURL("enabled-products", fmt.Sprint(i.ProductID), "services", i.ServiceID)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,8 @@ func (c *Client) DisableProduct(i *ProductEnablementInput) error {
 		return ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/enabled-products/%s/services/%s", i.ProductID, i.ServiceID)
+	path := ToSafeURL("enabled-products", fmt.Sprint(i.ProductID), "services", i.ServiceID)
+
 	_, err := c.Delete(path, nil)
 	return err
 }

--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -1,7 +1,6 @@
 package fastly
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 )
@@ -94,7 +93,7 @@ func (c *Client) PurgeKey(i *PurgeKeyInput) (*Purge, error) {
 		return nil, ErrMissingKey
 	}
 
-	path := fmt.Sprintf("/service/%s/purge/%s", i.ServiceID, i.Key)
+	path := ToSafeURL("service", i.ServiceID, "purge", i.Key)
 
 	ro := new(RequestOptions)
 	ro.Parallel = true
@@ -139,7 +138,7 @@ func (c *Client) PurgeKeys(i *PurgeKeysInput) (map[string]string, error) {
 		return nil, ErrMissingKeys
 	}
 
-	path := fmt.Sprintf("/service/%s/purge", i.ServiceID)
+	path := ToSafeURL("service", i.ServiceID, "purge")
 
 	ro := new(RequestOptions)
 	ro.Parallel = true
@@ -179,7 +178,8 @@ func (c *Client) PurgeAll(i *PurgeAllInput) (*Purge, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/purge_all", i.ServiceID)
+	path := ToSafeURL("service", i.ServiceID, "purge_all")
+
 	req, err := c.RawRequest("POST", path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/resource.go
+++ b/fastly/resource.go
@@ -2,7 +2,7 @@ package fastly
 
 import (
 	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -47,7 +47,7 @@ func (c *Client) ListResources(i *ListResourcesInput) ([]*Resource, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/resource", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "resource")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (c *Client) CreateResource(i *CreateResourceInput) (*Resource, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/resource", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "resource")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (c *Client) GetResource(i *GetResourceInput) (*Resource, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/resource/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.ResourceID))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "resource", i.ResourceID)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -161,7 +161,7 @@ func (c *Client) UpdateResource(i *UpdateResourceInput) (*Resource, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/resource/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.ResourceID))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "resource", i.ResourceID)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ func (c *Client) DeleteResource(i *DeleteResourceInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/resource/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.ResourceID))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "resource", i.ResourceID)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/secret_store.go
+++ b/fastly/secret_store.go
@@ -44,8 +44,8 @@ func (c *Client) CreateSecretStore(i *CreateSecretStoreInput) (*SecretStore, err
 		return nil, ErrMissingName
 	}
 
-	p := "/resources/stores/secret"
-	resp, err := c.PostJSON(p, i, &RequestOptions{
+	path := "/resources/stores/secret"
+	resp, err := c.PostJSON(path, i, &RequestOptions{
 		Parallel: true,
 	})
 	if err != nil {
@@ -84,7 +84,7 @@ type ListSecretStoresInput struct {
 // The returned next cursor, if non-blank, can be used as input to a subsequent
 // request for the next page of results.
 func (c *Client) ListSecretStores(i *ListSecretStoresInput) (*SecretStores, error) {
-	p := "/resources/stores/secret"
+	path := "/resources/stores/secret"
 
 	params := make(map[string]string, 2)
 	if i.Limit > 0 {
@@ -97,7 +97,7 @@ func (c *Client) ListSecretStores(i *ListSecretStoresInput) (*SecretStores, erro
 		params["name"] = i.Name
 	}
 
-	resp, err := c.Get(p, &RequestOptions{
+	resp, err := c.Get(path, &RequestOptions{
 		Params: params,
 		Headers: map[string]string{
 			"Content-Type": "application/json",
@@ -130,9 +130,9 @@ func (c *Client) GetSecretStore(i *GetSecretStoreInput) (*SecretStore, error) {
 		return nil, ErrMissingStoreID
 	}
 
-	p := "/resources/stores/secret/" + i.StoreID
+	path := ToSafeURL("resources", "stores", "secret", i.StoreID)
 
-	resp, err := c.Get(p, &RequestOptions{
+	resp, err := c.Get(path, &RequestOptions{
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 			"Accept":       "application/json",
@@ -164,9 +164,9 @@ func (c *Client) DeleteSecretStore(i *DeleteSecretStoreInput) error {
 		return ErrMissingStoreID
 	}
 
-	p := "/resources/stores/secret/" + i.StoreID
+	path := ToSafeURL("resources", "stores", "secret", i.StoreID)
 
-	resp, err := c.Delete(p, &RequestOptions{
+	resp, err := c.Delete(path, &RequestOptions{
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 			"Accept":       "application/json",
@@ -224,7 +224,7 @@ func (c *Client) CreateSecret(i *CreateSecretInput) (*Secret, error) {
 		return nil, ErrMissingSecret
 	}
 
-	p := "/resources/stores/secret/" + i.StoreID + "/secrets"
+	path := ToSafeURL("resources", "stores", "secret", i.StoreID, "secrets")
 
 	var body bytes.Buffer
 	err := json.NewEncoder(&body).Encode(struct {
@@ -251,7 +251,7 @@ func (c *Client) CreateSecret(i *CreateSecretInput) (*Secret, error) {
 		return nil, ErrInvalidMethod
 	}
 
-	resp, err := c.Request(method, p, &RequestOptions{
+	resp, err := c.Request(method, path, &RequestOptions{
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 			"Accept":       "application/json",
@@ -299,7 +299,7 @@ func (c *Client) ListSecrets(i *ListSecretsInput) (*Secrets, error) {
 		return nil, ErrMissingStoreID
 	}
 
-	p := "/resources/stores/secret/" + i.StoreID + "/secrets"
+	path := ToSafeURL("resources", "stores", "secret", i.StoreID, "secrets")
 
 	params := make(map[string]string, 2)
 	if i.Limit > 0 {
@@ -309,7 +309,7 @@ func (c *Client) ListSecrets(i *ListSecretsInput) (*Secrets, error) {
 		params["cursor"] = i.Cursor
 	}
 
-	resp, err := c.Get(p, &RequestOptions{
+	resp, err := c.Get(path, &RequestOptions{
 		Params: params,
 		Headers: map[string]string{
 			"Content-Type": "application/json",
@@ -347,9 +347,9 @@ func (c *Client) GetSecret(i *GetSecretInput) (*Secret, error) {
 		return nil, ErrMissingName
 	}
 
-	p := "/resources/stores/secret/" + i.StoreID + "/secrets/" + i.Name
+	path := ToSafeURL("resources", "stores", "secret", i.StoreID, "secrets", i.Name)
 
-	resp, err := c.Get(p, &RequestOptions{
+	resp, err := c.Get(path, &RequestOptions{
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 			"Accept":       "application/json",
@@ -386,9 +386,9 @@ func (c *Client) DeleteSecret(i *DeleteSecretInput) error {
 		return ErrMissingName
 	}
 
-	p := "/resources/stores/secret/" + i.StoreID + "/secrets/" + i.Name
+	path := ToSafeURL("resources", "stores", "secret", i.StoreID, "secrets", i.Name)
 
-	resp, err := c.Delete(p, &RequestOptions{
+	resp, err := c.Delete(path, &RequestOptions{
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 			"Accept":       "application/json",
@@ -439,9 +439,9 @@ func (ck *ClientKey) Encrypt(plaintext []byte) ([]byte, error) {
 // CreateClientKey creates a new time-limited client key for locally
 // encrypting secrets before uploading them to the Fastly API.
 func (c *Client) CreateClientKey() (*ClientKey, error) {
-	p := "/resources/stores/secret/client-key"
+	path := "/resources/stores/secret/client-key"
 
-	resp, err := c.Post(p, &RequestOptions{
+	resp, err := c.Post(path, &RequestOptions{
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 			"Accept":       "application/json",
@@ -465,9 +465,9 @@ func (c *Client) CreateClientKey() (*ClientKey, error) {
 // general the signing key changes very rarely, and it's recommended to
 // ship the signing key out-of-band from the API.
 func (c *Client) GetSigningKey() (ed25519.PublicKey, error) {
-	p := "/resources/stores/secret/signing-key"
+	path := "/resources/stores/secret/signing-key"
 
-	resp, err := c.Get(p, &RequestOptions{
+	resp, err := c.Get(path, &RequestOptions{
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 			"Accept":       "application/json",

--- a/fastly/service_authorization.go
+++ b/fastly/service_authorization.go
@@ -116,7 +116,8 @@ func (c *Client) GetServiceAuthorization(i *GetServiceAuthorizationInput) (*Serv
 		return nil, ErrMissingID
 	}
 
-	path := fmt.Sprintf("/service-authorizations/%s", i.ID)
+	path := ToSafeURL("service-authorizations", i.ID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -188,7 +189,8 @@ func (c *Client) UpdateServiceAuthorization(i *UpdateServiceAuthorizationInput) 
 		return nil, ErrMissingPermission
 	}
 
-	path := fmt.Sprintf("/service-authorizations/%s", i.ID)
+	path := ToSafeURL("service-authorizations", i.ID)
+
 	resp, err := c.PatchJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +217,8 @@ func (c *Client) DeleteServiceAuthorization(i *DeleteServiceAuthorizationInput) 
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/service-authorizations/%s", i.ID)
+	path := ToSafeURL("service-authorizations", i.ID)
+
 	_, err := c.Delete(path, nil)
 
 	return err

--- a/fastly/service_details.go
+++ b/fastly/service_details.go
@@ -143,7 +143,8 @@ func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s", i.ServiceID)
+	path := ToSafeURL("service", i.ServiceID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -178,7 +179,8 @@ func (c *Client) GetServiceDetails(i *GetServiceInput) (*ServiceDetail, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/details", i.ServiceID)
+	path := ToSafeURL("service", i.ServiceID, "details")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -209,7 +211,8 @@ func (c *Client) UpdateService(i *UpdateServiceInput) (*Service, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s", i.ServiceID)
+	path := ToSafeURL("service", i.ServiceID)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -235,7 +238,8 @@ func (c *Client) DeleteService(i *DeleteServiceInput) error {
 		return ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s", i.ServiceID)
+	path := ToSafeURL("service", i.ServiceID)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err
@@ -297,7 +301,8 @@ func (c *Client) ListServiceDomains(i *ListServiceDomainInput) (ServiceDomainsLi
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/domain", i.ServiceID)
+	path := ToSafeURL("service", i.ServiceID, "domain")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/service_version.go
+++ b/fastly/service_version.go
@@ -1,7 +1,7 @@
 package fastly
 
 import (
-	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -32,7 +32,8 @@ func (c *Client) ListVersions(i *ListVersionsInput) ([]*Version, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/version", i.ServiceID)
+	path := ToSafeURL("service", i.ServiceID, "version")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -90,7 +91,8 @@ func (c *Client) CreateVersion(i *CreateVersionInput) (*Version, error) {
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/version", i.ServiceID)
+	path := ToSafeURL("service", i.ServiceID, "version")
+
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -121,7 +123,7 @@ func (c *Client) GetVersion(i *GetVersionInput) (*Version, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion))
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -154,7 +156,7 @@ func (c *Client) UpdateVersion(i *UpdateVersionInput) (*Version, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion))
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -185,7 +187,7 @@ func (c *Client) ActivateVersion(i *ActivateVersionInput) (*Version, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/activate", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "activate")
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -216,7 +218,7 @@ func (c *Client) DeactivateVersion(i *DeactivateVersionInput) (*Version, error) 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/deactivate", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "deactivate")
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -250,7 +252,7 @@ func (c *Client) CloneVersion(i *CloneVersionInput) (*Version, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/clone", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "clone")
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -283,7 +285,7 @@ func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, string, error) 
 		return false, msg, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/validate", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "validate")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return false, msg, err
@@ -316,7 +318,7 @@ func (c *Client) LockVersion(i *LockVersionInput) (*Version, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/lock", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "lock")
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/stats_domain_inspector.go
+++ b/fastly/stats_domain_inspector.go
@@ -149,7 +149,7 @@ func (c *Client) GetDomainMetricsForServiceJSON(i *GetDomainMetricsInput, dst an
 		return ErrMissingServiceID
 	}
 
-	p := "/metrics/domains/services/" + i.ServiceID
+	path := ToSafeURL("metrics", "domains", "services", i.ServiceID)
 
 	ro := &RequestOptions{
 		Params: map[string]string{
@@ -176,7 +176,7 @@ func (c *Client) GetDomainMetricsForServiceJSON(i *GetDomainMetricsInput, dst an
 		ro.Params["start"] = strconv.FormatInt(i.Start.Unix(), 10)
 	}
 
-	resp, err := c.Get(p, ro)
+	resp, err := c.Get(path, ro)
 	if err != nil {
 		return err
 	}

--- a/fastly/stats_historical.go
+++ b/fastly/stats_historical.go
@@ -2,7 +2,6 @@ package fastly
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // StatsResponse is a response from the service stats API endpoint.
@@ -147,13 +146,18 @@ func (c *Client) GetStatsField(i *GetStatsInput) (*StatsFieldResponse, error) {
 
 // GetStatsJSON fetches stats and decodes the response directly to the JSON struct dst.
 func (c *Client) GetStatsJSON(i *GetStatsInput, dst any) error {
-	p := "/stats"
+	components := make([]string, 1, 5)
+
+	components[0] = "stats"
+
 	if i.Service != nil {
-		p = fmt.Sprintf("%s/service/%s", p, *i.Service)
+		components = append(components, "service", *i.Service)
 	}
 	if i.Field != nil {
-		p = fmt.Sprintf("%s/field/%s", p, *i.Field)
+		components = append(components, "field", *i.Field)
 	}
+
+	path := ToSafeURL(components...)
 
 	ro := &RequestOptions{
 		Params: map[string]string{},
@@ -171,7 +175,7 @@ func (c *Client) GetStatsJSON(i *GetStatsInput, dst any) error {
 		ro.Params["to"] = *i.To
 	}
 
-	resp, err := c.Get(p, ro)
+	resp, err := c.Get(path, ro)
 	if err != nil {
 		return err
 	}

--- a/fastly/stats_origin_inspector.go
+++ b/fastly/stats_origin_inspector.go
@@ -123,7 +123,7 @@ func (c *Client) GetOriginMetricsForServiceJSON(i *GetOriginMetricsInput, dst an
 		return ErrMissingServiceID
 	}
 
-	p := "/metrics/origins/services/" + i.ServiceID
+	path := ToSafeURL("metrics", "origins", "services", i.ServiceID)
 
 	ro := &RequestOptions{
 		Params: map[string]string{
@@ -147,7 +147,7 @@ func (c *Client) GetOriginMetricsForServiceJSON(i *GetOriginMetricsInput, dst an
 		ro.Params["start"] = strconv.FormatInt(i.Start.Unix(), 10)
 	}
 
-	resp, err := c.Get(p, ro)
+	resp, err := c.Get(path, ro)
 	if err != nil {
 		return err
 	}

--- a/fastly/stats_realtime.go
+++ b/fastly/stats_realtime.go
@@ -60,12 +60,13 @@ func (c *RTSClient) GetRealtimeStatsJSON(i *GetRealtimeStatsInput, dst any) erro
 		return ErrMissingServiceID
 	}
 
-	var path string
+	components := []string{"v1", "channel", i.ServiceID, "ts", strconv.FormatUint(i.Timestamp, 10)}
+
 	if i.Limit != nil {
-		path = ToSafeURL("v1", "channel", i.ServiceID, "ts", strconv.FormatUint(i.Timestamp, 10), "limit", strconv.FormatUint(uint64(*i.Limit), 10))
-	} else {
-		path = ToSafeURL("v1", "channel", i.ServiceID, "ts", strconv.FormatUint(i.Timestamp, 10))
+		components = append(components, "limit", strconv.FormatUint(uint64(*i.Limit), 10))
 	}
+
+	path := ToSafeURL(components...)
 
 	resp, err := c.client.Get(path, nil)
 	if err != nil {

--- a/fastly/stats_realtime.go
+++ b/fastly/stats_realtime.go
@@ -2,7 +2,7 @@ package fastly
 
 import (
 	"encoding/json"
-	"fmt"
+	"strconv"
 )
 
 // RealtimeStatsResponse is a response from Fastly's real-time analytics
@@ -60,10 +60,11 @@ func (c *RTSClient) GetRealtimeStatsJSON(i *GetRealtimeStatsInput, dst any) erro
 		return ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/v1/channel/%s/ts/%d", i.ServiceID, i.Timestamp)
-
+	var path string
 	if i.Limit != nil {
-		path = fmt.Sprintf("%s/limit/%d", path, *i.Limit)
+		path = ToSafeURL("v1", "channel", i.ServiceID, "ts", strconv.FormatUint(i.Timestamp, 10), "limit", strconv.FormatUint(uint64(*i.Limit), 10))
+	} else {
+		path = ToSafeURL("v1", "channel", i.ServiceID, "ts", strconv.FormatUint(i.Timestamp, 10))
 	}
 
 	resp, err := c.client.Get(path, nil)

--- a/fastly/tls_custom_activation.go
+++ b/fastly/tls_custom_activation.go
@@ -67,7 +67,7 @@ func (i *ListTLSActivationsInput) formatFilters() map[string]string {
 
 // ListTLSActivations retrieves all resources.
 func (c *Client) ListTLSActivations(i *ListTLSActivationsInput) ([]*TLSActivation, error) {
-	p := "/tls/activations"
+	path := "/tls/activations"
 	filters := &RequestOptions{
 		Params: i.formatFilters(),
 		Headers: map[string]string{
@@ -75,7 +75,7 @@ func (c *Client) ListTLSActivations(i *ListTLSActivationsInput) ([]*TLSActivatio
 		},
 	}
 
-	resp, err := c.Get(p, filters)
+	resp, err := c.Get(path, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (c *Client) GetTLSActivation(i *GetTLSActivationInput) (*TLSActivation, err
 		return nil, ErrMissingID
 	}
 
-	p := fmt.Sprintf("/tls/activations/%s", i.ID)
+	path := ToSafeURL("tls", "activations", i.ID)
 
 	ro := &RequestOptions{
 		Headers: map[string]string{
@@ -124,7 +124,7 @@ func (c *Client) GetTLSActivation(i *GetTLSActivationInput) (*TLSActivation, err
 		ro.Params = map[string]string{"include": *i.Include}
 	}
 
-	resp, err := c.Get(p, ro)
+	resp, err := c.Get(path, ro)
 	if err != nil {
 		return nil, err
 	}
@@ -159,9 +159,9 @@ func (c *Client) CreateTLSActivation(i *CreateTLSActivationInput) (*TLSActivatio
 		return nil, ErrMissingTLSDomain
 	}
 
-	p := "/tls/activations"
+	path := "/tls/activations"
 
-	resp, err := c.PostJSONAPI(p, i, nil)
+	resp, err := c.PostJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,8 @@ func (c *Client) UpdateTLSActivation(i *UpdateTLSActivationInput) (*TLSActivatio
 		return nil, ErrMissingCertificateMTLS
 	}
 
-	path := fmt.Sprintf("/tls/activations/%s", i.ID)
+	path := ToSafeURL("tls", "activations", i.ID)
+
 	resp, err := c.PatchJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -220,7 +221,8 @@ func (c *Client) DeleteTLSActivation(i *DeleteTLSActivationInput) error {
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/tls/activations/%s", i.ID)
+	path := ToSafeURL("tls", "activations", i.ID)
+
 	_, err := c.Delete(path, nil)
 	return err
 }

--- a/fastly/tls_custom_certificate.go
+++ b/fastly/tls_custom_certificate.go
@@ -78,7 +78,7 @@ func (i *ListCustomTLSCertificatesInput) formatFilters() map[string]string {
 
 // ListCustomTLSCertificates retrieves all resources.
 func (c *Client) ListCustomTLSCertificates(i *ListCustomTLSCertificatesInput) ([]*CustomTLSCertificate, error) {
-	p := "/tls/certificates"
+	path := "/tls/certificates"
 	filters := &RequestOptions{
 		Params: i.formatFilters(),
 		Headers: map[string]string{
@@ -86,7 +86,7 @@ func (c *Client) ListCustomTLSCertificates(i *ListCustomTLSCertificatesInput) ([
 		},
 	}
 
-	resp, err := c.Get(p, filters)
+	resp, err := c.Get(path, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -121,9 +121,9 @@ func (c *Client) GetCustomTLSCertificate(i *GetCustomTLSCertificateInput) (*Cust
 		return nil, ErrMissingID
 	}
 
-	p := fmt.Sprintf("/tls/certificates/%s", i.ID)
+	path := ToSafeURL("tls", "certificates", i.ID)
 
-	resp, err := c.Get(p, nil)
+	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -153,9 +153,9 @@ func (c *Client) CreateCustomTLSCertificate(i *CreateCustomTLSCertificateInput) 
 		return nil, ErrMissingCertBlob
 	}
 
-	p := "/tls/certificates"
+	path := "/tls/certificates"
 
-	resp, err := c.PostJSONAPI(p, i, nil)
+	resp, err := c.PostJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,8 @@ func (c *Client) UpdateCustomTLSCertificate(i *UpdateCustomTLSCertificateInput) 
 		return nil, ErrMissingCertBlob
 	}
 
-	path := fmt.Sprintf("/tls/certificates/%s", i.ID)
+	path := ToSafeURL("tls", "certificates", i.ID)
+
 	resp, err := c.PatchJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -219,7 +220,8 @@ func (c *Client) DeleteCustomTLSCertificate(i *DeleteCustomTLSCertificateInput) 
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/tls/certificates/%s", i.ID)
+	path := ToSafeURL("tls", "certificates", i.ID)
+
 	_, err := c.Delete(path, nil)
 	return err
 }

--- a/fastly/tls_custom_configuration.go
+++ b/fastly/tls_custom_configuration.go
@@ -71,7 +71,7 @@ func (i *ListCustomTLSConfigurationsInput) formatFilters() map[string]string {
 
 // ListCustomTLSConfigurations retrieves all resources.
 func (c *Client) ListCustomTLSConfigurations(i *ListCustomTLSConfigurationsInput) ([]*CustomTLSConfiguration, error) {
-	p := "/tls/configurations"
+	path := "/tls/configurations"
 	ro := &RequestOptions{
 		Params: i.formatFilters(),
 		Headers: map[string]string{
@@ -79,7 +79,7 @@ func (c *Client) ListCustomTLSConfigurations(i *ListCustomTLSConfigurationsInput
 		},
 	}
 
-	resp, err := c.Get(p, ro)
+	resp, err := c.Get(path, ro)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (c *Client) GetCustomTLSConfiguration(i *GetCustomTLSConfigurationInput) (*
 		return nil, ErrMissingID
 	}
 
-	p := fmt.Sprintf("/tls/configurations/%s", i.ID)
+	path := ToSafeURL("tls", "configurations", i.ID)
 
 	ro := &RequestOptions{
 		Headers: map[string]string{
@@ -128,7 +128,7 @@ func (c *Client) GetCustomTLSConfiguration(i *GetCustomTLSConfigurationInput) (*
 		ro.Params = map[string]string{"include": i.Include}
 	}
 
-	resp, err := c.Get(p, ro)
+	resp, err := c.Get(path, ro)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,8 @@ func (c *Client) UpdateCustomTLSConfiguration(i *UpdateCustomTLSConfigurationInp
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/tls/configurations/%s", i.ID)
+	path := ToSafeURL("tls", "configurations", i.ID)
+
 	resp, err := c.PatchJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/tls_mutual_authentication.go
+++ b/fastly/tls_mutual_authentication.go
@@ -47,7 +47,7 @@ func (i *ListTLSMutualAuthenticationsInput) formatFilters() map[string]string {
 
 // ListTLSMutualAuthentication retrieves all resources.
 func (c *Client) ListTLSMutualAuthentication(i *ListTLSMutualAuthenticationsInput) ([]*TLSMutualAuthentication, error) {
-	p := "/tls/mutual_authentications"
+	path := "/tls/mutual_authentications"
 	filters := &RequestOptions{
 		Params: i.formatFilters(),
 		Headers: map[string]string{
@@ -55,7 +55,7 @@ func (c *Client) ListTLSMutualAuthentication(i *ListTLSMutualAuthenticationsInpu
 		},
 	}
 
-	resp, err := c.Get(p, filters)
+	resp, err := c.Get(path, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -104,9 +104,9 @@ func (c *Client) GetTLSMutualAuthentication(i *GetTLSMutualAuthenticationInput) 
 		}
 	}
 
-	p := fmt.Sprintf("/tls/mutual_authentications/%s", i.ID)
+	path := ToSafeURL("tls", "mutual_authentications", i.ID)
 
-	resp, err := c.Get(p, ro)
+	resp, err := c.Get(path, ro)
 	if err != nil {
 		return nil, err
 	}
@@ -138,9 +138,9 @@ func (c *Client) CreateTLSMutualAuthentication(i *CreateTLSMutualAuthenticationI
 		return nil, ErrMissingCertBundle
 	}
 
-	p := "/tls/mutual_authentications"
+	path := "/tls/mutual_authentications"
 
-	resp, err := c.PostJSONAPI(p, i, nil)
+	resp, err := c.PostJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,8 @@ func (c *Client) UpdateTLSMutualAuthentication(i *UpdateTLSMutualAuthenticationI
 		return nil, ErrMissingID
 	}
 
-	path := fmt.Sprintf("/tls/mutual_authentications/%s", i.ID)
+	path := ToSafeURL("tls", "mutual_authentications", i.ID)
+
 	resp, err := c.PatchJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -201,7 +202,8 @@ func (c *Client) DeleteTLSMutualAuthentication(i *DeleteTLSMutualAuthenticationI
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/tls/mutual_authentications/%s", i.ID)
+	path := ToSafeURL("tls", "mutual_authentications", i.ID)
+
 	_, err := c.Delete(path, nil)
 	return err
 }

--- a/fastly/tls_platform.go
+++ b/fastly/tls_platform.go
@@ -81,7 +81,7 @@ func (i *ListBulkCertificatesInput) formatFilters() map[string]string {
 
 // ListBulkCertificates retrieves all resources.
 func (c *Client) ListBulkCertificates(i *ListBulkCertificatesInput) ([]*BulkCertificate, error) {
-	p := "/tls/bulk/certificates"
+	path := "/tls/bulk/certificates"
 	filters := &RequestOptions{
 		Params: i.formatFilters(),
 		Headers: map[string]string{
@@ -89,7 +89,7 @@ func (c *Client) ListBulkCertificates(i *ListBulkCertificatesInput) ([]*BulkCert
 		},
 	}
 
-	resp, err := c.Get(p, filters)
+	resp, err := c.Get(path, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -124,9 +124,9 @@ func (c *Client) GetBulkCertificate(i *GetBulkCertificateInput) (*BulkCertificat
 		return nil, ErrMissingID
 	}
 
-	p := fmt.Sprintf("/tls/bulk/certificates/%s", i.ID)
+	path := ToSafeURL("tls", "bulk", "certificates", i.ID)
 
-	resp, err := c.Get(p, nil)
+	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -161,9 +161,9 @@ func (c *Client) CreateBulkCertificate(i *CreateBulkCertificateInput) (*BulkCert
 		return nil, ErrMissingIntermediatesBlob
 	}
 
-	p := "/tls/bulk/certificates"
+	path := "/tls/bulk/certificates"
 
-	resp, err := c.PostJSONAPI(p, i, nil)
+	resp, err := c.PostJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,8 @@ func (c *Client) UpdateBulkCertificate(i *UpdateBulkCertificateInput) (*BulkCert
 		return nil, ErrMissingIntermediatesBlob
 	}
 
-	path := fmt.Sprintf("/tls/bulk/certificates/%s", i.ID)
+	path := ToSafeURL("tls", "bulk", "certificates", i.ID)
+
 	resp, err := c.PatchJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -233,7 +234,8 @@ func (c *Client) DeleteBulkCertificate(i *DeleteBulkCertificateInput) error {
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/tls/bulk/certificates/%s", i.ID)
+	path := ToSafeURL("tls", "bulk", "certificates", i.ID)
+
 	_, err := c.Delete(path, nil)
 	return err
 }

--- a/fastly/tls_private_keys.go
+++ b/fastly/tls_private_keys.go
@@ -65,7 +65,7 @@ func (i *ListPrivateKeysInput) formatFilters() map[string]string {
 
 // ListPrivateKeys retrieves all resources.
 func (c *Client) ListPrivateKeys(i *ListPrivateKeysInput) ([]*PrivateKey, error) {
-	p := "/tls/private_keys"
+	path := "/tls/private_keys"
 	filters := &RequestOptions{
 		Params: i.formatFilters(),
 		Headers: map[string]string{
@@ -73,7 +73,7 @@ func (c *Client) ListPrivateKeys(i *ListPrivateKeysInput) ([]*PrivateKey, error)
 		},
 	}
 
-	resp, err := c.Get(p, filters)
+	resp, err := c.Get(path, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -102,9 +102,9 @@ func (c *Client) GetPrivateKey(i *GetPrivateKeyInput) (*PrivateKey, error) {
 		return nil, ErrMissingID
 	}
 
-	p := fmt.Sprintf("/tls/private_keys/%s", i.ID)
+	path := ToSafeURL("tls", "private_keys", i.ID)
 
-	resp, err := c.Get(p, nil)
+	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ type CreatePrivateKeyInput struct {
 
 // CreatePrivateKey creates a new resource.
 func (c *Client) CreatePrivateKey(i *CreatePrivateKeyInput) (*PrivateKey, error) {
-	p := "/tls/private_keys"
+	path := "/tls/private_keys"
 
 	if i.Key == "" {
 		return nil, ErrMissingKey
@@ -138,7 +138,7 @@ func (c *Client) CreatePrivateKey(i *CreatePrivateKeyInput) (*PrivateKey, error)
 		return nil, ErrMissingName
 	}
 
-	resp, err := c.PostJSONAPI(p, i, nil)
+	resp, err := c.PostJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,8 @@ func (c *Client) DeletePrivateKey(i *DeletePrivateKeyInput) error {
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/tls/private_keys/%s", i.ID)
+	path := ToSafeURL("tls", "private_keys", i.ID)
+
 	_, err := c.Delete(path, nil)
 	return err
 }

--- a/fastly/tls_subscription.go
+++ b/fastly/tls_subscription.go
@@ -221,7 +221,7 @@ func (c *Client) GetTLSSubscription(i *GetTLSSubscriptionInput) (*TLSSubscriptio
 		return nil, ErrMissingID
 	}
 
-	path := fmt.Sprintf("/tls/subscriptions/%s", i.ID)
+	path := ToSafeURL("tls", "subscriptions", i.ID)
 
 	requestOptions := &RequestOptions{
 		Headers: map[string]string{
@@ -278,7 +278,8 @@ func (c *Client) UpdateTLSSubscription(i *UpdateTLSSubscriptionInput) (*TLSSubsc
 		}
 	}
 
-	path := fmt.Sprintf("/tls/subscriptions/%s", i.ID)
+	path := ToSafeURL("tls", "subscriptions", i.ID)
+
 	resp, err := c.PatchJSONAPI(path, i, &ro)
 	if err != nil {
 		return nil, err
@@ -316,7 +317,8 @@ func (c *Client) DeleteTLSSubscription(i *DeleteTLSSubscriptionInput) error {
 		}
 	}
 
-	path := fmt.Sprintf("/tls/subscriptions/%s", i.ID)
+	path := ToSafeURL("tls", "subscriptions", i.ID)
+
 	_, err := c.Delete(path, &ro)
 	return err
 }

--- a/fastly/token.go
+++ b/fastly/token.go
@@ -1,7 +1,6 @@
 package fastly
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 )
@@ -67,7 +66,8 @@ func (c *Client) ListCustomerTokens(i *ListCustomerTokensInput) ([]*Token, error
 		return nil, ErrMissingCustomerID
 	}
 
-	path := fmt.Sprintf("/customer/%s/tokens", i.CustomerID)
+	path := ToSafeURL("customer", i.CustomerID, "tokens")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,8 @@ func (c *Client) DeleteToken(i *DeleteTokenInput) error {
 		return ErrMissingTokenID
 	}
 
-	path := fmt.Sprintf("/tokens/%s", i.TokenID)
+	path := ToSafeURL("tokens", i.TokenID)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/user.go
+++ b/fastly/user.go
@@ -1,8 +1,6 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
 	"time"
 )
 
@@ -37,7 +35,8 @@ func (c *Client) ListCustomerUsers(i *ListCustomerUsersInput) ([]*User, error) {
 		return nil, ErrMissingCustomerID
 	}
 
-	path := fmt.Sprintf("/customer/%s/users", i.CustomerID)
+	path := ToSafeURL("customer", i.CustomerID, "users")
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -81,7 +80,8 @@ func (c *Client) GetUser(i *GetUserInput) (*User, error) {
 		return nil, ErrMissingUserID
 	}
 
-	path := fmt.Sprintf("/user/%s", i.UserID)
+	path := ToSafeURL("user", i.UserID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -137,7 +137,8 @@ func (c *Client) UpdateUser(i *UpdateUserInput) (*User, error) {
 		return nil, ErrMissingUserID
 	}
 
-	path := fmt.Sprintf("/user/%s", i.UserID)
+	path := ToSafeURL("user", i.UserID)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -163,7 +164,8 @@ func (c *Client) DeleteUser(i *DeleteUserInput) error {
 		return ErrMissingUserID
 	}
 
-	path := fmt.Sprintf("/user/%s", i.UserID)
+	path := ToSafeURL("user", i.UserID)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err
@@ -192,7 +194,8 @@ func (c *Client) ResetUserPassword(i *ResetUserPasswordInput) error {
 		return ErrMissingLogin
 	}
 
-	path := fmt.Sprintf("/user/%s/password/request_reset", url.PathEscape(i.Login))
+	path := ToSafeURL("user", i.Login, "password", "request_reset")
+
 	resp, err := c.Post(path, nil)
 	if err != nil {
 		return err

--- a/fastly/vcl_cache_setting.go
+++ b/fastly/vcl_cache_setting.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -51,7 +50,7 @@ func (c *Client) ListCacheSettings(i *ListCacheSettingsInput) ([]*CacheSetting, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/cache_settings", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "cache_settings")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -92,7 +91,7 @@ func (c *Client) CreateCacheSetting(i *CreateCacheSettingInput) (*CacheSetting, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/cache_settings", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "cache_settings")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -128,7 +127,7 @@ func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error)
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/cache_settings/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "cache_settings", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -174,7 +173,7 @@ func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/cache_settings/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "cache_settings", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -210,7 +209,7 @@ func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/cache_settings/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "cache_settings", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/vcl_condition.go
+++ b/fastly/vcl_condition.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -37,7 +36,7 @@ func (c *Client) ListConditions(i *ListConditionsInput) ([]*Condition, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/condition", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "condition")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -76,7 +75,7 @@ func (c *Client) CreateCondition(i *CreateConditionInput) (*Condition, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/condition", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "condition")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -112,7 +111,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "condition", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -156,7 +155,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "condition", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -192,7 +191,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "condition", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/vcl_custom.go
+++ b/fastly/vcl_custom.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -35,7 +34,7 @@ func (c *Client) ListVCLs(i *ListVCLsInput) ([]*VCL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/vcl", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "vcl")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -71,7 +70,7 @@ func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "vcl", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -102,7 +101,7 @@ func (c *Client) GetGeneratedVCL(i *GetGeneratedVCLInput) (*VCL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/generated_vcl", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "generated_vcl")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -139,7 +138,7 @@ func (c *Client) CreateVCL(i *CreateVCLInput) (*VCL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/vcl", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "vcl")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -179,7 +178,7 @@ func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "vcl", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -215,7 +214,7 @@ func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s/main", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "vcl", i.Name, "main")
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +250,7 @@ func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "vcl", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/vcl_gzip.go
+++ b/fastly/vcl_gzip.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -36,7 +35,7 @@ func (c *Client) ListGzips(i *ListGzipsInput) ([]*Gzip, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/gzip", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "gzip")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -75,7 +74,7 @@ func (c *Client) CreateGzip(i *CreateGzipInput) (*Gzip, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/gzip", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "gzip")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -111,7 +110,7 @@ func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/gzip/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "gzip", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -155,7 +154,7 @@ func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/gzip/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "gzip", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -191,7 +190,7 @@ func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/gzip/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "gzip", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/vcl_header.go
+++ b/fastly/vcl_header.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -87,7 +86,7 @@ func (c *Client) ListHeaders(i *ListHeadersInput) ([]*Header, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/header", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "header")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -142,7 +141,7 @@ func (c *Client) CreateHeader(i *CreateHeaderInput) (*Header, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/header", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "header")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -178,7 +177,7 @@ func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/header/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "header", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -238,7 +237,7 @@ func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/header/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "header", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -274,7 +273,7 @@ func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/header/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "header", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/vcl_http3.go
+++ b/fastly/vcl_http3.go
@@ -1,7 +1,7 @@
 package fastly
 
 import (
-	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -32,7 +32,7 @@ func (c *Client) GetHTTP3(i *GetHTTP3Input) (*HTTP3, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/http3", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "http3")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (c *Client) EnableHTTP3(i *EnableHTTP3Input) (*HTTP3, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/http3", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "http3")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (c *Client) DisableHTTP3(i *DisableHTTP3Input) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/http3", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "http3")
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/vcl_rate_limiter.go
+++ b/fastly/vcl_rate_limiter.go
@@ -5,6 +5,7 @@ package fastly
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -198,7 +199,7 @@ func (c *Client) ListERLs(i *ListERLsInput) ([]*ERL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/rate-limiters", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "rate-limiters")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -254,7 +255,7 @@ func (c *Client) CreateERL(i *CreateERLInput) (*ERL, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/rate-limiters", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "rate-limiters")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -281,7 +282,8 @@ func (c *Client) DeleteERL(i *DeleteERLInput) error {
 		return ErrMissingERLID
 	}
 
-	path := fmt.Sprintf("/rate-limiters/%s", i.ERLID)
+	path := ToSafeURL("rate-limiters", i.ERLID)
+
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err
@@ -311,7 +313,8 @@ func (c *Client) GetERL(i *GetERLInput) (*ERL, error) {
 		return nil, ErrMissingERLID
 	}
 
-	path := fmt.Sprintf("/rate-limiters/%s", i.ERLID)
+	path := ToSafeURL("rate-limiters", i.ERLID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -362,7 +365,8 @@ func (c *Client) UpdateERL(i *UpdateERLInput) (*ERL, error) {
 		return nil, ErrMissingERLID
 	}
 
-	path := fmt.Sprintf("/rate-limiters/%s", i.ERLID)
+	path := ToSafeURL("rate-limiters", i.ERLID)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/vcl_request_setting.go
+++ b/fastly/vcl_request_setting.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -80,7 +79,7 @@ func (c *Client) ListRequestSettings(i *ListRequestSettingsInput) ([]*RequestSet
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/request_settings", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "request_settings")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -136,7 +135,7 @@ func (c *Client) CreateRequestSetting(i *CreateRequestSettingInput) (*RequestSet
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/request_settings", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "request_settings")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -172,7 +171,7 @@ func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/request_settings/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "request_settings", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -233,7 +232,7 @@ func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSet
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/request_settings/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "request_settings", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -269,7 +268,7 @@ func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/request_settings/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "request_settings", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/vcl_response_object.go
+++ b/fastly/vcl_response_object.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -40,7 +39,7 @@ func (c *Client) ListResponseObjects(i *ListResponseObjectsInput) ([]*ResponseOb
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/response_object", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "response_object")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -86,7 +85,7 @@ func (c *Client) CreateResponseObject(i *CreateResponseObjectInput) (*ResponseOb
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/response_object", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "response_object")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -122,7 +121,7 @@ func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, 
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/response_object/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "response_object", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -173,7 +172,7 @@ func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseOb
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/response_object/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "response_object", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -209,7 +208,7 @@ func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/response_object/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "response_object", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/fastly/vcl_settings.go
+++ b/fastly/vcl_settings.go
@@ -1,8 +1,6 @@
 package fastly
 
-import (
-	"fmt"
-)
+import "strconv"
 
 // Settings represents a backend response from the Fastly API.
 type Settings struct {
@@ -31,7 +29,7 @@ func (c *Client) GetSettings(i *GetSettingsInput) (*Settings, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/settings", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "settings")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -70,7 +68,7 @@ func (c *Client) UpdateSettings(i *UpdateSettingsInput) (*Settings, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/settings", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "settings")
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -1,8 +1,7 @@
 package fastly
 
 import (
-	"fmt"
-	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -86,7 +85,7 @@ func (c *Client) CreateSnippet(i *CreateSnippetInput) (*Snippet, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/snippet", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "snippet")
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -130,7 +129,7 @@ func (c *Client) UpdateSnippet(i *UpdateSnippetInput) (*Snippet, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/snippet/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "snippet", i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -173,7 +172,8 @@ func (c *Client) UpdateDynamicSnippet(i *UpdateDynamicSnippetInput) (*DynamicSni
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/snippet/%s", i.ServiceID, i.SnippetID)
+	path := ToSafeURL("service", i.ServiceID, "snippet", i.SnippetID)
+
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (c *Client) DeleteSnippet(i *DeleteSnippetInput) error {
 		return ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/snippet/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "snippet", i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err
@@ -246,7 +246,7 @@ func (c *Client) ListSnippets(i *ListSnippetsInput) ([]*Snippet, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/snippet", i.ServiceID, i.ServiceVersion)
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "snippet")
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -285,7 +285,7 @@ func (c *Client) GetSnippet(i *GetSnippetInput) (*Snippet, error) {
 		return nil, ErrMissingServiceVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%d/snippet/%s", i.ServiceID, i.ServiceVersion, url.PathEscape(i.Name))
+	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "snippet", i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -318,7 +318,8 @@ func (c *Client) GetDynamicSnippet(i *GetDynamicSnippetInput) (*DynamicSnippet, 
 		return nil, ErrMissingServiceID
 	}
 
-	path := fmt.Sprintf("/service/%s/snippet/%s", i.ServiceID, i.SnippetID)
+	path := ToSafeURL("service", i.ServiceID, "snippet", i.SnippetID)
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -186,7 +186,8 @@ func (c *Client) GetWAF(i *GetWAFInput) (*WAF, error) {
 		return nil, ErrMissingID
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s", i.ID)
+	path := ToSafeURL("waf", "firewalls", i.ID)
+
 	resp, err := c.Get(path, &RequestOptions{
 		Params: map[string]string{
 			"filter[service_version_number]": strconv.Itoa(i.ServiceVersion),
@@ -239,7 +240,8 @@ func (c *Client) UpdateWAF(i *UpdateWAFInput) (*WAF, error) {
 		}
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s", i.ID)
+	path := ToSafeURL("waf", "firewalls", i.ID)
+
 	resp, err := c.PatchJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -271,7 +273,8 @@ func (c *Client) DeleteWAF(i *DeleteWAFInput) error {
 		return ErrMissingID
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s", i.ID)
+	path := ToSafeURL("waf", "firewalls", i.ID)
+
 	_, err := c.DeleteJSONAPI(path, i, nil)
 	return err
 }

--- a/fastly/waf_active_rule.go
+++ b/fastly/waf_active_rule.go
@@ -89,7 +89,8 @@ func (c *Client) ListWAFActiveRules(i *ListWAFActiveRulesInput) (*WAFActiveRuleR
 		return nil, ErrMissingWAFVersionNumber
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/active-rules", i.WAFID, i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "active-rules")
+
 	resp, err := c.Get(path, &RequestOptions{
 		Params: i.formatFilters(),
 	})
@@ -204,7 +205,8 @@ func (c *Client) CreateWAFActiveRules(i *CreateWAFActiveRulesInput) ([]*WAFActiv
 		return nil, ErrMissingWAFActiveRule
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/active-rules", i.WAFID, i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "active-rules")
+
 	resp, err := c.PostJSONAPIBulk(path, i.Rules, nil)
 	if err != nil {
 		return nil, err
@@ -294,7 +296,8 @@ func (c *Client) DeleteWAFActiveRules(i *DeleteWAFActiveRulesInput) error {
 		return ErrMissingWAFActiveRule
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/active-rules", i.WAFID, i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "active-rules")
+
 	_, err := c.DeleteJSONAPIBulk(path, i.Rules, nil)
 	return err
 }

--- a/fastly/waf_rule_exclusion.go
+++ b/fastly/waf_rule_exclusion.go
@@ -151,7 +151,8 @@ func (c *Client) ListWAFRuleExclusions(i *ListWAFRuleExclusionsInput) (*WAFRuleE
 		return nil, ErrMissingWAFVersionNumber
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions", i.WAFID, i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "exclusions")
+
 	resp, err := c.Get(path, &RequestOptions{
 		Params: i.formatFilters(),
 	})
@@ -241,7 +242,8 @@ func (c *Client) CreateWAFRuleExclusion(i *CreateWAFRuleExclusionInput) (*WAFRul
 		return nil, ErrMissingWAFRuleExclusion
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions", i.WAFID, i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "exclusions")
+
 	resp, err := c.PostJSONAPI(path, i.WAFRuleExclusion, nil)
 	if err != nil {
 		return nil, err
@@ -273,7 +275,8 @@ func (c *Client) UpdateWAFRuleExclusion(i *UpdateWAFRuleExclusionInput) (*WAFRul
 		return nil, ErrMissingWAFRuleExclusion
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions/%d", i.WAFID, i.WAFVersionNumber, i.Number)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "exclusions", strconv.Itoa(i.Number))
+
 	resp, err := c.PatchJSONAPI(path, i.WAFRuleExclusion, nil)
 	if err != nil {
 		return nil, err
@@ -299,7 +302,8 @@ func (c *Client) DeleteWAFRuleExclusion(i *DeleteWAFRuleExclusionInput) error {
 		return ErrMissingNumber
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/exclusions/%d", i.WAFID, i.WAFVersionNumber, i.Number)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "exclusions", strconv.Itoa(i.Number))
+
 	_, err := c.Delete(path, nil)
 	return err
 }

--- a/fastly/waf_version.go
+++ b/fastly/waf_version.go
@@ -133,7 +133,8 @@ func (c *Client) ListWAFVersions(i *ListWAFVersionsInput) (*WAFVersionResponse, 
 		return nil, ErrMissingWAFID
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions", i.WAFID)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions")
+
 	resp, err := c.Get(path, &RequestOptions{
 		Params: i.formatFilters(),
 	})
@@ -226,7 +227,8 @@ func (c *Client) GetWAFVersion(i *GetWAFVersionInput) (*WAFVersion, error) {
 		return nil, ErrMissingWAFVersionNumber
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d", i.WAFID, i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber))
+
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -334,7 +336,8 @@ func (c *Client) UpdateWAFVersion(i *UpdateWAFVersionInput) (*WAFVersion, error)
 		return nil, ErrMissingWAFVersionID
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d", *i.WAFID, *i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", *i.WAFID, "versions", strconv.Itoa(*i.WAFVersionNumber))
+
 	resp, err := c.PatchJSONAPI(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -366,7 +369,8 @@ func (c *Client) LockWAFVersion(i *LockWAFVersionInput) (*WAFVersion, error) {
 		return nil, ErrMissingWAFVersionNumber
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d", i.WAFID, i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber))
+
 	resp, err := c.PatchJSONAPI(path, &struct {
 		Locked bool `jsonapi:"attr,locked"`
 	}{true}, nil)
@@ -400,7 +404,8 @@ func (c *Client) CloneWAFVersion(i *CloneWAFVersionInput) (*WAFVersion, error) {
 		return nil, ErrMissingWAFVersionNumber
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/clone", i.WAFID, i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "clone")
+
 	resp, err := c.PutJSONAPI(path, &CloneWAFVersionInput{}, nil)
 	if err != nil {
 		return nil, err
@@ -432,7 +437,8 @@ func (c *Client) DeployWAFVersion(i *DeployWAFVersionInput) error {
 		return ErrMissingWAFVersionNumber
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions/%d/activate", i.WAFID, i.WAFVersionNumber)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "activate")
+
 	_, err := c.PutJSONAPI(path, &DeployWAFVersionInput{}, nil)
 	return err
 }
@@ -451,7 +457,8 @@ func (c *Client) CreateEmptyWAFVersion(i *CreateEmptyWAFVersionInput) (*WAFVersi
 		return nil, ErrMissingWAFID
 	}
 
-	path := fmt.Sprintf("/waf/firewalls/%s/versions", i.WAFID)
+	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions")
+
 	resp, err := c.PostJSONAPI(path, nil, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#543 will be reverted before this PR is merged, as this achieves the same result (disallowing injection of path elements in serviceID fields).

As discussed in our chat today, this PR adds a `ToSafeURL` function which accepts a slice of strings that are used to construct the API endpoint URL. Each string is checked for unacceptable values (currently just `..`) and passed through `url.PathEscape`. The result is that if any components contains a 'special character' which could affect parsing or routing of the resulting URL, it will be URL-encoded for safety.

I attempted to find all places where API endpoint URLs were being constructed from one or more components dynamically, but it is certainly possible that I missed some!

While this PR touches a lot of files, I find that the code is more readable now, as the URL-construction process isn't polluted by `Sprintf` format strings.