### PR TITLE
feat(custom_dashboards): Add support for Custom Dashboards APIs.

### DIFF
--- a/fastly/fixtures/observability_custom_dashboards/create_custom_dashboard.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/create_custom_dashboard.yaml
@@ -2,8 +2,9 @@
 version: 1
 interactions:
 - request:
-    body: '{"description":"My dashboard is super cool.","items":[],"name":"My Cool
-      Dashboard"}'
+    body: '{"description":"My dashboard is super cool.","items":[{"data_source":{"config":{"metrics":["requests"]},"type":"stats.edge"},"span":4,"subtitle":"This
+      is a subtitle","title":"A Dashboard Item","visualization":{"config":{"plot_type":"line"},"type":"chart"}}],"name":"My
+      Cool Dashboard"}'
     form: {}
     headers:
       Accept:
@@ -15,19 +16,20 @@ interactions:
     url: https://api.fastly.com/observability/dashboards
     method: POST
   response:
-    body: '{"id":"2i2SYSBHe4ktahuorJrn8P","name":"My Cool Dashboard","description":"My
-      dashboard is super cool.","items":[],"created_at":"2024-09-13T21:08:15Z","updated_at":"2024-09-13T21:08:15Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}'
+    body: '{"id":"4d8YrSYlEVN7O9q55PTROf","name":"My Cool Dashboard","description":"My
+      dashboard is super cool.","items":[{"id":"4Ntbw0nSnAOre49gUjzpE8","span":4,"title":"A
+      Dashboard Item","subtitle":"This is a subtitle","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2024-09-16T18:50:27Z","updated_at":"2024-09-16T18:50:27Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "261"
+      - "493"
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Sep 2024 21:08:15 GMT
+      - Mon, 16 Sep 2024 18:50:27 GMT
       Pragma:
       - no-cache
       Server:
@@ -45,9 +47,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100135-CHI, cache-pdk-katl1840061-PDK
+      - cache-chi-klot8100135-CHI, cache-pdk-kpdk1780083-PDK
       X-Timer:
-      - S1726261696.923679,VS0,VE68
+      - S1726512628.902944,VS0,VE79
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/fixtures/observability_custom_dashboards/create_custom_dashboard.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/create_custom_dashboard.yaml
@@ -1,0 +1,53 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"description":"My dashboard is super cool.","items":[],"name":"My Cool
+      Dashboard"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.23.0)
+    url: https://api.fastly.com/observability/dashboards
+    method: POST
+  response:
+    body: '{"id":"2i2SYSBHe4ktahuorJrn8P","name":"My Cool Dashboard","description":"My
+      dashboard is super cool.","items":[],"created_at":"2024-09-13T21:08:15Z","updated_at":"2024-09-13T21:08:15Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "261"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Sep 2024 21:08:15 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
+      Status:
+      - 201 Created
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-klot8100135-CHI, cache-pdk-katl1840061-PDK
+      X-Timer:
+      - S1726261696.923679,VS0,VE68
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/fixtures/observability_custom_dashboards/delete_custom_dashboard.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/delete_custom_dashboard.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.23.0)
+    url: https://api.fastly.com/observability/dashboards/2i2SYSBHe4ktahuorJrn8P
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Sep 2024 21:08:16 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
+      Status:
+      - 204 No Content
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-klot8100114-CHI, cache-pdk-katl1840061-PDK
+      X-Timer:
+      - S1726261696.240009,VS0,VE68
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/fastly/fixtures/observability_custom_dashboards/delete_custom_dashboard.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/delete_custom_dashboard.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.23.0)
-    url: https://api.fastly.com/observability/dashboards/2i2SYSBHe4ktahuorJrn8P
+    url: https://api.fastly.com/observability/dashboards/4d8YrSYlEVN7O9q55PTROf
     method: DELETE
   response:
     body: ""
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Sep 2024 21:08:16 GMT
+      - Mon, 16 Sep 2024 18:50:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100114-CHI, cache-pdk-katl1840061-PDK
+      - cache-chi-klot8100140-CHI, cache-pdk-kpdk1780083-PDK
       X-Timer:
-      - S1726261696.240009,VS0,VE68
+      - S1726512628.228117,VS0,VE65
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/fixtures/observability_custom_dashboards/get_custom_dashboard.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/get_custom_dashboard.yaml
@@ -7,22 +7,23 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.23.0)
-    url: https://api.fastly.com/observability/dashboards/2i2SYSBHe4ktahuorJrn8P
+    url: https://api.fastly.com/observability/dashboards/4d8YrSYlEVN7O9q55PTROf
     method: GET
   response:
-    body: '{"id":"2i2SYSBHe4ktahuorJrn8P","name":"My Cool Dashboard","description":"My
-      dashboard is super cool.","items":[],"created_at":"2024-09-13T21:08:15Z","updated_at":"2024-09-13T21:08:15Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}'
+    body: '{"id":"4d8YrSYlEVN7O9q55PTROf","name":"My Cool Dashboard","description":"My
+      dashboard is super cool.","items":[{"id":"4Ntbw0nSnAOre49gUjzpE8","span":4,"title":"A
+      Dashboard Item","subtitle":"This is a subtitle","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2024-09-16T18:50:27Z","updated_at":"2024-09-16T18:50:27Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "261"
+      - "493"
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Sep 2024 21:08:16 GMT
+      - Mon, 16 Sep 2024 18:50:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100114-CHI, cache-pdk-katl1840061-PDK
+      - cache-chi-klot8100140-CHI, cache-pdk-kpdk1780083-PDK
       X-Timer:
