### PR TITLE
Allow to manage default cert for custom TLS configurations

### DIFF
--- a/fastly/fixtures/custom_tls_configuration/get.yaml
+++ b/fastly/fixtures/custom_tls_configuration/get.yaml
@@ -12,7 +12,7 @@ interactions:
     url: https://api.fastly.com/tls/configurations/TLS_CONFIGURATION_ID
     method: GET
   response:
-    body: '{"data":{"id":"TLS_CONFIGURATION_ID","type":"tls_configuration","attributes":{"bulk":false,"created_at":"2018-09-11T20:59:51.000Z","default":true,"http_protocols":["http/1.1","http/2"],"name":"My configuration","tls_protocols":["1.2"],"updated_at":"2020-10-20T22:16:11.000Z"},"relationships":{"dns_records":{"data":[{"id":"IP_ADDRESS","type":"dns_record"}]}}},"included":[{"id":"IP_ADDRESS","type":"dns_record","attributes":{"record_type":"A","region":"global"}}]}'
+    body: '{"data":{"id":"TLS_CONFIGURATION_ID","type":"tls_configuration","attributes":{"bulk":false,"created_at":"2018-09-11T20:59:51.000Z","default":true,"http_protocols":["http/1.1","http/2"],"name":"My configuration","tls_protocols":["1.2"],"updated_at":"2020-10-20T22:16:11.000Z"},"relationships":{"default_certificate":{"data":{"id":"DEFAULT_CERTIFICATE_ID","type":"tls_certificate"}},"dns_records":{"data":[{"id":"IP_ADDRESS","type":"dns_record"}]}}},"included":[{"id":"IP_ADDRESS","type":"dns_record","attributes":{"record_type":"A","region":"global"}}]}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/fixtures/custom_tls_configuration/update.yaml
+++ b/fastly/fixtures/custom_tls_configuration/update.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"data":{"type":"","attributes":{"id":"TLS_CONFIGURATION_ID","name":"My configuration v2"}}}
+      {"data":{"type":"","attributes":{"id":"TLS_CONFIGURATION_ID","name":"My configuration v2"},"relationships":{"default_certificate":{"data":{"id":"NEW_DEFAULT_CERTIFICATE_ID","type":"tls_certificate"}}}}}
     form: {}
     headers:
       Accept:
@@ -15,7 +15,7 @@ interactions:
     url: https://api.fastly.com/tls/configurations/TLS_CONFIGURATION_ID
     method: PATCH
   response:
-    body: '{"data":{"id":"TLS_CONFIGURATION_ID","type":"tls_configuration","attributes":{"bulk":false,"created_at":"2018-09-11T20:59:51.000Z","default":true,"http_protocols":["http/1.1","http/2"],"name":"My configuration v2","tls_protocols":["1.2"],"updated_at":"2020-10-22T22:38:24.000Z"}}}'
+    body: '{"data":{"id":"TLS_CONFIGURATION_ID","type":"tls_configuration","attributes":{"bulk":false,"created_at":"2018-09-11T20:59:51.000Z","default":true,"http_protocols":["http/1.1","http/2"],"name":"My configuration v2","tls_protocols":["1.2"],"updated_at":"2020-10-22T22:38:24.000Z"},"relationships":{"default_certificate":{"data":{"id":"NEW_DEFAULT_CERTIFICATE_ID","type":"tls_certificate"}}}}}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/tls_custom_configuration.go
+++ b/fastly/tls_custom_configuration.go
@@ -11,15 +11,16 @@ import (
 
 // CustomTLSConfiguration represents a TLS configuration response from the Fastly API.
 type CustomTLSConfiguration struct {
-	Bulk          bool         `jsonapi:"attr,bulk"`
-	CreatedAt     *time.Time   `jsonapi:"attr,created_at,iso8601"`
-	DNSRecords    []*DNSRecord `jsonapi:"relation,dns_records"`
-	Default       bool         `jsonapi:"attr,default"`
-	HTTPProtocols []string     `jsonapi:"attr,http_protocols"`
-	ID            string       `jsonapi:"primary,tls_configuration"`
-	Name          string       `jsonapi:"attr,name"`
-	TLSProtocols  []string     `jsonapi:"attr,tls_protocols"`
-	UpdatedAt     *time.Time   `jsonapi:"attr,updated_at,iso8601"`
+	Bulk               bool                `jsonapi:"attr,bulk"`
+	CreatedAt          *time.Time          `jsonapi:"attr,created_at,iso8601"`
+	DNSRecords         []*DNSRecord        `jsonapi:"relation,dns_records"`
+	Default            bool                `jsonapi:"attr,default"`
+	HTTPProtocols      []string            `jsonapi:"attr,http_protocols"`
+	ID                 string              `jsonapi:"primary,tls_configuration"`
+	Name               string              `jsonapi:"attr,name"`
+	TLSProtocols       []string            `jsonapi:"attr,tls_protocols"`
+	UpdatedAt          *time.Time          `jsonapi:"attr,updated_at,iso8601"`
+	DefaultCertificate *DefaultCertificate `jsonapi:"relation,default_certificate,omitempty"`
 }
 
 // DNSRecord is a child of CustomTLSConfiguration.
@@ -27,6 +28,12 @@ type DNSRecord struct {
 	ID         string `jsonapi:"primary,dns_record"`
 	RecordType string `jsonapi:"attr,record_type"`
 	Region     string `jsonapi:"attr,region"`
+}
+
+// DefaultCertificate is a child of CustomTLSConfiguration. Used as a fallback cert for Platform TLS.
+type DefaultCertificate struct {
+	ID   string `jsonapi:"primary,tls_certificate"`
+	Type string `jsonapi:"attr,type"`
 }
 
 // ListCustomTLSConfigurationsInput is used as input to the ListCustomTLSConfigurationsInput function.
@@ -148,6 +155,8 @@ type UpdateCustomTLSConfigurationInput struct {
 	ID string
 	// Name is a custom name for your TLS configuration.
 	Name string `jsonapi:"attr,name"`
+	// DefaultCertificate is the default certificate for the TLS configuration. Used as a fallback cert for Platform TLS.
+	DefaultCertificate *DefaultCertificate `jsonapi:"relation,default_certificate,omitempty"`
 }
 
 // UpdateCustomTLSConfiguration updates the specified resource.

--- a/fastly/tls_custom_configuration_test.go
+++ b/fastly/tls_custom_configuration_test.go
@@ -11,6 +11,7 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 
 	var err error
 	conID := "TLS_CONFIGURATION_ID"
+	certID := "DEFAULT_CERTIFICATE_ID"
 
 	// Get
 	var gcon *CustomTLSConfiguration
@@ -24,6 +25,14 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 	}
 	if conID != gcon.ID {
 		t.Errorf("bad ID: %q (%q)", conID, gcon.ID)
+	}
+
+	if gcon.DefaultCertificate == nil {
+		t.Errorf("missing default certificate: %v", gcon.DefaultCertificate)
+	}
+
+	if gcon.DefaultCertificate.ID != certID {
+		t.Errorf("wrong default certificate ID: %v", gcon.DefaultCertificate.ID)
 	}
 
 	// List
@@ -41,10 +50,15 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 	// Update
 	var ucon *CustomTLSConfiguration
 	newName := "My configuration v2"
+	newCertID := "NEW_DEFAULT_CERTIFICATE_ID"
 	record(t, fixtureBase+"update", func(c *Client) {
 		ucon, err = c.UpdateCustomTLSConfiguration(&UpdateCustomTLSConfigurationInput{
 			ID:   "TLS_CONFIGURATION_ID",
 			Name: newName,
+			DefaultCertificate: &DefaultCertificate{
+				ID:   newCertID,
+				Type: "tls_certificate",
+			},
 		})
 	})
 	if err != nil {
@@ -55,6 +69,12 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 	}
 	if ucon.Name != newName {
 		t.Errorf("bad Name: %q (%q)", newName, ucon.Name)
+	}
+	if ucon.DefaultCertificate == nil {
+		t.Fatal("missing default certificate")
+	}
+	if ucon.DefaultCertificate.ID != newCertID {
+		t.Errorf("bad default cert ID: %q (%q)", newCertID, ucon.DefaultCertificate.ID)
 	}
 }
 


### PR DESCRIPTION
This PR allows to manage the default certificate for custom TLS configuration. This is relevant for PlatformTLS. 