### PR TITLE
test(product_enablement): Add test suites for all supported products.

### DIFF
--- a/fastly/fastly_test.go
+++ b/fastly/fastly_test.go
@@ -20,16 +20,12 @@ var testStatsClient = NewRealtimeStatsClient()
 var testDeliveryServiceID = deliveryServiceIDForTest()
 
 // ID of the Compute service for testing.
-//
-//lint:ignore U1000 this will be used in an upcoming commit
 var testComputeServiceID = computeServiceIDForTest()
 
 // ID of the default Delivery service for testing.
 var defaultDeliveryTestServiceID = "kKJb5bOFI47uHeBVluGfX1"
 
 // ID of the default Compute service for testing.
-//
-//lint:ignore U1000 this will be used in an upcoming commit
 var defaultComputeTestServiceID = "XsjdElScZGjmfCcTwsYRC1"
 
 const (
@@ -51,7 +47,6 @@ func deliveryServiceIDForTest() string {
 	return defaultDeliveryTestServiceID
 }
 
-//lint:ignore U1000 this will be used in an upcoming commit
 func computeServiceIDForTest() string {
 	if tsid := os.Getenv("FASTLY_TEST_COMPUTE_SERVICE_ID"); tsid != "" {
 		return tsid

--- a/fastly/fixtures/product_enablement/disable_bot_management.yaml
+++ b/fastly/fixtures/product_enablement/disable_bot_management.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/bot_management/services/kKJb5bOFI47uHeBVluGfX1
     method: DELETE
   response:
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:55 GMT
+      - Wed, 06 Nov 2024 20:18:24 GMT
       Pragma:
       - no-cache
       Server:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000069-CHI, cache-nyc-kteb1890025-NYC
+      - cache-chi-kigq8000069-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839134.821062,VS0,VE1506
+      - S1730924303.402314,VS0,VE1024
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/fixtures/product_enablement/disable_brotli_compression.yaml
+++ b/fastly/fixtures/product_enablement/disable_brotli_compression.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
     method: DELETE
   response:
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:22 GMT
+      - Wed, 06 Nov 2024 20:18:21 GMT
       Pragma:
       - no-cache
       Server:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-nyc-kteb1890054-NYC
+      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839103.536201,VS0,VE231
+      - S1730924302.575396,VS0,VE210
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/fixtures/product_enablement/disable_domain_inspector.yaml
+++ b/fastly/fixtures/product_enablement/disable_domain_inspector.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/domain_inspector/services/kKJb5bOFI47uHeBVluGfX1
+    method: DELETE
   response:
-    body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "83"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100037-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924303.583736,VS0,VE990
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/product_enablement/disable_fanout.yaml
+++ b/fastly/fixtures/product_enablement/disable_fanout.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/fanout/services/XsjdElScZGjmfCcTwsYRC1
+    method: DELETE
   response:
-    body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "83"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-kigq8000137-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924303.658245,VS0,VE520
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/product_enablement/disable_image_optimizer.yaml
+++ b/fastly/fixtures/product_enablement/disable_image_optimizer.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/image_optimizer/services/kKJb5bOFI47uHeBVluGfX1
+    method: DELETE
   response:
-    body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "83"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:25 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-kigq8000128-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924304.279790,VS0,VE1095
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/product_enablement/disable_log_explorer_insights.yaml
+++ b/fastly/fixtures/product_enablement/disable_log_explorer_insights.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/log_explorer_insights/services/kKJb5bOFI47uHeBVluGfX1
     method: DELETE
   response:
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:43 GMT
+      - Wed, 06 Nov 2024 20:18:25 GMT
       Pragma:
       - no-cache
       Server:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100124-CHI, cache-nyc-kteb1890072-NYC
+      - cache-chi-klot8100124-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839122.120404,VS0,VE884
+      - S1730924305.931884,VS0,VE831
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/fixtures/product_enablement/disable_origin_inspector.yaml
+++ b/fastly/fixtures/product_enablement/disable_origin_inspector.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/origin_inspector/services/kKJb5bOFI47uHeBVluGfX1
+    method: DELETE
   response:
-    body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "83"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:25 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100125-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924304.959599,VS0,VE1155
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/product_enablement/disable_websockets.yaml
+++ b/fastly/fixtures/product_enablement/disable_websockets.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/websockets/services/kKJb5bOFI47uHeBVluGfX1
+    method: DELETE
   response:
-    body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "83"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100118-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924303.978744,VS0,VE427
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/product_enablement/enable_bot_management.yaml
+++ b/fastly/fixtures/product_enablement/enable_bot_management.yaml
@@ -2,17 +2,15 @@
 version: 1
 interactions:
 - request:
-    body: ProductID=bot_management&ServiceID=kKJb5bOFI47uHeBVluGfX1
-    form:
-      ProductID:
-      - bot_management
-      ServiceID:
-      - kKJb5bOFI47uHeBVluGfX1
+    body: '{"ProductID":1,"ServiceID":"kKJb5bOFI47uHeBVluGfX1"}'
+    form: {}
     headers:
+      Accept:
+      - application/json
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/bot_management/services/kKJb5bOFI47uHeBVluGfX1
     method: PUT
   response:
@@ -28,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:53 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -46,9 +44,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000069-CHI, cache-nyc-kteb1890025-NYC
+      - cache-chi-kigq8000069-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839132.074411,VS0,VE1612
+      - S1730924301.146435,VS0,VE2136
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/enable_brotli_compression.yaml
+++ b/fastly/fixtures/product_enablement/enable_brotli_compression.yaml
@@ -2,17 +2,15 @@
 version: 1
 interactions:
 - request:
-    body: ProductID=brotli_compression&ServiceID=kKJb5bOFI47uHeBVluGfX1
-    form:
-      ProductID:
-      - brotli_compression
-      ServiceID:
-      - kKJb5bOFI47uHeBVluGfX1
+    body: '{"ProductID":2,"ServiceID":"kKJb5bOFI47uHeBVluGfX1"}'
+    form: {}
     headers:
+      Accept:
+      - application/json
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
     method: PUT
   response:
@@ -28,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:22 GMT
+      - Wed, 06 Nov 2024 20:18:21 GMT
       Pragma:
       - no-cache
       Server:
@@ -46,9 +44,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-nyc-kteb1890054-NYC
+      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839102.088178,VS0,VE332
+      - S1730924301.146427,VS0,VE294
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/enable_domain_inspector.yaml
+++ b/fastly/fixtures/product_enablement/enable_domain_inspector.yaml
@@ -2,33 +2,37 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"ProductID":3,"ServiceID":"kKJb5bOFI47uHeBVluGfX1"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/domain_inspector/services/kKJb5bOFI47uHeBVluGfX1
+    method: PUT
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"domain_inspector","object":"product"},"service":{"id":"kKJb5bOFI47uHeBVluGfX1","object":"service"},"_links":{"self":"/enabled-products/domain_inspector/services/kKJb5bOFI47uHeBVluGfX1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "205"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:22 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +44,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100037-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924301.151413,VS0,VE1295
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/enable_fanout.yaml
+++ b/fastly/fixtures/product_enablement/enable_fanout.yaml
@@ -2,33 +2,37 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"ProductID":4,"ServiceID":"XsjdElScZGjmfCcTwsYRC1"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/fanout/services/XsjdElScZGjmfCcTwsYRC1
+    method: PUT
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"fanout","object":"product"},"service":{"id":"XsjdElScZGjmfCcTwsYRC1","object":"service"},"_links":{"self":"/enabled-products/fanout/services/XsjdElScZGjmfCcTwsYRC1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "185"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:22 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +44,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-kigq8000137-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924301.151422,VS0,VE1313
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/enable_image_optimizer.yaml
+++ b/fastly/fixtures/product_enablement/enable_image_optimizer.yaml
@@ -2,33 +2,37 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"ProductID":5,"ServiceID":"kKJb5bOFI47uHeBVluGfX1"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/image_optimizer/services/kKJb5bOFI47uHeBVluGfX1
+    method: PUT
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"image_optimizer","object":"product"},"service":{"id":"kKJb5bOFI47uHeBVluGfX1","object":"service"},"_links":{"self":"/enabled-products/image_optimizer/services/kKJb5bOFI47uHeBVluGfX1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "203"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:24 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +44,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-kigq8000128-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924301.151476,VS0,VE3000
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/enable_log_explorer_insights.yaml
+++ b/fastly/fixtures/product_enablement/enable_log_explorer_insights.yaml
@@ -2,17 +2,15 @@
 version: 1
 interactions:
 - request:
-    body: ProductID=log_explorer_insights&ServiceID=kKJb5bOFI47uHeBVluGfX1
-    form:
-      ProductID:
-      - log_explorer_insights
-      ServiceID:
-      - kKJb5bOFI47uHeBVluGfX1
+    body: '{"ProductID":6,"ServiceID":"kKJb5bOFI47uHeBVluGfX1"}'
+    form: {}
     headers:
+      Accept:
+      - application/json
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/log_explorer_insights/services/kKJb5bOFI47uHeBVluGfX1
     method: PUT
   response:
@@ -28,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:41 GMT
+      - Wed, 06 Nov 2024 20:18:24 GMT
       Pragma:
       - no-cache
       Server:
@@ -46,9 +44,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100124-CHI, cache-nyc-kteb1890072-NYC
+      - cache-chi-klot8100124-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839120.324995,VS0,VE1651
+      - S1730924301.151447,VS0,VE3654
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/enable_origin_inspector.yaml
+++ b/fastly/fixtures/product_enablement/enable_origin_inspector.yaml
@@ -2,33 +2,37 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"ProductID":7,"ServiceID":"kKJb5bOFI47uHeBVluGfX1"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/origin_inspector/services/kKJb5bOFI47uHeBVluGfX1
+    method: PUT
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"origin_inspector","object":"product"},"service":{"id":"kKJb5bOFI47uHeBVluGfX1","object":"service"},"_links":{"self":"/enabled-products/origin_inspector/services/kKJb5bOFI47uHeBVluGfX1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "205"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +44,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100125-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924301.146490,VS0,VE2698
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/enable_websockets.yaml
+++ b/fastly/fixtures/product_enablement/enable_websockets.yaml
@@ -2,33 +2,37 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"ProductID":8,"ServiceID":"kKJb5bOFI47uHeBVluGfX1"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
-    method: GET
+    url: https://api.fastly.com/enabled-products/websockets/services/kKJb5bOFI47uHeBVluGfX1
+    method: PUT
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"websockets","object":"product"},"service":{"id":"kKJb5bOFI47uHeBVluGfX1","object":"service"},"_links":{"self":"/enabled-products/websockets/services/kKJb5bOFI47uHeBVluGfX1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "193"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:22 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +44,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100118-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924301.146427,VS0,VE1736
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/get-disabled_bot_management.yaml
+++ b/fastly/fixtures/product_enablement/get-disabled_bot_management.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/bot_management/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:55 GMT
+      - Wed, 06 Nov 2024 20:18:24 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000069-CHI, cache-nyc-kteb1890025-NYC
+      - cache-chi-kigq8000069-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839135.334741,VS0,VE111
+      - S1730924304.433536,VS0,VE114
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/fastly/fixtures/product_enablement/get-disabled_domain_inspector.yaml
+++ b/fastly/fixtures/product_enablement/get-disabled_domain_inspector.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/domain_inspector/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
     body: |
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100037-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
+      - S1730924304.578991,VS0,VE110
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/fastly/fixtures/product_enablement/get-disabled_fanout.yaml
+++ b/fastly/fixtures/product_enablement/get-disabled_fanout.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/fanout/services/XsjdElScZGjmfCcTwsYRC1
     method: GET
   response:
     body: |
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-kigq8000137-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
+      - S1730924303.183636,VS0,VE89
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/fastly/fixtures/product_enablement/get-disabled_image_optimizer.yaml
+++ b/fastly/fixtures/product_enablement/get-disabled_image_optimizer.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/image_optimizer/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
     body: |
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:25 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-kigq8000128-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
+      - S1730924305.381459,VS0,VE108
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/fastly/fixtures/product_enablement/get-disabled_log_explorer_insights.yaml
+++ b/fastly/fixtures/product_enablement/get-disabled_log_explorer_insights.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/log_explorer_insights/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:43 GMT
+      - Wed, 06 Nov 2024 20:18:25 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100124-CHI, cache-nyc-kteb1890072-NYC
+      - cache-chi-klot8100124-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839123.011400,VS0,VE117
+      - S1730924306.769626,VS0,VE123
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/fastly/fixtures/product_enablement/get-disabled_origin_inspector.yaml
+++ b/fastly/fixtures/product_enablement/get-disabled_origin_inspector.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/origin_inspector/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
     body: |
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:25 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100125-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
+      - S1730924305.119257,VS0,VE112
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/fastly/fixtures/product_enablement/get-disabled_websockets.yaml
+++ b/fastly/fixtures/product_enablement/get-disabled_websockets.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/websockets/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
     body: |
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100118-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
+      - S1730924303.413407,VS0,VE54
     status: 400 Bad Request
     code: 400
     duration: ""

--- a/fastly/fixtures/product_enablement/get_bot_management.yaml
+++ b/fastly/fixtures/product_enablement/get_bot_management.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/bot_management/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:53 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000069-CHI, cache-nyc-kteb1890025-NYC
+      - cache-chi-kigq8000069-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839134.697110,VS0,VE116
+      - S1730924303.290433,VS0,VE106
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/get_brotli_compression.yaml
+++ b/fastly/fixtures/product_enablement/get_brotli_compression.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:22 GMT
+      - Wed, 06 Nov 2024 20:18:21 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-nyc-kteb1890054-NYC
+      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839102.429491,VS0,VE100
+      - S1730924301.447537,VS0,VE122
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/get_domain_inspector.yaml
+++ b/fastly/fixtures/product_enablement/get_domain_inspector.yaml
@@ -7,28 +7,28 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/domain_inspector/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"domain_inspector","object":"product"},"service":{"id":"kKJb5bOFI47uHeBVluGfX1","object":"service"},"_links":{"self":"/enabled-products/domain_inspector/services/kKJb5bOFI47uHeBVluGfX1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "205"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:22 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100037-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924302.461842,VS0,VE117
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/get_fanout.yaml
+++ b/fastly/fixtures/product_enablement/get_fanout.yaml
@@ -7,28 +7,28 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/fanout/services/XsjdElScZGjmfCcTwsYRC1
     method: GET
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"fanout","object":"product"},"service":{"id":"XsjdElScZGjmfCcTwsYRC1","object":"service"},"_links":{"self":"/enabled-products/fanout/services/XsjdElScZGjmfCcTwsYRC1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "185"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:22 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-kigq8000137-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924302.484157,VS0,VE115
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/get_image_optimizer.yaml
+++ b/fastly/fixtures/product_enablement/get_image_optimizer.yaml
@@ -7,28 +7,28 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/image_optimizer/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"image_optimizer","object":"product"},"service":{"id":"kKJb5bOFI47uHeBVluGfX1","object":"service"},"_links":{"self":"/enabled-products/image_optimizer/services/kKJb5bOFI47uHeBVluGfX1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "203"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:24 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-kigq8000128-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924304.156258,VS0,VE116
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/get_log_explorer_insights.yaml
+++ b/fastly/fixtures/product_enablement/get_log_explorer_insights.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
     url: https://api.fastly.com/enabled-products/log_explorer_insights/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Nov 2024 20:38:42 GMT
+      - Wed, 06 Nov 2024 20:18:24 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100124-CHI, cache-nyc-kteb1890072-NYC
+      - cache-chi-klot8100124-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730839122.985337,VS0,VE128
+      - S1730924305.814337,VS0,VE111
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/get_origin_inspector.yaml
+++ b/fastly/fixtures/product_enablement/get_origin_inspector.yaml
@@ -7,28 +7,28 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/origin_inspector/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"origin_inspector","object":"product"},"service":{"id":"kKJb5bOFI47uHeBVluGfX1","object":"service"},"_links":{"self":"/enabled-products/origin_inspector/services/kKJb5bOFI47uHeBVluGfX1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "205"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:23 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100125-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924304.853084,VS0,VE101
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/fixtures/product_enablement/get_websockets.yaml
+++ b/fastly/fixtures/product_enablement/get_websockets.yaml
@@ -7,28 +7,28 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.23.2)
-    url: https://api.fastly.com/enabled-products/brotli_compression/services/kKJb5bOFI47uHeBVluGfX1
+    url: https://api.fastly.com/enabled-products/websockets/services/kKJb5bOFI47uHeBVluGfX1
     method: GET
   response:
     body: |
-      {"type":"","title":"no product on service","status":400,"errors":null,"detail":""}
+      {"product":{"id":"websockets","object":"product"},"service":{"id":"kKJb5bOFI47uHeBVluGfX1","object":"service"},"_links":{"self":"/enabled-products/websockets/services/kKJb5bOFI47uHeBVluGfX1"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "83"
+      - "193"
       Content-Type:
       - application/json
       Date:
-      - Wed, 06 Nov 2024 20:18:21 GMT
+      - Wed, 06 Nov 2024 20:18:22 GMT
       Pragma:
       - no-cache
       Server:
       - control-gateway
       Status:
-      - 400 Bad Request
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,9 +40,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000119-CHI, cache-ewr-kewr1740064-EWR
+      - cache-chi-klot8100118-CHI, cache-ewr-kewr1740064-EWR
       X-Timer:
-      - S1730924302.790192,VS0,VE105
-    status: 400 Bad Request
-    code: 400
+      - S1730924303.887761,VS0,VE86
+    status: 200 OK
+    code: 200
     duration: ""

--- a/fastly/product_enablement.go
+++ b/fastly/product_enablement.go
@@ -1,7 +1,5 @@
 package fastly
 
-import "fmt"
-
 // ProductEnablement represents a response from the Fastly API.
 type ProductEnablement struct {
 	Product *ProductEnablementNested `mapstructure:"product"`
@@ -69,7 +67,7 @@ func (c *Client) GetProduct(i *ProductEnablementInput) (*ProductEnablement, erro
 		return nil, ErrMissingServiceID
 	}
 
-	path := ToSafeURL("enabled-products", fmt.Sprint(i.ProductID), "services", i.ServiceID)
+	path := ToSafeURL("enabled-products", i.ProductID.String(), "services", i.ServiceID)
 
 	resp, err := c.Get(path, nil)
 	if err != nil {
@@ -94,9 +92,9 @@ func (c *Client) EnableProduct(i *ProductEnablementInput) (*ProductEnablement, e
 		return nil, ErrMissingServiceID
 	}
 
-	path := ToSafeURL("enabled-products", fmt.Sprint(i.ProductID), "services", i.ServiceID)
+	path := ToSafeURL("enabled-products", i.ProductID.String(), "services", i.ServiceID)
 
-	resp, err := c.PutForm(path, i, nil)
+	resp, err := c.PutJSON(path, i, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +116,7 @@ func (c *Client) DisableProduct(i *ProductEnablementInput) error {
 		return ErrMissingServiceID
 	}
 
-	path := ToSafeURL("enabled-products", fmt.Sprint(i.ProductID), "services", i.ServiceID)
+	path := ToSafeURL("enabled-products", i.ProductID.String(), "services", i.ServiceID)
 
 	_, err := c.Delete(path, nil)
 	return err

--- a/fastly/product_enablement_domain_inspector_test.go
+++ b/fastly/product_enablement_domain_inspector_test.go
@@ -1,0 +1,121 @@
+package fastly
+
+import (
+	"testing"
+)
+
+func TestClient_ProductEnablement_domain_inspector(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	// Enable Product - Bot Management
+	var pe *ProductEnablement
+	record(t, "product_enablement/enable_domain_inspector", func(c *Client) {
+		pe, err = c.EnableProduct(&ProductEnablementInput{
+			ProductID: ProductDomainInspector,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *pe.Product.ProductID != ProductDomainInspector.String() {
+		t.Errorf("bad feature_revision: %s", *pe.Product.ProductID)
+	}
+
+	// Get Product status
+	var gpe *ProductEnablement
+	record(t, "product_enablement/get_domain_inspector", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductDomainInspector,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *gpe.Product.ProductID != ProductDomainInspector.String() {
+		t.Errorf("bad feature_revision: %s", *gpe.Product.ProductID)
+	}
+
+	// Disable Product
+	record(t, "product_enablement/disable_domain_inspector", func(c *Client) {
+		err = c.DisableProduct(&ProductEnablementInput{
+			ProductID: ProductDomainInspector,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get Product status again to check disabled
+	record(t, "product_enablement/get-disabled_domain_inspector", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductDomainInspector,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+
+	// The API returns a 400 if Product is not enabled.
+	// The API client returns an error if a non-2xx is returned from the API.
+	if err == nil {
+		t.Fatal("expected a 400 from the API but got a 2xx")
+	}
+}
+
+func TestClient_GetProduct_validation_domain_inspector(t *testing.T) {
+	var err error
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ProductID: ProductDomainInspector,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_EnableProduct_validation_domain_inspector(t *testing.T) {
+	var err error
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ProductID: ProductDomainInspector,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DisableProduct_validation_domain_inspector(t *testing.T) {
+	var err error
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ProductID: ProductDomainInspector,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}

--- a/fastly/product_enablement_fanout_test.go
+++ b/fastly/product_enablement_fanout_test.go
@@ -1,0 +1,121 @@
+package fastly
+
+import (
+	"testing"
+)
+
+func TestClient_ProductEnablement_fanout(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	// Enable Product - Bot Management
+	var pe *ProductEnablement
+	record(t, "product_enablement/enable_fanout", func(c *Client) {
+		pe, err = c.EnableProduct(&ProductEnablementInput{
+			ProductID: ProductFanout,
+			ServiceID: testComputeServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *pe.Product.ProductID != ProductFanout.String() {
+		t.Errorf("bad feature_revision: %s", *pe.Product.ProductID)
+	}
+
+	// Get Product status
+	var gpe *ProductEnablement
+	record(t, "product_enablement/get_fanout", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductFanout,
+			ServiceID: testComputeServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *gpe.Product.ProductID != ProductFanout.String() {
+		t.Errorf("bad feature_revision: %s", *gpe.Product.ProductID)
+	}
+
+	// Disable Product
+	record(t, "product_enablement/disable_fanout", func(c *Client) {
+		err = c.DisableProduct(&ProductEnablementInput{
+			ProductID: ProductFanout,
+			ServiceID: testComputeServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get Product status again to check disabled
+	record(t, "product_enablement/get-disabled_fanout", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductFanout,
+			ServiceID: testComputeServiceID,
+		})
+	})
+
+	// The API returns a 400 if Product is not enabled.
+	// The API client returns an error if a non-2xx is returned from the API.
+	if err == nil {
+		t.Fatal("expected a 400 from the API but got a 2xx")
+	}
+}
+
+func TestClient_GetProduct_validation_fanout(t *testing.T) {
+	var err error
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ProductID: ProductFanout,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_EnableProduct_validation_fanout(t *testing.T) {
+	var err error
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ProductID: ProductFanout,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DisableProduct_validation_fanout(t *testing.T) {
+	var err error
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ProductID: ProductFanout,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}

--- a/fastly/product_enablement_image_optimizer_test.go
+++ b/fastly/product_enablement_image_optimizer_test.go
@@ -1,0 +1,121 @@
+package fastly
+
+import (
+	"testing"
+)
+
+func TestClient_ProductEnablement_image_optimizer(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	// Enable Product - Bot Management
+	var pe *ProductEnablement
+	record(t, "product_enablement/enable_image_optimizer", func(c *Client) {
+		pe, err = c.EnableProduct(&ProductEnablementInput{
+			ProductID: ProductImageOptimizer,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *pe.Product.ProductID != ProductImageOptimizer.String() {
+		t.Errorf("bad feature_revision: %s", *pe.Product.ProductID)
+	}
+
+	// Get Product status
+	var gpe *ProductEnablement
+	record(t, "product_enablement/get_image_optimizer", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductImageOptimizer,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *gpe.Product.ProductID != ProductImageOptimizer.String() {
+		t.Errorf("bad feature_revision: %s", *gpe.Product.ProductID)
+	}
+
+	// Disable Product
+	record(t, "product_enablement/disable_image_optimizer", func(c *Client) {
+		err = c.DisableProduct(&ProductEnablementInput{
+			ProductID: ProductImageOptimizer,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get Product status again to check disabled
+	record(t, "product_enablement/get-disabled_image_optimizer", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductImageOptimizer,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+
+	// The API returns a 400 if Product is not enabled.
+	// The API client returns an error if a non-2xx is returned from the API.
+	if err == nil {
+		t.Fatal("expected a 400 from the API but got a 2xx")
+	}
+}
+
+func TestClient_GetProduct_validation_image_optimizer(t *testing.T) {
+	var err error
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ProductID: ProductImageOptimizer,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_EnableProduct_validation_image_optimizer(t *testing.T) {
+	var err error
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ProductID: ProductImageOptimizer,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DisableProduct_validation_image_optimizer(t *testing.T) {
+	var err error
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ProductID: ProductImageOptimizer,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}

--- a/fastly/product_enablement_origin_inspector_test.go
+++ b/fastly/product_enablement_origin_inspector_test.go
@@ -1,0 +1,121 @@
+package fastly
+
+import (
+	"testing"
+)
+
+func TestClient_ProductEnablement_origin_inspector(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	// Enable Product - Bot Management
+	var pe *ProductEnablement
+	record(t, "product_enablement/enable_origin_inspector", func(c *Client) {
+		pe, err = c.EnableProduct(&ProductEnablementInput{
+			ProductID: ProductOriginInspector,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *pe.Product.ProductID != ProductOriginInspector.String() {
+		t.Errorf("bad feature_revision: %s", *pe.Product.ProductID)
+	}
+
+	// Get Product status
+	var gpe *ProductEnablement
+	record(t, "product_enablement/get_origin_inspector", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductOriginInspector,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *gpe.Product.ProductID != ProductOriginInspector.String() {
+		t.Errorf("bad feature_revision: %s", *gpe.Product.ProductID)
+	}
+
+	// Disable Product
+	record(t, "product_enablement/disable_origin_inspector", func(c *Client) {
+		err = c.DisableProduct(&ProductEnablementInput{
+			ProductID: ProductOriginInspector,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get Product status again to check disabled
+	record(t, "product_enablement/get-disabled_origin_inspector", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductOriginInspector,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+
+	// The API returns a 400 if Product is not enabled.
+	// The API client returns an error if a non-2xx is returned from the API.
+	if err == nil {
+		t.Fatal("expected a 400 from the API but got a 2xx")
+	}
+}
+
+func TestClient_GetProduct_validation_origin_inspector(t *testing.T) {
+	var err error
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ProductID: ProductOriginInspector,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_EnableProduct_validation_origin_inspector(t *testing.T) {
+	var err error
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ProductID: ProductOriginInspector,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DisableProduct_validation_origin_inspector(t *testing.T) {
+	var err error
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ProductID: ProductOriginInspector,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}

--- a/fastly/product_enablement_websockets_test.go
+++ b/fastly/product_enablement_websockets_test.go
@@ -1,0 +1,121 @@
+package fastly
+
+import (
+	"testing"
+)
+
+func TestClient_ProductEnablement_websockets(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	// Enable Product - Bot Management
+	var pe *ProductEnablement
+	record(t, "product_enablement/enable_websockets", func(c *Client) {
+		pe, err = c.EnableProduct(&ProductEnablementInput{
+			ProductID: ProductWebSockets,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *pe.Product.ProductID != ProductWebSockets.String() {
+		t.Errorf("bad feature_revision: %s", *pe.Product.ProductID)
+	}
+
+	// Get Product status
+	var gpe *ProductEnablement
+	record(t, "product_enablement/get_websockets", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductWebSockets,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *gpe.Product.ProductID != ProductWebSockets.String() {
+		t.Errorf("bad feature_revision: %s", *gpe.Product.ProductID)
+	}
+
+	// Disable Product
+	record(t, "product_enablement/disable_websockets", func(c *Client) {
+		err = c.DisableProduct(&ProductEnablementInput{
+			ProductID: ProductWebSockets,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get Product status again to check disabled
+	record(t, "product_enablement/get-disabled_websockets", func(c *Client) {
+		gpe, err = c.GetProduct(&ProductEnablementInput{
+			ProductID: ProductWebSockets,
+			ServiceID: testDeliveryServiceID,
+		})
+	})
+
+	// The API returns a 400 if Product is not enabled.
+	// The API client returns an error if a non-2xx is returned from the API.
+	if err == nil {
+		t.Fatal("expected a 400 from the API but got a 2xx")
+	}
+}
+
+func TestClient_GetProduct_validation_websockets(t *testing.T) {
+	var err error
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ProductID: ProductWebSockets,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.GetProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_EnableProduct_validation_websockets(t *testing.T) {
+	var err error
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ProductID: ProductWebSockets,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	_, err = testClient.EnableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DisableProduct_validation_websockets(t *testing.T) {
+	var err error
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ProductID: ProductWebSockets,
+	})
+	if err != ErrMissingServiceID {
+		t.Errorf("bad error: %s", err)
+	}
+
+	err = testClient.DisableProduct(&ProductEnablementInput{
+		ServiceID: "foo",
+	})
+	if err != ErrMissingProductID {
+		t.Errorf("bad error: %s", err)
+	}
+}


### PR DESCRIPTION
All supported products now have test suites which test 'get',
'enable', and 'disable' functionality. This requires using a Compute
service for testing as the Fanout product can only be enabled on
Compute services.

Additionally some small improvements were made in the core product
enablement code: unnecessary usage of 'fmt' was removed, and the
'enable' operation now sends the API call with a JSON body instead of
a www-form-urlencoded body.