-      - S1726261696.086195,VS0,VE55
+      - S1726512628.073431,VS0,VE53
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/observability_custom_dashboards/get_custom_dashboard.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/get_custom_dashboard.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.23.0)
+    url: https://api.fastly.com/observability/dashboards/2i2SYSBHe4ktahuorJrn8P
+    method: GET
+  response:
+    body: '{"id":"2i2SYSBHe4ktahuorJrn8P","name":"My Cool Dashboard","description":"My
+      dashboard is super cool.","items":[],"created_at":"2024-09-13T21:08:15Z","updated_at":"2024-09-13T21:08:15Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "261"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Sep 2024 21:08:16 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-klot8100114-CHI, cache-pdk-katl1840061-PDK
+      X-Timer:
+      - S1726261696.086195,VS0,VE55
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/observability_custom_dashboards/list_custom_dashboards.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/list_custom_dashboards.yaml
@@ -20,8 +20,9 @@ interactions:
       5xx","subtitle":"blue is \"compute\", green is not???","data_source":{"type":"stats.edge","config":{"metrics":["compute_resp_status_5xx","status_5xx"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2023-11-06T22:37:48Z","updated_at":"2023-11-06T22:50:37Z","created_by":"","updated_by":""},{"id":"12rbGpXjMQOMJwUZj0FVf2","name":"fasdf","description":"","items":[{"id":"4OD1b3psvtQ8EPOR5k3KmC","span":4,"title":"fdsaf","subtitle":"sadf","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2023-05-02T14:32:15Z","updated_at":"2023-05-02T16:59:36Z","created_by":"","updated_by":""},{"id":"4uqEmZo4PdgX2EUWxoGLjN","name":"Just
       checking POST headers","description":"","items":[],"created_at":"2024-07-09T18:18:01Z","updated_at":"2024-07-09T18:18:01Z","created_by":"6aqLztR9TLUCE2z3AloYbt","updated_by":"6aqLztR9TLUCE2z3AloYbt"},{"id":"UUP04HJC6BWlHGREbUt1R","name":"My
       Cool Dashboard","description":"My dashboard is super cool.","items":[],"created_at":"2024-07-22T19:53:51Z","updated_at":"2024-07-22T19:53:51Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"28AuseY7yJonnqDeXozmrJ","name":"My
-      Cool Dashboard","description":"My dashboard is super cool.","items":[],"created_at":"2024-07-22T19:54:58Z","updated_at":"2024-07-22T19:54:58Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"2i2SYSBHe4ktahuorJrn8P","name":"My
-      Cool Dashboard","description":"My dashboard is super cool.","items":[],"created_at":"2024-09-13T21:08:15Z","updated_at":"2024-09-13T21:08:15Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"4vSKQ9rVoUlHNvl3gUbz0z","name":"my
+      Cool Dashboard","description":"My dashboard is super cool.","items":[],"created_at":"2024-07-22T19:54:58Z","updated_at":"2024-07-22T19:54:58Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"4d8YrSYlEVN7O9q55PTROf","name":"My
+      Cool Dashboard","description":"My dashboard is super cool.","items":[{"id":"4Ntbw0nSnAOre49gUjzpE8","span":4,"title":"A
+      Dashboard Item","subtitle":"This is a subtitle","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2024-09-16T18:50:27Z","updated_at":"2024-09-16T18:50:27Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"4vSKQ9rVoUlHNvl3gUbz0z","name":"my
       impersonated dashboard!","description":"","items":[],"created_at":"2024-06-27T22:21:20Z","updated_at":"2024-06-27T22:21:20Z","created_by":"6aqLztR9TLUCE2z3AloYbt","updated_by":"6aqLztR9TLUCE2z3AloYbt"},{"id":"5OGhkA3Y84dgPWjInl9uF9","name":"My
       new impersonation dashboard","description":"","items":[{"id":"ElNimE7Iymes5v96eAkil","span":12,"title":"This
       is a chart","subtitle":"subtitle...","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"bar"}}}],"created_at":"2024-07-22T19:51:11Z","updated_at":"2024-07-22T19:51:11Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"6kgqXM7F3tWgdCyhFbp9ZB","name":"My
@@ -34,7 +35,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Sep 2024 21:08:16 GMT
+      - Mon, 16 Sep 2024 18:50:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -52,9 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100135-CHI, cache-pdk-katl1840061-PDK
+      - cache-chi-klot8100135-CHI, cache-pdk-kpdk1780083-PDK
       X-Timer:
-      - S1726261696.005339,VS0,VE64
+      - S1726512628.995377,VS0,VE62
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/observability_custom_dashboards/list_custom_dashboards.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/list_custom_dashboards.yaml
@@ -1,0 +1,60 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.23.0)
+    url: https://api.fastly.com/observability/dashboards
+    method: GET
+  response:
+    body: '{"data":[{"id":"5lPlp5aTUCOr0nSHqaVzC8","name":"asdf","description":"","items":[],"created_at":"2023-05-04T17:47:06Z","updated_at":"2024-01-17T23:11:54Z","created_by":"","updated_by":""},{"id":"61RxWJKW4NWsa5jGKV4l4A","name":"asdf","description":"","items":[],"created_at":"2023-05-04T17:47:44Z","updated_at":"2024-01-17T23:11:56Z","created_by":"","updated_by":""},{"id":"6KBJDGi7aQar6dxGp8gN20","name":"asdfdsf","description":"","items":[],"created_at":"2023-05-04T17:48:24Z","updated_at":"2023-05-11T18:29:26Z","created_by":"","updated_by":""},{"id":"3JMZfcutzVaFUjlAHr6Pba","name":"Dashboard
+      for testing api","description":"","items":[{"id":"1zqTeY6KzSrI7CFFOinG2P","span":4,"title":"test
+      donut","subtitle":"asdfadfsf","data_source":{"type":"stats.edge","config":{"metrics":["compute_resp_body_bytes","compute_resp_header_bytes"]}},"visualization":{"type":"chart","config":{"plot_type":"donut","calculation_method":"sum"}}},{"id":"p5o2e65VeqtSLXFjrrngR","span":8,"title":"fart","subtitle":"this
+      chart''s a fart","data_source":{"type":"stats.edge","config":{"metrics":["cache_hit_ratio"]}},"visualization":{"type":"chart","config":{"plot_type":"single-metric","calculation_method":"min"}}}],"created_at":"2023-07-28T16:54:56Z","updated_at":"2024-03-18T18:36:18Z","created_by":"","updated_by":""},{"id":"4tWc6Hr1MXJZcubU38Dpq8","name":"Dropdown
+      test","description":"","items":[],"created_at":"2023-04-17T19:46:41Z","updated_at":"2024-01-17T23:11:49Z","created_by":"","updated_by":""},{"id":"17rdlVHH2d8oc64RVbKQgg","name":"empty
+      charts","description":"","items":[],"created_at":"2023-12-21T20:25:55Z","updated_at":"2023-12-21T20:38:29Z","created_by":"","updated_by":""},{"id":"S3SbM0492DPrfZplpR8cg","name":"errors","description":"","items":[{"id":"3jaynxYnZoVojkVpsSzFVe","span":4,"title":"mem
+      exceeded","subtitle":"asdf","data_source":{"type":"stats.edge","config":{"metrics":["compute_resource_limit_exceeded"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}},{"id":"2nk0ks3UCH571AFwiRxTpI","span":4,"title":"compute
+      5xx","subtitle":"blue is \"compute\", green is not???","data_source":{"type":"stats.edge","config":{"metrics":["compute_resp_status_5xx","status_5xx"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2023-11-06T22:37:48Z","updated_at":"2023-11-06T22:50:37Z","created_by":"","updated_by":""},{"id":"12rbGpXjMQOMJwUZj0FVf2","name":"fasdf","description":"","items":[{"id":"4OD1b3psvtQ8EPOR5k3KmC","span":4,"title":"fdsaf","subtitle":"sadf","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2023-05-02T14:32:15Z","updated_at":"2023-05-02T16:59:36Z","created_by":"","updated_by":""},{"id":"4uqEmZo4PdgX2EUWxoGLjN","name":"Just
+      checking POST headers","description":"","items":[],"created_at":"2024-07-09T18:18:01Z","updated_at":"2024-07-09T18:18:01Z","created_by":"6aqLztR9TLUCE2z3AloYbt","updated_by":"6aqLztR9TLUCE2z3AloYbt"},{"id":"UUP04HJC6BWlHGREbUt1R","name":"My
+      Cool Dashboard","description":"My dashboard is super cool.","items":[],"created_at":"2024-07-22T19:53:51Z","updated_at":"2024-07-22T19:53:51Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"28AuseY7yJonnqDeXozmrJ","name":"My
+      Cool Dashboard","description":"My dashboard is super cool.","items":[],"created_at":"2024-07-22T19:54:58Z","updated_at":"2024-07-22T19:54:58Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"2i2SYSBHe4ktahuorJrn8P","name":"My
+      Cool Dashboard","description":"My dashboard is super cool.","items":[],"created_at":"2024-09-13T21:08:15Z","updated_at":"2024-09-13T21:08:15Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"4vSKQ9rVoUlHNvl3gUbz0z","name":"my
+      impersonated dashboard!","description":"","items":[],"created_at":"2024-06-27T22:21:20Z","updated_at":"2024-06-27T22:21:20Z","created_by":"6aqLztR9TLUCE2z3AloYbt","updated_by":"6aqLztR9TLUCE2z3AloYbt"},{"id":"5OGhkA3Y84dgPWjInl9uF9","name":"My
+      new impersonation dashboard","description":"","items":[{"id":"ElNimE7Iymes5v96eAkil","span":12,"title":"This
+      is a chart","subtitle":"subtitle...","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"bar"}}}],"created_at":"2024-07-22T19:51:11Z","updated_at":"2024-07-22T19:51:11Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"},{"id":"6kgqXM7F3tWgdCyhFbp9ZB","name":"My
+      new impersonation dashboard","description":"this dashboard has no items","items":[],"created_at":"2024-07-22T19:51:39Z","updated_at":"2024-07-22T19:51:39Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}],"meta":{"next_cursor":"","limit":100,"total":15}}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Sep 2024 21:08:16 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-klot8100135-CHI, cache-pdk-katl1840061-PDK
+      X-Timer:
+      - S1726261696.005339,VS0,VE64
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/observability_custom_dashboards/update_custom_dashboard.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/update_custom_dashboard.yaml
@@ -2,8 +2,9 @@
 version: 1
 interactions:
 - request:
