### PR TITLE
Adding limit query parameter origin inspector

### DIFF
--- a/fastly/fixtures/origin_inspector/metrics_for_service.yaml
+++ b/fastly/fixtures/origin_inspector/metrics_for_service.yaml
@@ -16,7 +16,7 @@ interactions:
       Accept-Ranges:
       - bytes
       Age:
-      - "56"
+      - "0"
       Cache-Control:
       - no-store
       Content-Length:
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 26 Nov 2024 19:51:41 GMT
+      - Tue, 26 Nov 2024 20:19:08 GMT
       Pragma:
       - no-cache
       Server:
@@ -38,13 +38,13 @@ interactions:
       Via:
       - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS, HIT
+      - MISS, MISS
       X-Cache-Hits:
-      - 0, 1
+      - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000107-CHI, cache-yul1970082-YUL
+      - cache-chi-kigq8000107-CHI, cache-yul1970076-YUL
       X-Timer:
-      - S1732650701.244207,VS0,VE1
+      - S1732652349.659616,VS0,VE223
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/origin_inspector/metrics_for_service.yaml
+++ b/fastly/fixtures/origin_inspector/metrics_for_service.yaml
@@ -1,41 +1,50 @@
+---
 version: 1
 interactions:
-  - request:
-      body: ""
-      form: {}
-      headers:
-        User-Agent:
-          - FastlyGo/6.0.1 (+github.com/fastly/go-fastly; go1.17.2)
-      url: https://api.fastly.com/metrics/origins/services/kKJb5bOFI47uHeBVluGfX1?cursor=&datacenter=LHR%2CJFK&downsample=day&end=1644796800&group_by=host&host=host01&metric=responses%2Cstatus_2xx&region=europe%2Cusa&start=1644624000
-      method: GET
-    response:
-      body: |
-        {"data":[{"dimensions":{"host":"host01"},"values":[{"responses":26795476,"status_2xx":26750746,"timestamp":1644624000},{"responses":27071107,"status_2xx":27026758,"timestamp":1644710400}]}],"meta":{"start":"2022-02-12T00:00:00Z","end":"2022-02-14T00:00:00Z","downsample":"day","metric":"responses,status_2xx","limit":100,"next_cursor":"","sort":"host","group_by":"host","filters":{"datacenters":"LHR,JFK","hosts":"host01","regions":"europe,usa"}},"status":"success"}
-      headers:
-        Accept-Ranges:
-          - bytes
-        Content-Length:
-          - "471"
-        Content-Type:
-          - application/json
-        Date:
-          - Tue, 15 Feb 2022 11:09:41 GMT
-        Status:
-          - 200 OK
-        Strict-Transport-Security:
-          - max-age=31536000
-        Vary:
-          - Accept-Encoding
-        Via:
-          - 1.1 varnish, 1.1 varnish
-        X-Cache:
-          - MISS, MISS
-        X-Cache-Hits:
-          - 0, 0
-        X-Served-By:
-          - cache-control-slwdc9037-CONTROL-SLWDC, cache-lon4281-LON
-        X-Timer:
-          - S1644923381.893816,VS0,VE147
-      status: 200 OK
-      code: 200
-      duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.22.2)
+    url: https://api.fastly.com/metrics/origins/services/kKJb5bOFI47uHeBVluGfX1?cursor=&datacenter=LHR%2CJFK&downsample=day&end=1732579200&group_by=host&host=host01&limit=150&metric=responses%2Cstatus_2xx&region=europe%2Cusa&start=1732406400
+    method: GET
+  response:
+    body: |
+      {"data":[],"meta":{"start":"2024-11-24T00:00:00Z","end":"2024-11-26T00:00:00Z","downsample":"day","metric":"responses,status_2xx","limit":150,"next_cursor":"","sort":"host","group_by":"host","filters":{"datacenters":"LHR,JFK","hosts":"host01","regions":"europe,usa"}},"status":"success"}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Age:
+      - "56"
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "288"
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Nov 2024 19:51:41 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - control-gateway
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 1
+      X-Served-By:
+      - cache-chi-kigq8000107-CHI, cache-yul1970082-YUL
+      X-Timer:
+      - S1732650701.244207,VS0,VE1
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/stats_domain_inspector.go
+++ b/fastly/stats_domain_inspector.go
@@ -117,7 +117,7 @@ type GetDomainMetricsInput struct {
 	End *time.Time
 	// GroupBy is the dimensions to return in the query.
 	GroupBy []string
-	// Limit is the limit of returned data
+	// Limit is the limit of entries requested
 	Limit *int
 	// Metrics is the metric to retrieve. Up to ten metrics are accepted.
 	Metrics []string

--- a/fastly/stats_domain_inspector.go
+++ b/fastly/stats_domain_inspector.go
@@ -117,7 +117,7 @@ type GetDomainMetricsInput struct {
 	End *time.Time
 	// GroupBy is the dimensions to return in the query.
 	GroupBy []string
-	// Limit is the limit of entries requested
+	// Limit specifies the maximum number of entries to be returned
 	Limit *int
 	// Metrics is the metric to retrieve. Up to ten metrics are accepted.
 	Metrics []string

--- a/fastly/stats_origin_inspector.go
+++ b/fastly/stats_origin_inspector.go
@@ -91,7 +91,7 @@ type GetOriginMetricsInput struct {
 	End *time.Time
 	// GroupBy is the dimensions to return in the query.
 	GroupBy []string
-	// Limit is the limit of returned data
+	// Limit is the limit of entries requested
 	Limit *int
 	// Hosts limits query to one or more specific origin hosts.
 	Hosts []string

--- a/fastly/stats_origin_inspector.go
+++ b/fastly/stats_origin_inspector.go
@@ -91,7 +91,7 @@ type GetOriginMetricsInput struct {
 	End *time.Time
 	// GroupBy is the dimensions to return in the query.
 	GroupBy []string
-	// Limit is the limit of entries requested
+	// Limit specifies the maximum number of entries to be returned
 	Limit *int
 	// Hosts limits query to one or more specific origin hosts.
 	Hosts []string

--- a/fastly/stats_origin_inspector.go
+++ b/fastly/stats_origin_inspector.go
@@ -91,6 +91,8 @@ type GetOriginMetricsInput struct {
 	End *time.Time
 	// GroupBy is the dimensions to return in the query.
 	GroupBy []string
+	// Limit is the limit of returned data
+	Limit *int
 	// Hosts limits query to one or more specific origin hosts.
 	Hosts []string
 	// Metrics is the metric to retrieve. Up to ten metrics are accepted.
@@ -145,6 +147,9 @@ func (c *Client) GetOriginMetricsForServiceJSON(i *GetOriginMetricsInput, dst an
 	}
 	if i.Start != nil {
 		ro.Params["start"] = strconv.FormatInt(i.Start.Unix(), 10)
+	}
+	if i.Limit != nil {
+		ro.Params["limit"] = strconv.Itoa(*i.Limit)
 	}
 
 	resp, err := c.Get(path, ro)

--- a/fastly/stats_origin_inspector_test.go
+++ b/fastly/stats_origin_inspector_test.go
@@ -11,8 +11,9 @@ func TestClient_GetOriginMetricsForService(t *testing.T) {
 	// NOTE: Update this to a recent time when regenerating the test fixtures,
 	// otherwise the data may be outside of retention and an error will be
 	// returned.
-	end := time.Date(2022, 2, 14, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 11, 26, 0, 0, 0, 0, time.UTC)
 	start := end.Add(-2 * 24 * time.Hour)
+	limit := 150
 	var err error
 	record(t, "origin_inspector/metrics_for_service", func(c *Client) {
 		_, err = c.GetOriginMetricsForService(&GetOriginMetricsInput{
@@ -26,6 +27,7 @@ func TestClient_GetOriginMetricsForService(t *testing.T) {
 			Regions:     []string{"europe", "usa"},
 			ServiceID:   testDeliveryServiceID,
 			Start:       &start,
+			Limit:       &limit,
 		})
 	})
 	if err != nil {


### PR DESCRIPTION
This PR adds the missing `limit` query parameter to the request on origin inspector endpoint.