-    body: '{"description":"My dashboard just got even cooler.","items":[{"data_source":{"config":{"metrics":["requests"]},"type":"stats.edge"},"span":4,"subtitle":"This
-      is a subtitle","title":"A Dashboard Item","visualization":{"config":{"plot_type":"line"},"type":"chart"}}],"name":"My
+    body: '{"description":"My dashboard just got even cooler.","items":[{"data_source":{"config":{"metrics":["edge_hit_requests"]},"type":"stats.edge"},"id":"4Ntbw0nSnAOre49gUjzpE8","span":4,"subtitle":"This
+      is a subtitle","title":"An Updated Dashboard Item","visualization":{"config":{"plot_type":"single-metric"},"type":"chart"}},{"data_source":{"config":{"metrics":["requests"]},"type":"stats.edge"},"span":4,"subtitle":"This
+      is a subtitle","title":"A New Dashboard Item","visualization":{"config":{"plot_type":"line"},"type":"chart"}}],"name":"My
       Updated Dashboard"}'
     form: {}
     headers:
@@ -13,23 +14,24 @@ interactions:
       - application/json
       User-Agent:
       - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.23.0)
-    url: https://api.fastly.com/observability/dashboards/2i2SYSBHe4ktahuorJrn8P
+    url: https://api.fastly.com/observability/dashboards/4d8YrSYlEVN7O9q55PTROf
     method: PATCH
   response:
-    body: '{"id":"2i2SYSBHe4ktahuorJrn8P","name":"My Updated Dashboard","description":"My
-      dashboard just got even cooler.","items":[{"id":"6bWq84DyDKEm2I6xlZxNQ2","span":4,"title":"A
-      Dashboard Item","subtitle":"This is a subtitle","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2024-09-13T21:08:15Z","updated_at":"2024-09-13T21:08:16Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}'
+    body: '{"id":"4d8YrSYlEVN7O9q55PTROf","name":"My Updated Dashboard","description":"My
+      dashboard just got even cooler.","items":[{"id":"4Ntbw0nSnAOre49gUjzpE8","span":4,"title":"An
+      Updated Dashboard Item","subtitle":"This is a subtitle","data_source":{"type":"stats.edge","config":{"metrics":["edge_hit_requests"]}},"visualization":{"type":"chart","config":{"plot_type":"single-metric"}}},{"id":"2u2k23O7s7RHwHaPHbW1Pg","span":4,"title":"A
+      New Dashboard Item","subtitle":"This is a subtitle","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2024-09-16T18:50:27Z","updated_at":"2024-09-16T18:50:28Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "503"
+      - "767"
       Content-Type:
       - application/json
       Date:
-      - Fri, 13 Sep 2024 21:08:16 GMT
+      - Mon, 16 Sep 2024 18:50:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -47,9 +49,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100114-CHI, cache-pdk-katl1840061-PDK
+      - cache-chi-klot8100140-CHI, cache-pdk-kpdk1780083-PDK
       X-Timer:
-      - S1726261696.156023,VS0,VE70
+      - S1726512628.140121,VS0,VE73
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/observability_custom_dashboards/update_custom_dashboard.yaml
+++ b/fastly/fixtures/observability_custom_dashboards/update_custom_dashboard.yaml
@@ -1,0 +1,55 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"description":"My dashboard just got even cooler.","items":[{"data_source":{"config":{"metrics":["requests"]},"type":"stats.edge"},"span":4,"subtitle":"This
+      is a subtitle","title":"A Dashboard Item","visualization":{"config":{"plot_type":"line"},"type":"chart"}}],"name":"My
+      Updated Dashboard"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.23.0)
+    url: https://api.fastly.com/observability/dashboards/2i2SYSBHe4ktahuorJrn8P
+    method: PATCH
+  response:
+    body: '{"id":"2i2SYSBHe4ktahuorJrn8P","name":"My Updated Dashboard","description":"My
+      dashboard just got even cooler.","items":[{"id":"6bWq84DyDKEm2I6xlZxNQ2","span":4,"title":"A
+      Dashboard Item","subtitle":"This is a subtitle","data_source":{"type":"stats.edge","config":{"metrics":["requests"]}},"visualization":{"type":"chart","config":{"plot_type":"line"}}}],"created_at":"2024-09-13T21:08:15Z","updated_at":"2024-09-13T21:08:16Z","created_by":"7Y26Rzri7e1Jp2feVbkX8H","updated_by":"7Y26Rzri7e1Jp2feVbkX8H"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Sep 2024 21:08:16 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-klot8100114-CHI, cache-pdk-katl1840061-PDK
+      X-Timer:
+      - S1726261696.156023,VS0,VE70
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -118,6 +118,64 @@ type VisualizationConfig struct {
 	PlotType PlotType `json:"plot_type"`
 }
 
+type dashboardItemOption interface {
+	apply(*DashboardItem)
+}
+type optionFunc func(*DashboardItem)
+
+func (f optionFunc) apply(di *DashboardItem) {
+	f(di)
+}
+
+func WithTitle(title string) dashboardItemOption {
+	return optionFunc(func(di *DashboardItem) {
+		di.Title = title
+	})
+}
+func WithSubtitle(subtitle string) dashboardItemOption {
+	return optionFunc(func(di *DashboardItem) {
+		di.Subtitle = subtitle
+	})
+}
+func WithSpan(span uint8) dashboardItemOption {
+	return optionFunc(func(di *DashboardItem) {
+		di.Span = span
+	})
+}
+func WithCalculationMethod(calculationMethod CalculationMethod) dashboardItemOption {
+	return optionFunc(func(di *DashboardItem) {
+		di.Visualization.Config.CalculationMethod = &calculationMethod
+	})
+}
+func WithFormat(format VisualizationFormat) dashboardItemOption {
+	return optionFunc(func(di *DashboardItem) {
+		di.Visualization.Config.Format = &format
+	})
+}
+
+func NewDashboardItem(sourceType DashboardSourceType, metrics []string, plotType PlotType, options ...dashboardItemOption) DashboardItem {
+	di := DashboardItem{
+		DataSource: DashboardDataSource{
+			Type: sourceType,
+			Config: DashboardSourceConfig{
+				Metrics: metrics,
+			},
+		},
+		Visualization: DashboardVisualization{
+			Type: VisualizationTypeChart,
+			Config: VisualizationConfig{
+				PlotType: plotType,
+			},
+		},
+	}
+
+	for _, o := range options {
+		o.apply(&di)
+	}
+
+	return di
+}
+
 type ListDashboardsResponse struct {
 	Data []ObservabilityCustomDashboard `json:"data"`
 	Meta DashboardMeta                  `json:"meta"`

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -89,33 +89,33 @@ type PlotType string
 
 const (
 	PlotTypeLine         PlotType = "line"
-	PlotTypeBar                   = "bar"
-	PlotTypeDonut                 = "donut"
-	PlotTypeSingleMetric          = "single-metric"
+	PlotTypeBar          PlotType = "bar"
+	PlotTypeDonut        PlotType = "donut"
+	PlotTypeSingleMetric PlotType = "single-metric"
 )
 
 type Format string
 
 const (
 	FormatNumber       Format = "number"
-	FormatBytes               = "bytes"
-	FormatPercent             = "percent"
-	FormatRequests            = "requests"
-	FormatResponses           = "responses"
-	FormatSeconds             = "seconds"
-	FormatMilliseconds        = "milliseconds"
-	FormatRatio               = "ratio"
-	FormatBitrate             = "bitrate"
+	FormatBytes        Format = "bytes"
+	FormatPercent      Format = "percent"
+	FormatRequests     Format = "requests"
+	FormatResponses    Format = "responses"
+	FormatSeconds      Format = "seconds"
+	FormatMilliseconds Format = "milliseconds"
+	FormatRatio        Format = "ratio"
+	FormatBitrate      Format = "bitrate"
 )
 
 type CalculationMethod string
 
 const (
 	CalculationMethodAvg    CalculationMethod = "avg"
-	CalculationMethodSum                      = "sum"
-	CalculationMethodMin                      = "min"
-	CalculationMethodMax                      = "max"
-	CalculationMethodLatest                   = "latest"
+	CalculationMethodSum    CalculationMethod = "sum"
+	CalculationMethodMin    CalculationMethod = "min"
+	CalculationMethodMax    CalculationMethod = "max"
+	CalculationMethodLatest CalculationMethod = "latest"
 )
 
 type VisualizationConfig struct {

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -22,21 +22,21 @@ const (
 // ObservabilityCustomDashboard is a named container for a custom dashboard configuration
 type ObservabilityCustomDashboard struct {
 	// The date and time the dashboard was created
-	CreatedAt time.Time `mapstructure:"created_at"`
+	CreatedAt time.Time
 	// The ID of the user who created the dashboard
-	CreatedBy string `mapstructure:"created_by"`
+	CreatedBy string
 	// A short description of the dashboard
-	Description string `mapstructure:"description"`
+	Description string
 	// The unique identifier of the dashboard
-	ID string `mapstructure:"id"`
+	ID string
 	// A list of DashboardItems
-	Items []DashboardItem `mapstructure:"items"`
+	Items []DashboardItem
 	// A human-readable name
-	Name string `mapstructure:"name"`
+	Name string
 	// The date and time the dashboard was last updated
-	UpdatedAt time.Time `mapstructure:"updated_at"`
+	UpdatedAt time.Time
 	// The ID of the user who last modified the dashboard
-	UpdatedBy string `mapstructure:"updated_by"`
+	UpdatedBy string
 }
 
 // DashboardItem describes an item (or "widget") of a dashboard

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -39,17 +39,17 @@ type ObservabilityCustomDashboard struct {
 
 // DashboardItem describes an item (or "widget") of a dashboard
 type DashboardItem struct {
-	// DataSource describes the source of the metrics to be displayed (required).
+	// DataSource describes the source of the metrics to be displayed (required)
 	DataSource DataSource `json:"data_source"`
-	// ID is a unique identifier for the DashboardItem (read-only).
+	// ID is a unique identifier for the DashboardItem (read-only)
 	ID string `json:"id,omitempty"`
-	// Span is the number of columns (1-12) for the DashboardItem to span (default: 4).
+	// Span is the number of columns (1-12) for the DashboardItem to span (default: 4)
 	Span uint8 `json:"span"`
-	// Subtitle is a human-readable subtitle to display, often a description of the visualization (optional).
+	// Subtitle is a human-readable subtitle to display, often a description of the visualization (optional)
 	Subtitle string `json:"subtitle"`
-	// Title is a human-readable title to display (optional).
+	// Title is a human-readable title to display (optional)
 	Title string `json:"title"`
-	// Visualization describes the way the DashboardItem should display data (required).
+	// Visualization describes the way the DashboardItem should display data (required)
 	Visualization Visualization `json:"visualization"`
 }
 
@@ -61,16 +61,19 @@ const (
 	SourceTypeStatsOrigin = "stats.origin"
 )
 
+// DataSource describes the data to display in a DashboardItem
 type DataSource struct {
-	// Config describes configuration options for the selected data source (required).
+	// Config describes configuration options for the selected data source (required)
 	Config SourceConfig `json:"config"`
-	// Type is the source of the data to display (required).
+	// Type is the source of the data to display (required)
 	Type SourceType `json:"type"`
 }
 
 type Metric string
 
 type SourceConfig struct {
+	// Metrics is the list metrics to visualize (required)
+	// Valid options are defined by the selected SourceType. See https://www.fastly.com/documentation/reference/api/observability/custom-dashboards/#data-source
 	Metrics []Metric `json:"metrics"`
 }
 
@@ -79,9 +82,9 @@ type VisualizationType string
 const VisualizationTypeChart VisualizationType = "chart"
 
 type Visualization struct {
-	// Config describes configuration options for the given visualization (required).
+	// Config describes configuration options for the given visualization (required)
 	Config VisualizationConfig `json:"config"`
-	// Type is type of visualization to display. Currently only "chart" is supported (required).
+	// Type is type of visualization to display. Currently only "chart" is supported (required)
 	Type VisualizationType `json:"type"`
 }
 
@@ -94,18 +97,18 @@ const (
 	PlotTypeSingleMetric PlotType = "single-metric"
 )
 
-type Format string
+type VisualizationFormat string
 
 const (
-	FormatNumber       Format = "number"
-	FormatBytes        Format = "bytes"
-	FormatPercent      Format = "percent"
-	FormatRequests     Format = "requests"
-	FormatResponses    Format = "responses"
-	FormatSeconds      Format = "seconds"
-	FormatMilliseconds Format = "milliseconds"
-	FormatRatio        Format = "ratio"
-	FormatBitrate      Format = "bitrate"
+	FormatNumber       VisualizationFormat = "number"
+	FormatBytes        VisualizationFormat = "bytes"
+	FormatPercent      VisualizationFormat = "percent"
+	FormatRequests     VisualizationFormat = "requests"
+	FormatResponses    VisualizationFormat = "responses"
+	FormatSeconds      VisualizationFormat = "seconds"
+	FormatMilliseconds VisualizationFormat = "milliseconds"
+	FormatRatio        VisualizationFormat = "ratio"
+	FormatBitrate      VisualizationFormat = "bitrate"
 )
 
 type CalculationMethod string
@@ -119,11 +122,11 @@ const (
 )
 
 type VisualizationConfig struct {
-	// CalculationMethod is the aggregation function to apply to the dataset (optional).
+	// CalculationMethod is the aggregation function to apply to the dataset (optional)
 	CalculationMethod *CalculationMethod `json:"calculation_method,omitempty"`
-	// Format is the units to use to format the data (optional, default: number).
-	Format *Format `json:"format,omitempty"`
-	// PlotType is the type of chart to display (required).
+	// Format indicates the unit used to format the data (optional, default: number)
+	Format *VisualizationFormat `json:"format,omitempty"`
+	// PlotType is the type of chart to display (required)
 	PlotType PlotType `json:"plot_type"`
 }
 
@@ -132,7 +135,7 @@ type ListDashboardsResponse struct {
 	Meta DashboardMeta                  `json:"meta"`
 }
 
-// DashboardMeta holds metadata about a dashboards query.
+// DashboardMeta holds metadata about a dashboards query
 type DashboardMeta struct {
 	Limit      int    `json:"limit"`
 	NextCursor string `json:"next_cursor"`
@@ -140,13 +143,13 @@ type DashboardMeta struct {
 	Total      int    `json:"total"`
 }
 
-// ListObservabilityCustomDashboardsInput is used as input to the ListObservabilityCustomDashboards function.
+// ListObservabilityCustomDashboardsInput is used as input to the ListObservabilityCustomDashboards function
 type ListObservabilityCustomDashboardsInput struct {
-	// Cursor is the pagination cursor from a previous request's meta (optional).
+	// Cursor is the pagination cursor from a previous request's meta (optional)
 	Cursor *string
-	// Limit is the maximum number of items included in each response (optional).
+	// Limit is the maximum number of items included in each response (optional)
 	Limit *int
-	// Sort is the field on which to sort dashboards (optional).
+	// Sort is the field on which to sort dashboards (optional)
 	Sort *string
 }
 
@@ -200,7 +203,7 @@ func (c *Client) CreateObservabilityCustomDashboard(i *CreateObservabilityCustom
 }
 
 type GetObservabilityCustomDashboardInput struct {
-	// ID of the dashboard to fetch (required).
+	// ID of the dashboard to fetch (required)
 	ID *string
 }
 
@@ -225,7 +228,7 @@ func (c *Client) GetObservabilityCustomDashboard(i *GetObservabilityCustomDashbo
 
 type UpdateObservabilityCustomDashboardInput struct {
 	Description *string `json:"description,omitempty"`
-	// ID of the dashboard to fetch (required).
+	// ID of the dashboard to fetch (required)
 	ID    *string          `json:"-"`
 	Items *[]DashboardItem `json:"items,omitempty"`
 	Name  *string          `json:"name,omitempty"`
@@ -251,7 +254,7 @@ func (c *Client) UpdateObservabilityCustomDashboard(i *UpdateObservabilityCustom
 }
 
 type DeleteObservabilityCustomDashboardInput struct {
-	// ID of the dashboard to delete (required).
+	// ID of the dashboard to delete (required)
 	ID *string
 }
 

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -207,25 +207,10 @@ func (c *Client) ListObservabilityCustomDashboards(i *ListObservabilityCustomDas
 	return ldr, nil
 }
 
-type InputDashboardItem struct {
-	// DataSource describes the source of the metrics to be displayed (required).
-	DataSource DataSource `json:"data_source"`
-	// ID is a unique identifier for the DashboardItem (read-only).
-	ID *string `json:"id,omitempty"`
-	// Span is the number of columns (1-12) for the DashboardItem to span (default: 4).
-	Span uint8 `json:"span"`
-	// Subtitle is a human-readable subtitle to display, often a description of the visualization (optional).
-	Subtitle string `json:"subtitle"`
-	// Title is a human-readable title to display (optional).
-	Title string `json:"title"`
-	// Visualization describes the way the DashboardItem should display data (required).
-	Visualization Visualization `json:"visualization"`
-}
-
 type CreateObservabilityCustomDashboardInput struct {
-	Description *string              `json:"description,omitempty"`
-	Items       []InputDashboardItem `json:"items"`
-	Name        string               `json:"name"`
+	Description *string         `json:"description,omitempty"`
+	Items       []DashboardItem `json:"items"`
+	Name        string          `json:"name"`
 }
 
 func (c *Client) CreateObservabilityCustomDashboard(i *CreateObservabilityCustomDashboardInput) (*ObservabilityCustomDashboard, error) {
@@ -270,9 +255,9 @@ func (c *Client) GetObservabilityCustomDashboard(i *GetObservabilityCustomDashbo
 type UpdateObservabilityCustomDashboardInput struct {
 	Description *string `json:"description,omitempty"`
 	// ID of the dashboard to fetch (required).
-	ID    *string               `json:"-"`
-	Items *[]InputDashboardItem `json:"items,omitempty"`
-	Name  *string               `json:"name,omitempty"`
+	ID    *string          `json:"-"`
+	Items *[]DashboardItem `json:"items,omitempty"`
+	Name  *string          `json:"name,omitempty"`
 }
 
 func (c *Client) UpdateObservabilityCustomDashboard(i *UpdateObservabilityCustomDashboardInput) (*ObservabilityCustomDashboard, error) {

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -40,7 +40,7 @@ type ObservabilityCustomDashboard struct {
 // DashboardItem describes an item (or "widget") of a dashboard
 type DashboardItem struct {
 	// DataSource describes the source of the metrics to be displayed (required)
-	DataSource DataSource `json:"data_source"`
+	DataSource DashboardDataSource `json:"data_source"`
 	// ID is a unique identifier for the DashboardItem (read-only)
 	ID string `json:"id,omitempty"`
 	// Span is the number of columns (1-12) for the DashboardItem to span (default: 4)
@@ -50,10 +50,10 @@ type DashboardItem struct {
 	// Title is a human-readable title to display (optional)
 	Title string `json:"title"`
 	// Visualization describes the way the DashboardItem should display data (required)
-	Visualization Visualization `json:"visualization"`
+	Visualization DashboardVisualization `json:"visualization"`
 }
 
-type SourceType string
+type DashboardSourceType string
 
 const (
 	SourceTypeStatsEdge   = "stats.edge"
@@ -61,27 +61,25 @@ const (
 	SourceTypeStatsOrigin = "stats.origin"
 )
 
-// DataSource describes the data to display in a DashboardItem
-type DataSource struct {
+// DashboardDataSource describes the data to display in a DashboardItem
+type DashboardDataSource struct {
 	// Config describes configuration options for the selected data source (required)
-	Config SourceConfig `json:"config"`
+	Config DashboardSourceConfig `json:"config"`
 	// Type is the source of the data to display (required)
-	Type SourceType `json:"type"`
+	Type DashboardSourceType `json:"type"`
 }
 
-type Metric string
-
-type SourceConfig struct {
+type DashboardSourceConfig struct {
 	// Metrics is the list metrics to visualize (required)
 	// Valid options are defined by the selected SourceType. See https://www.fastly.com/documentation/reference/api/observability/custom-dashboards/#data-source
-	Metrics []Metric `json:"metrics"`
+	Metrics []string `json:"metrics"`
 }
 
 type VisualizationType string
 
 const VisualizationTypeChart VisualizationType = "chart"
 
-type Visualization struct {
+type DashboardVisualization struct {
 	// Config describes configuration options for the given visualization (required)
 	Config VisualizationConfig `json:"config"`
 	// Type is type of visualization to display. Currently only "chart" is supported (required)
@@ -100,15 +98,15 @@ const (
 type VisualizationFormat string
 
 const (
-	FormatNumber       VisualizationFormat = "number"
-	FormatBytes        VisualizationFormat = "bytes"
-	FormatPercent      VisualizationFormat = "percent"
-	FormatRequests     VisualizationFormat = "requests"
-	FormatResponses    VisualizationFormat = "responses"
-	FormatSeconds      VisualizationFormat = "seconds"
-	FormatMilliseconds VisualizationFormat = "milliseconds"
-	FormatRatio        VisualizationFormat = "ratio"
-	FormatBitrate      VisualizationFormat = "bitrate"
+	VisualizationFormatNumber       VisualizationFormat = "number"
+	VisualizationFormatBytes        VisualizationFormat = "bytes"
+	VisualizationFormatPercent      VisualizationFormat = "percent"
+	VisualizationFormatRequests     VisualizationFormat = "requests"
+	VisualizationFormatResponses    VisualizationFormat = "responses"
+	VisualizationFormatSeconds      VisualizationFormat = "seconds"
+	VisualizationFormatMilliseconds VisualizationFormat = "milliseconds"
+	VisualizationFormatRatio        VisualizationFormat = "ratio"
+	VisualizationFormatBitrate      VisualizationFormat = "bitrate"
 )
 
 type CalculationMethod string

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -1,0 +1,318 @@
+package fastly
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const path = "/observability/dashboards"
+
+const (
+	ErrInvalidDataSourceType    = ""
+	ErrInvalidMetric            = ""
+	ErrInvalidVisualizationType = ""
+	ErrInvalidPlotType          = ""
+	ErrInvalidCalculationMethod = ""
+)
+
+// ObservabilityCustomDashboard is a named container for a custom dashboard configuration
+type ObservabilityCustomDashboard struct {
+	// The date and time the dashboard was created
+	CreatedAt time.Time `mapstructure:"created_at"`
+	// The ID of the user who created the dashboard
+	CreatedBy string `mapstructure:"created_by"`
+	// A short description of the dashboard
+	Description string `mapstructure:"description"`
+	// The unique identifier of the dashboard
+	ID string `mapstructure:"id"`
+	// A list of DashboardItems
+	Items []DashboardItem `mapstructure:"items"`
+	// A human-readable name
+	Name string `mapstructure:"name"`
+	// The date and time the dashboard was last updated
+	UpdatedAt time.Time `mapstructure:"updated_at"`
+	// The ID of the user who last modified the dashboard
+	UpdatedBy string `mapstructure:"updated_by"`
+}
+
+// DashboardItem describes an item (or "widget") of a dashboard
+type DashboardItem struct {
+	// DataSource describes the source of the metrics to be displayed (required).
+	DataSource DataSource `json:"data_source"`
+	// ID is a unique identifier for the DashboardItem (read-only).
+	ID string `json:"id,omitempty"`
+	// Span is the number of columns (1-12) for the DashboardItem to span (default: 4).
+	Span uint8 `json:"span"`
+	// Subtitle is a human-readable subtitle to display, often a description of the visualization (optional).
+	Subtitle string `json:"subtitle"`
+	// Title is a human-readable title to display (optional).
+	Title string `json:"title"`
+	// Visualization describes the way the DashboardItem should display data (required).
+	Visualization Visualization `json:"visualization"`
+}
+
+type SourceType int
+
+const (
+	SourceTypeUndefined SourceType = iota
+	SourceTypeStatsEdge
+	SourceTypeStatsDomain
+	SourceTypeStatsOrigin
+)
+
+var stringToSourceType = map[string]SourceType{
+	"stats.edge":   SourceTypeStatsEdge,
+	"stats.domain": SourceTypeStatsDomain,
+	"stats.origin": SourceTypeStatsOrigin,
+}
+
+var sourceTypeToString = map[SourceType]string{
+	SourceTypeStatsEdge:   "stats.edge",
+	SourceTypeStatsDomain: "stats.domain",
+	SourceTypeStatsOrigin: "stats.origin",
+}
+
+func (st SourceType) String() string {
+	return sourceTypeToString[st]
+}
+func (st SourceType) MarshalJSON() ([]byte, error) {
+	if st == SourceTypeUndefined {
+		return nil, errors.New("cannot marshal undefined SourceType")
+	}
+	return json.Marshal(st.String())
+}
+func (st *SourceType) UnmarshalJSON(data []byte) (err error) {
+	var str string
+	if err = json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	var ok bool
+	if *st, ok = stringToSourceType[str]; !ok {
+		return NewFieldError("DataSource.Type").Message(fmt.Sprintf("Invalid value \"%s\" for DataSource.Type", data))
+	}
+	return nil
+}
+
+type DataSource struct {
+	Config SourceConfig `json:"config"`
+	Type   SourceType   `json:"type"`
+}
+
+type Metric string
+
+type SourceConfig struct {
+	Metrics []Metric `json:"metrics"`
+}
+
+type VisualizationType string
+
+const VisualizationTypeChart VisualizationType = "chart"
+
+type Visualization struct {
+	Config VisualizationConfig `json:"config"`
+	Type   VisualizationType   `json:"type"`
+}
+
+type PlotType string
+
+const (
+	PlotTypeLine         PlotType = "line"
+	PlotTypeBar                   = "bar"
+	PlotTypeDonut                 = "donut"
+	PlotTypeSingleMetric          = "single-metric"
+)
+
+type Format string
+
+const (
+	FormatNumber       Format = "number"
+	FormatBytes               = "bytes"
+	FormatPercent             = "percent"
+	FormatRequests            = "requests"
+	FormatResponses           = "responses"
+	FormatSeconds             = "seconds"
+	FormatMilliseconds        = "milliseconds"
+	FormatRatio               = "ratio"
+	FormatBitrate             = "bitrate"
+)
+
+type CalculationMethod string
+
+const (
+	CalculationMethodAvg    CalculationMethod = "avg"
+	CalculationMethodSum                      = "sum"
+	CalculationMethodMin                      = "min"
+	CalculationMethodMax                      = "max"
+	CalculationMethodLatest                   = "latest"
+)
+
+type VisualizationConfig struct {
+	CalculationMethod *CalculationMethod `json:"calculation_method,omitempty"`
+	Format            *Format            `json:"format,omitempty"`
+	PlotType          PlotType           `json:"plot_type"`
+}
+
+type ListDashboardsResponse struct {
+	Data []ObservabilityCustomDashboard `json:"data"`
+	Meta DashboardMeta                  `json:"meta"`
+}
+
+// DashboardMeta holds metadata about a dashboards query.
+type DashboardMeta struct {
+	Limit      int    `json:"limit"`
+	NextCursor string `json:"next_cursor"`
+	Sort       string `json:"sort"`
+	Total      int    `json:"total"`
+}
+
+// ListObservabilityCustomDashboardsInput is used as input to the ListObservabilityCustomDashboards function.
+type ListObservabilityCustomDashboardsInput struct {
+	// Cursor is the pagination cursor from a previous request's meta (optional).
+	Cursor *string
+	// Limit is the maximum number of items included in each response (optional).
+	Limit *int
+	// Sort is the field on which to sort dashboards (optional).
+	Sort *string
+}
+
+func (c *Client) ListObservabilityCustomDashboards(i *ListObservabilityCustomDashboardsInput) (*ListDashboardsResponse, error) {
+	ro := &RequestOptions{
+		Params: map[string]string{},
+	}
+	if i.Cursor != nil {
+		ro.Params["cursor"] = *i.Cursor
+	}
+	if i.Limit != nil {
+		ro.Params["limit"] = strconv.Itoa(*i.Limit)
+	}
+	if i.Sort != nil {
+		ro.Params["sort"] = *i.Sort
+	}
+
+	resp, err := c.Get(path, ro)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var ldr *ListDashboardsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ldr); err != nil {
+		return nil, err
+	}
+
+	return ldr, nil
+}
+
+type InputDashboardItem struct {
+	// DataSource describes the source of the metrics to be displayed (required).
+	DataSource DataSource `json:"data_source"`
+	// ID is a unique identifier for the DashboardItem (read-only).
+	ID *string `json:"id,omitempty"`
+	// Span is the number of columns (1-12) for the DashboardItem to span (default: 4).
+	Span uint8 `json:"span"`
+	// Subtitle is a human-readable subtitle to display, often a description of the visualization (optional).
+	Subtitle string `json:"subtitle"`
+	// Title is a human-readable title to display (optional).
+	Title string `json:"title"`
+	// Visualization describes the way the DashboardItem should display data (required).
+	Visualization Visualization `json:"visualization"`
+}
+
+type CreateObservabilityCustomDashboardInput struct {
+	Description *string              `json:"description,omitempty"`
+	Items       []InputDashboardItem `json:"items"`
+	Name        string               `json:"name"`
+}
+
+func (c *Client) CreateObservabilityCustomDashboard(i *CreateObservabilityCustomDashboardInput) (*ObservabilityCustomDashboard, error) {
+	path := ToSafeURL("observability", "dashboards")
+	resp, err := c.PostJSON(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var ocd *ObservabilityCustomDashboard
+	if err := json.NewDecoder(resp.Body).Decode(&ocd); err != nil {
+		return nil, err
+	}
+	return ocd, nil
+}
+
+type GetObservabilityCustomDashboardInput struct {
+	// ID of the dashboard to fetch (required).
+	ID *string
+}
+
+func (c *Client) GetObservabilityCustomDashboard(i *GetObservabilityCustomDashboardInput) (*ObservabilityCustomDashboard, error) {
+	if i.ID == nil {
+		return nil, ErrMissingID
+	}
+
+	path := ToSafeURL("observability", "dashboards", *i.ID)
+	resp, err := c.Get(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var ocd *ObservabilityCustomDashboard
+	if err := json.NewDecoder(resp.Body).Decode(&ocd); err != nil {
+		return nil, err
+	}
+	return ocd, nil
+}
+
+type UpdateObservabilityCustomDashboardInput struct {
+	Description *string `json:"description,omitempty"`
+	// ID of the dashboard to fetch (required).
+	ID    *string               `json:"-"`
+	Items *[]InputDashboardItem `json:"items,omitempty"`
+	Name  *string               `json:"name,omitempty"`
+}
+
+func (c *Client) UpdateObservabilityCustomDashboard(i *UpdateObservabilityCustomDashboardInput) (*ObservabilityCustomDashboard, error) {
+	if i.ID == nil {
+		return nil, ErrMissingID
+	}
+
+	path := ToSafeURL("observability", "dashboards", *i.ID)
+	resp, err := c.PatchJSON(path, i, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var ocd *ObservabilityCustomDashboard
+	if err := json.NewDecoder(resp.Body).Decode(&ocd); err != nil {
+		return nil, err
+	}
+	return ocd, nil
+}
+
+type DeleteObservabilityCustomDashboardInput struct {
+	// ID of the dashboard to delete (required).
+	ID *string
+}
+
+func (c *Client) DeleteObservabilityCustomDashboard(i *DeleteObservabilityCustomDashboardInput) error {
+	if i.ID == nil {
+		return ErrMissingID
+	}
+	path := ToSafeURL("observability", "dashboards", *i.ID)
+	resp, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return NewHTTPError(resp)
+	}
+
+	return nil
+}

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -7,16 +7,6 @@ import (
 	"time"
 )
 
-const path = "/observability/dashboards"
-
-const (
-	ErrInvalidDataSourceType    = ""
-	ErrInvalidMetric            = ""
-	ErrInvalidVisualizationType = ""
-	ErrInvalidPlotType          = ""
-	ErrInvalidCalculationMethod = ""
-)
-
 // ObservabilityCustomDashboard is a named container for a custom dashboard configuration
 type ObservabilityCustomDashboard struct {
 	// The date and time the dashboard was created
@@ -152,6 +142,7 @@ type ListObservabilityCustomDashboardsInput struct {
 }
 
 func (c *Client) ListObservabilityCustomDashboards(i *ListObservabilityCustomDashboardsInput) (*ListDashboardsResponse, error) {
+	path := ToSafeURL("observability", "dashboards")
 	ro := &RequestOptions{
 		Params: map[string]string{},
 	}

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -2,8 +2,6 @@ package fastly
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -55,47 +53,13 @@ type DashboardItem struct {
 	Visualization Visualization `json:"visualization"`
 }
 
-type SourceType int
+type SourceType string
 
 const (
-	SourceTypeUndefined SourceType = iota
-	SourceTypeStatsEdge
-	SourceTypeStatsDomain
-	SourceTypeStatsOrigin
+	SourceTypeStatsEdge   = "stats.edge"
+	SourceTypeStatsDomain = "stats.domain"
+	SourceTypeStatsOrigin = "stats.origin"
 )
-
-var stringToSourceType = map[string]SourceType{
-	"stats.edge":   SourceTypeStatsEdge,
-	"stats.domain": SourceTypeStatsDomain,
-	"stats.origin": SourceTypeStatsOrigin,
-}
-
-var sourceTypeToString = map[SourceType]string{
-	SourceTypeStatsEdge:   "stats.edge",
-	SourceTypeStatsDomain: "stats.domain",
-	SourceTypeStatsOrigin: "stats.origin",
-}
-
-func (st SourceType) String() string {
-	return sourceTypeToString[st]
-}
-func (st SourceType) MarshalJSON() ([]byte, error) {
-	if st == SourceTypeUndefined {
-		return nil, errors.New("cannot marshal undefined SourceType")
-	}
-	return json.Marshal(st.String())
-}
-func (st *SourceType) UnmarshalJSON(data []byte) (err error) {
-	var str string
-	if err = json.Unmarshal(data, &str); err != nil {
-		return err
-	}
-	var ok bool
-	if *st, ok = stringToSourceType[str]; !ok {
-		return NewFieldError("DataSource.Type").Message(fmt.Sprintf("Invalid value \"%s\" for DataSource.Type", data))
-	}
-	return nil
-}
 
 type DataSource struct {
 	// Config describes configuration options for the selected data source (required).

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -98,8 +98,10 @@ func (st *SourceType) UnmarshalJSON(data []byte) (err error) {
 }
 
 type DataSource struct {
+	// Config describes configuration options for the selected data source (required).
 	Config SourceConfig `json:"config"`
-	Type   SourceType   `json:"type"`
+	// Type is the source of the data to display (required).
+	Type SourceType `json:"type"`
 }
 
 type Metric string
@@ -113,8 +115,10 @@ type VisualizationType string
 const VisualizationTypeChart VisualizationType = "chart"
 
 type Visualization struct {
+	// Config describes configuration options for the given visualization (required).
 	Config VisualizationConfig `json:"config"`
-	Type   VisualizationType   `json:"type"`
+	// Type is type of visualization to display. Currently only "chart" is supported (required).
+	Type VisualizationType `json:"type"`
 }
 
 type PlotType string
@@ -151,9 +155,12 @@ const (
 )
 
 type VisualizationConfig struct {
+	// CalculationMethod is the aggregation function to apply to the dataset (optional).
 	CalculationMethod *CalculationMethod `json:"calculation_method,omitempty"`
-	Format            *Format            `json:"format,omitempty"`
-	PlotType          PlotType           `json:"plot_type"`
+	// Format is the units to use to format the data (optional, default: number).
+	Format *Format `json:"format,omitempty"`
+	// PlotType is the type of chart to display (required).
+	PlotType PlotType `json:"plot_type"`
 }
 
 type ListDashboardsResponse struct {

--- a/fastly/observability_custom_dashboard.go
+++ b/fastly/observability_custom_dashboard.go
@@ -10,21 +10,21 @@ import (
 // ObservabilityCustomDashboard is a named container for a custom dashboard configuration
 type ObservabilityCustomDashboard struct {
 	// The date and time the dashboard was created
-	CreatedAt time.Time
+	CreatedAt time.Time `json:"created_at"`
 	// The ID of the user who created the dashboard
-	CreatedBy string
+	CreatedBy string `json:"created_by"`
 	// A short description of the dashboard
-	Description string
+	Description string `json:"description"`
 	// The unique identifier of the dashboard
-	ID string
+	ID string `json:"id"`
 	// A list of DashboardItems
-	Items []DashboardItem
+	Items []DashboardItem `json:"items"`
 	// A human-readable name
-	Name string
+	Name string `json:"name"`
 	// The date and time the dashboard was last updated
-	UpdatedAt time.Time
+	UpdatedAt time.Time `json:"updated_at"`
 	// The ID of the user who last modified the dashboard
-	UpdatedBy string
+	UpdatedBy string `json:"updated_by"`
 }
 
 // DashboardItem describes an item (or "widget") of a dashboard

--- a/fastly/observability_custom_dashboard_test.go
+++ b/fastly/observability_custom_dashboard_test.go
@@ -14,16 +14,16 @@ func TestClient_ObservabilityCustomDashboards(t *testing.T) {
 		Description: ToPointer("My dashboard is super cool."),
 		Name:        "My Cool Dashboard",
 		Items: []DashboardItem{{
-			DataSource: DataSource{
-				Config: SourceConfig{
-					Metrics: []Metric{"requests"},
+			DataSource: DashboardDataSource{
+				Config: DashboardSourceConfig{
+					Metrics: []string{"requests"},
 				},
 				Type: SourceTypeStatsEdge,
 			},
 			Span:     4,
 			Subtitle: "This is a subtitle",
 			Title:    "A Dashboard Item",
-			Visualization: Visualization{
+			Visualization: DashboardVisualization{
 				Config: VisualizationConfig{PlotType: PlotTypeLine},
 				Type:   VisualizationTypeChart,
 			},
@@ -90,21 +90,21 @@ func TestClient_ObservabilityCustomDashboards(t *testing.T) {
 	// Update
 	var ucd *ObservabilityCustomDashboard
 	items := ocd.Items
-	items[0].DataSource.Config.Metrics = []Metric{"edge_hit_requests"}
+	items[0].DataSource.Config.Metrics = []string{"edge_hit_requests"}
 	items[0].Visualization.Config.PlotType = PlotTypeSingleMetric
 	items[0].Title = "An Updated Dashboard Item"
 
 	items = append(items, DashboardItem{
-		DataSource: DataSource{
-			Config: SourceConfig{
-				Metrics: []Metric{"requests"},
+		DataSource: DashboardDataSource{
+			Config: DashboardSourceConfig{
+				Metrics: []string{"requests"},
 			},
 			Type: SourceTypeStatsEdge,
 		},
 		Span:     4,
 		Subtitle: "This is a subtitle",
 		Title:    "A New Dashboard Item",
-		Visualization: Visualization{
+		Visualization: DashboardVisualization{
 			Config: VisualizationConfig{PlotType: PlotTypeLine},
 			Type:   VisualizationTypeChart,
 		},


### PR DESCRIPTION
[DI-1346](https://fastly.atlassian.net/browse/DI-1346) Implements client for [Observability Custom Dashboards API](https://www.fastly.com/documentation/reference/api/observability/custom-dashboards/)


[DI-1346]: https://fastly.atlassian.net/browse/DI-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