### PR TITLE
refactor: Expose various test types/functions/variables for other packages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,13 @@ GOMAXPROCS ?= 4
 
 NAME := $(notdir $(shell pwd))
 
-# Test Service IDs
+# Test Resource IDs
 FASTLY_TEST_DELIVERY_SERVICE_ID ?=
 DEFAULT_FASTLY_TEST_DELIVERY_SERVICE_ID = kKJb5bOFI47uHeBVluGfX1
 FASTLY_TEST_COMPUTE_SERVICE_ID ?=
 DEFAULT_FASTLY_TEST_COMPUTE_SERVICE_ID = XsjdElScZGjmfCcTwsYRC1
+FASTLY_TEST_NGWAF_WORKSPACE_ID ?=
+DEFAULT_FASTLY_TEST_NGWAF_WORKSPACE_ID = alk6DTsYKHKucJCOIavaJM
 FASTLY_API_KEY ?=
 #
 # Enables support for tools such as https://github.com/rakyll/gotest
@@ -72,6 +74,11 @@ fix-compute-fixtures: ## Updates test fixtures with a specified default Compute 
 	@echo "==> Updating fixtures"
 	@$(shell pwd)/scripts/fixFixtures.sh ${FASTLY_TEST_COMPUTE_SERVICE_ID} ${DEFAULT_FASTLY_TEST_COMPUTE_SERVICE_ID}
 .PHONY: fix-compute-fixtures
+
+fix-ngwaf-fixtures: ## Updates test fixtures with a specified default Next-Gen WAF workspace ID.
+	@echo "==> Updating fixtures"
+	@$(shell pwd)/scripts/fixFixtures.sh ${FASTLY_TEST_NGWAF_WORKSPACE_ID} ${DEFAULT_FASTLY_TEST_NGWAF_WORKSPACE_ID}
+.PHONY: fix-ngwaf-fixtures
 
 check-imports: ## A check which lists improperly-formatted imports, if they exist.
 	@$(shell pwd)/scripts/check-imports.sh

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,12 +3,13 @@
 Go Fastly uses [go-vcr](https://github.com/dnaeon/go-vcr) to "record"
 and "replay" API request fixtures to improve the speed and portability
 of integration tests. The test suite uses a pair of service IDs (one
-for Delivery, one for Compute) for its test cases.
+for Delivery, one for Compute) for its test cases. It also uses one
+Next-Gen WAF workspace ID for various test cases.
 
-Contributors without access to the test services can still update the
-fixtures but with some additional steps required. Below is an example
-workflow for updating a set of fixture files (where `...` should be
-replaced with an appropriate value):
+Contributors without access to the test services or workspace can
+still update the fixtures but with some additional steps
+required. Below is an example workflow for updating a set of fixture
+files (where `...` should be replaced with an appropriate value):
 
 ```sh
 # Remove all YAML fixture files from the specified directory.
@@ -20,10 +21,11 @@ rm -r fastly/fixtures/.../*
 #
 # FASTLY_TEST_DELIVERY_SERVICE_ID: should correspond to a real Delivery service you control.
 # FASTLY_TEST_COMPUTE_SERVICE_ID: should correspond to a real Compute service you control.
+# FASTLY_TEST_NGWAF_WORKSPACE_ID: should correspond to a real Next-Gen WAF workspace you control.
 # FASTLY_API_KEY: should be a real token associated with the services you control.
 # TESTARGS: allows you to use the -run flag of the 'go test' command.
 #
-make test FASTLY_TEST_DELIVERY_SERVICE_ID="..." FASTLY_TEST_COMPUTE_SERVICE_ID="..." FASTLY_API_KEY="..." TESTARGS="-run=..."
+make test FASTLY_TEST_DELIVERY_SERVICE_ID="..." FASTLY_TEST_COMPUTE_SERVICE_ID="..." FASTLY_TEST_NGWAF_WORKSPACE_ID="..." FASTLY_API_KEY="..." TESTARGS="-run=..."
 ```
 
 > **NOTE**: to run the tests with go-vcr disabled, set `VCR_DISABLE=1` (`make test-full` does this).
@@ -31,7 +33,8 @@ make test FASTLY_TEST_DELIVERY_SERVICE_ID="..." FASTLY_TEST_COMPUTE_SERVICE_ID="
 When adding or updating client code and integration tests,
 contributors should record a new set of fixtures. Before submitting a
 pull request with new or updated fixtures, we ask that contributors
-update them to use the default service IDs by running two commands:
+update them to use the default service IDs and workspace ID by running
+three commands:
 
 ```sh
 make fix-delivery-fixtures FASTLY_TEST_DELIVERY_SERVICE_ID=<your Delivery SID>
@@ -39,6 +42,10 @@ make fix-delivery-fixtures FASTLY_TEST_DELIVERY_SERVICE_ID=<your Delivery SID>
 
 ```sh
 make fix-compute-fixtures FASTLY_TEST_COMPUTE_SERVICE_ID=<your Compute SID>
+```
+
+```sh
+make fix-ngwaf-fixtures FASTLY_TEST_NGWAF_WORKSPACE_ID=<your Next-Gen WAF workspace ID>
 ```
 
 ### Important Test Tips!

--- a/fastly/account_event_test.go
+++ b/fastly/account_event_test.go
@@ -11,7 +11,7 @@ func TestClient_APIEvents(t *testing.T) {
 
 	var err error
 	var events GetAPIEventsResponse
-	record(t, "events/get_events", func(c *Client) {
+	Record(t, "events/get_events", func(c *Client) {
 		events, err = c.GetAPIEvents(&GetAPIEventsFilterInput{
 			PageNumber: 1,
 			MaxResults: 1,
@@ -25,7 +25,7 @@ func TestClient_APIEvents(t *testing.T) {
 	}
 
 	var event *Event
-	record(t, "events/get_event", func(c *Client) {
+	Record(t, "events/get_event", func(c *Client) {
 		event, err = c.GetAPIEvent(&GetAPIEventInput{
 			EventID: events.Events[0].ID,
 		})
@@ -40,7 +40,7 @@ func TestClient_APIEvents(t *testing.T) {
 
 func TestClient_GetAPIEvent_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetAPIEvent(&GetAPIEventInput{
+	_, err = TestClient.GetAPIEvent(&GetAPIEventInput{
 		EventID: "",
 	})
 	if err != ErrMissingEventID {

--- a/fastly/acl.go
+++ b/fastly/acl.go
@@ -43,7 +43,7 @@ func (c *Client) ListACLs(i *ListACLsInput) ([]*ACL, error) {
 	defer resp.Body.Close()
 
 	var as []*ACL
-	if err := decodeBodyMap(resp.Body, &as); err != nil {
+	if err := DecodeBodyMap(resp.Body, &as); err != nil {
 		return nil, err
 	}
 	return as, nil
@@ -77,7 +77,7 @@ func (c *Client) CreateACL(i *CreateACLInput) (*ACL, error) {
 	defer resp.Body.Close()
 
 	var a *ACL
-	if err := decodeBodyMap(resp.Body, &a); err != nil {
+	if err := DecodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -114,7 +114,7 @@ func (c *Client) DeleteACL(i *DeleteACLInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -154,7 +154,7 @@ func (c *Client) GetACL(i *GetACLInput) (*ACL, error) {
 	defer resp.Body.Close()
 
 	var a *ACL
-	if err := decodeBodyMap(resp.Body, &a); err != nil {
+	if err := DecodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -193,7 +193,7 @@ func (c *Client) UpdateACL(i *UpdateACLInput) (*ACL, error) {
 	defer resp.Body.Close()
 
 	var a *ACL
-	if err := decodeBodyMap(resp.Body, &a); err != nil {
+	if err := DecodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 

--- a/fastly/acl_entries_batch_test.go
+++ b/fastly/acl_entries_batch_test.go
@@ -13,7 +13,7 @@ func TestClient_BatchModifyACLEntries_Create(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
 
 	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
@@ -41,7 +41,7 @@ func TestClient_BatchModifyACLEntries_Create(t *testing.T) {
 
 	// When: I execute the batch create operations against the Fastly API,
 	var err error
-	record(t, fixtureBase+"create_acl_entries", func(c *Client) {
+	Record(t, fixtureBase+"create_acl_entries", func(c *Client) {
 		err = c.BatchModifyACLEntries(batchCreateOperations)
 	})
 	if err != nil {
@@ -50,7 +50,7 @@ func TestClient_BatchModifyACLEntries_Create(t *testing.T) {
 
 	// Then: I expect to be able to list all of the created ACL entries.
 	var actualACLEntries []*ACLEntry
-	record(t, fixtureBase+"list_after_create", func(c *Client) {
+	Record(t, fixtureBase+"list_after_create", func(c *Client) {
 		actualACLEntries, err = c.ListACLEntries(&ListACLEntriesInput{
 			ServiceID: *testService.ServiceID,
 			ACLID:     *testACL.ACLID,
@@ -109,7 +109,7 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
 
 	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
@@ -136,7 +136,7 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 	}
 
 	var err error
-	record(t, fixtureBase+"create_acl_entries", func(c *Client) {
+	Record(t, fixtureBase+"create_acl_entries", func(c *Client) {
 		err = c.BatchModifyACLEntries(batchCreateOperations)
 	})
 	if err != nil {
@@ -144,7 +144,7 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 	}
 
 	var createdACLEntries []*ACLEntry
-	record(t, fixtureBase+"list_before_delete", func(client *Client) {
+	Record(t, fixtureBase+"list_before_delete", func(client *Client) {
 		createdACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
 			ServiceID: *testService.ServiceID,
 			ACLID:     *testACL.ACLID,
@@ -170,7 +170,7 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 		},
 	}
 
-	record(t, fixtureBase+"delete_acl_entries", func(c *Client) {
+	Record(t, fixtureBase+"delete_acl_entries", func(c *Client) {
 		err = c.BatchModifyACLEntries(batchDeleteOperations)
 	})
 	if err != nil {
@@ -179,7 +179,7 @@ func TestClient_BatchModifyACLEntries_Delete(t *testing.T) {
 
 	// Then: I expect to be able to list a single ACL entry.
 	var actualACLEntries []*ACLEntry
-	record(t, fixtureBase+"list_after_delete", func(client *Client) {
+	Record(t, fixtureBase+"list_after_delete", func(client *Client) {
 		actualACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
 			ServiceID: *testService.ServiceID,
 			ACLID:     *testACL.ACLID,
@@ -208,7 +208,7 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
 
 	testACL := createTestACL(t, fixtureBase+"create_acl", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
@@ -235,7 +235,7 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 	}
 
 	var err error
-	record(t, fixtureBase+"create_acl_entries", func(c *Client) {
+	Record(t, fixtureBase+"create_acl_entries", func(c *Client) {
 		err = c.BatchModifyACLEntries(batchCreateOperations)
 	})
 	if err != nil {
@@ -243,7 +243,7 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 	}
 
 	var createdACLEntries []*ACLEntry
-	record(t, fixtureBase+"list_before_update", func(client *Client) {
+	Record(t, fixtureBase+"list_before_update", func(client *Client) {
 		createdACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
 			ServiceID: *testService.ServiceID,
 			ACLID:     *testACL.ACLID,
@@ -273,7 +273,7 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 		},
 	}
 
-	record(t, fixtureBase+"update_acl_entries", func(c *Client) {
+	Record(t, fixtureBase+"update_acl_entries", func(c *Client) {
 		err = c.BatchModifyACLEntries(batchUpdateOperations)
 	})
 	if err != nil {
@@ -282,7 +282,7 @@ func TestClient_BatchModifyACLEntries_Update(t *testing.T) {
 
 	// Then: I expect to be able to list all of the ACL entries with modifications applied to a single item.
 	var actualACLEntries []*ACLEntry
-	record(t, fixtureBase+"list_after_update", func(client *Client) {
+	Record(t, fixtureBase+"list_after_update", func(client *Client) {
 		actualACLEntries, err = client.ListACLEntries(&ListACLEntriesInput{
 			ServiceID: *testService.ServiceID,
 			ACLID:     *testACL.ACLID,

--- a/fastly/acl_entry.go
+++ b/fastly/acl_entry.go
@@ -122,7 +122,7 @@ func (c *Client) GetACLEntry(i *GetACLEntryInput) (*ACLEntry, error) {
 	defer resp.Body.Close()
 
 	var e *ACLEntry
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 
@@ -163,7 +163,7 @@ func (c *Client) CreateACLEntry(i *CreateACLEntryInput) (*ACLEntry, error) {
 	defer resp.Body.Close()
 
 	var e *ACLEntry
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 
@@ -201,7 +201,7 @@ func (c *Client) DeleteACLEntry(i *DeleteACLEntryInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 
@@ -251,7 +251,7 @@ func (c *Client) UpdateACLEntry(i *UpdateACLEntryInput) (*ACLEntry, error) {
 	defer resp.Body.Close()
 
 	var e *ACLEntry
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 
@@ -307,5 +307,5 @@ func (c *Client) BatchModifyACLEntries(i *BatchModifyACLEntriesInput) error {
 
 	var batchModifyResult map[string]string
 
-	return decodeBodyMap(resp.Body, &batchModifyResult)
+	return DecodeBodyMap(resp.Body, &batchModifyResult)
 }

--- a/fastly/acl_entry_test.go
+++ b/fastly/acl_entry_test.go
@@ -11,7 +11,7 @@ func TestClient_ACLEntries(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"version", *testService.ServiceID)
 
 	testACL := createTestACL(t, fixtureBase+"acl", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestACL(t, testACL, fixtureBase+"delete_acl")
@@ -19,7 +19,7 @@ func TestClient_ACLEntries(t *testing.T) {
 	// Create
 	var err error
 	var e *ACLEntry
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		e, err = c.CreateACLEntry(&CreateACLEntryInput{
 			ServiceID: *testService.ServiceID,
 			ACLID:     *testACL.ACLID,
@@ -51,7 +51,7 @@ func TestClient_ACLEntries(t *testing.T) {
 
 	// List
 	var es []*ACLEntry
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		es, err = c.ListACLEntries(&ListACLEntriesInput{
 			ACLID:     *testACL.ACLID,
 			Direction: ToPointer("descend"),
@@ -70,7 +70,7 @@ func TestClient_ACLEntries(t *testing.T) {
 	// List with paginator
 	var es2 []*ACLEntry
 	var paginator *ListPaginator[ACLEntry]
-	record(t, fixtureBase+"list2", func(c *Client) {
+	Record(t, fixtureBase+"list2", func(c *Client) {
 		paginator = c.GetACLEntries(&GetACLEntriesInput{
 			ACLID:     *testACL.ACLID,
 			Direction: ToPointer("ascend"),
@@ -100,7 +100,7 @@ func TestClient_ACLEntries(t *testing.T) {
 
 	// Get
 	var ne *ACLEntry
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		ne, err = c.GetACLEntry(&GetACLEntryInput{
 			ServiceID: *testService.ServiceID,
 			ACLID:     *testACL.ACLID,
@@ -126,7 +126,7 @@ func TestClient_ACLEntries(t *testing.T) {
 
 	// Update
 	var ue *ACLEntry
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		ue, err = c.UpdateACLEntry(&UpdateACLEntryInput{
 			ServiceID: *testService.ServiceID,
 			ACLID:     *testACL.ACLID,
@@ -155,7 +155,7 @@ func TestClient_ACLEntries(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteACLEntry(&DeleteACLEntryInput{
 			ServiceID: *testService.ServiceID,
 			ACLID:     *testACL.ACLID,
@@ -170,12 +170,12 @@ func TestClient_ACLEntries(t *testing.T) {
 func TestClient_ListACLEntries_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListACLEntries(&ListACLEntriesInput{})
+	_, err = TestClient.ListACLEntries(&ListACLEntriesInput{})
 	if err != ErrMissingACLID {
 		t.Errorf("bad ACL ID: %s", err)
 	}
 
-	_, err = testClient.ListACLEntries(&ListACLEntriesInput{
+	_, err = TestClient.ListACLEntries(&ListACLEntriesInput{
 		ACLID: "123",
 	})
 	if err != ErrMissingServiceID {
@@ -186,12 +186,12 @@ func TestClient_ListACLEntries_validation(t *testing.T) {
 func TestClient_CreateACLEntry_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateACLEntry(&CreateACLEntryInput{})
+	_, err = TestClient.CreateACLEntry(&CreateACLEntryInput{})
 	if err != ErrMissingACLID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateACLEntry(&CreateACLEntryInput{
+	_, err = TestClient.CreateACLEntry(&CreateACLEntryInput{
 		ACLID: "123",
 	})
 	if err != ErrMissingServiceID {
@@ -202,19 +202,19 @@ func TestClient_CreateACLEntry_validation(t *testing.T) {
 func TestClient_GetACLEntry_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetACLEntry(&GetACLEntryInput{})
+	_, err = TestClient.GetACLEntry(&GetACLEntryInput{})
 	if err != ErrMissingACLID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetACLEntry(&GetACLEntryInput{
+	_, err = TestClient.GetACLEntry(&GetACLEntryInput{
 		ACLID: "123",
 	})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetACLEntry(&GetACLEntryInput{
+	_, err = TestClient.GetACLEntry(&GetACLEntryInput{
 		ACLID:   "123",
 		EntryID: "456",
 	})
@@ -226,19 +226,19 @@ func TestClient_GetACLEntry_validation(t *testing.T) {
 func TestClient_UpdateACLEntry_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateACLEntry(&UpdateACLEntryInput{})
+	_, err = TestClient.UpdateACLEntry(&UpdateACLEntryInput{})
 	if err != ErrMissingACLID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateACLEntry(&UpdateACLEntryInput{
+	_, err = TestClient.UpdateACLEntry(&UpdateACLEntryInput{
 		ACLID: "123",
 	})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateACLEntry(&UpdateACLEntryInput{
+	_, err = TestClient.UpdateACLEntry(&UpdateACLEntryInput{
 		ACLID:   "123",
 		EntryID: "456",
 	})
@@ -250,19 +250,19 @@ func TestClient_UpdateACLEntry_validation(t *testing.T) {
 func TestClient_DeleteACLEntry_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteACLEntry(&DeleteACLEntryInput{})
+	err = TestClient.DeleteACLEntry(&DeleteACLEntryInput{})
 	if err != ErrMissingACLID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteACLEntry(&DeleteACLEntryInput{
+	err = TestClient.DeleteACLEntry(&DeleteACLEntryInput{
 		ACLID: "123",
 	})
 	if err != ErrMissingEntryID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteACLEntry(&DeleteACLEntryInput{
+	err = TestClient.DeleteACLEntry(&DeleteACLEntryInput{
 		ACLID:   "123",
 		EntryID: "456",
 	})
@@ -274,12 +274,12 @@ func TestClient_DeleteACLEntry_validation(t *testing.T) {
 func TestClient_BatchModifyACLEntries_validation(t *testing.T) {
 	var err error
 
-	err = testClient.BatchModifyACLEntries(&BatchModifyACLEntriesInput{})
+	err = TestClient.BatchModifyACLEntries(&BatchModifyACLEntriesInput{})
 	if err != ErrMissingACLID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.BatchModifyACLEntries(&BatchModifyACLEntriesInput{
+	err = TestClient.BatchModifyACLEntries(&BatchModifyACLEntriesInput{
 		ACLID: "123",
 	})
 	if err != ErrMissingServiceID {
@@ -287,7 +287,7 @@ func TestClient_BatchModifyACLEntries_validation(t *testing.T) {
 	}
 
 	oversizedACLEntries := make([]*BatchACLEntry, BatchModifyMaximumOperations+1)
-	err = testClient.BatchModifyACLEntries(&BatchModifyACLEntriesInput{
+	err = TestClient.BatchModifyACLEntries(&BatchModifyACLEntriesInput{
 		ACLID:     "123",
 		ServiceID: "456",
 		Entries:   oversizedACLEntries,

--- a/fastly/acl_test.go
+++ b/fastly/acl_test.go
@@ -9,14 +9,14 @@ func TestClient_ACLs(t *testing.T) {
 
 	fixtureBase := "acls/"
 
-	testVersion := createTestVersion(t, fixtureBase+"version", testDeliveryServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"version", TestDeliveryServiceID)
 
 	// Create
 	var err error
 	var a *ACL
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		a, err = c.CreateACL(&CreateACLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           ToPointer("test_acl"),
 		})
@@ -27,9 +27,9 @@ func TestClient_ACLs(t *testing.T) {
 
 	// Create with expected error
 	var errExpected error
-	record(t, fixtureBase+"create_expected_error", func(c *Client) {
+	Record(t, fixtureBase+"create_expected_error", func(c *Client) {
 		_, errExpected = c.CreateACL(&CreateACLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 		})
 	})
@@ -39,15 +39,15 @@ func TestClient_ACLs(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"cleanup", func(c *Client) {
+		Record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteACL(&DeleteACLInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *testVersion.Number,
 				Name:           "test_acl",
 			})
 
 			_ = c.DeleteACL(&DeleteACLInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *testVersion.Number,
 				Name:           "new_test_acl",
 			})
@@ -60,9 +60,9 @@ func TestClient_ACLs(t *testing.T) {
 
 	// List
 	var as []*ACL
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		as, err = c.ListACLs(&ListACLsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 		})
 	})
@@ -75,9 +75,9 @@ func TestClient_ACLs(t *testing.T) {
 
 	// Get
 	var na *ACL
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		na, err = c.GetACL(&GetACLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           "test_acl",
 		})
@@ -91,9 +91,9 @@ func TestClient_ACLs(t *testing.T) {
 
 	// Update
 	var ua *ACL
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		ua, err = c.UpdateACL(&UpdateACLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           "test_acl",
 			NewName:        ToPointer("new_test_acl"),
@@ -111,9 +111,9 @@ func TestClient_ACLs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteACL(&DeleteACLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           "new_test_acl",
 		})
@@ -125,14 +125,14 @@ func TestClient_ACLs(t *testing.T) {
 
 func TestClient_ListACLs_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListACLs(&ListACLsInput{
+	_, err = TestClient.ListACLs(&ListACLsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListACLs(&ListACLsInput{
+	_, err = TestClient.ListACLs(&ListACLsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -143,14 +143,14 @@ func TestClient_ListACLs_validation(t *testing.T) {
 
 func TestClient_CreateACL_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateACL(&CreateACLInput{
+	_, err = TestClient.CreateACL(&CreateACLInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateACL(&CreateACLInput{
+	_, err = TestClient.CreateACL(&CreateACLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -161,7 +161,7 @@ func TestClient_CreateACL_validation(t *testing.T) {
 
 func TestClient_GetACL_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetACL(&GetACLInput{
+	_, err = TestClient.GetACL(&GetACLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -169,7 +169,7 @@ func TestClient_GetACL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetACL(&GetACLInput{
+	_, err = TestClient.GetACL(&GetACLInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -177,7 +177,7 @@ func TestClient_GetACL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetACL(&GetACLInput{
+	_, err = TestClient.GetACL(&GetACLInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -189,7 +189,7 @@ func TestClient_GetACL_validation(t *testing.T) {
 func TestClient_UpdateACL_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateACL(&UpdateACLInput{
+	_, err = TestClient.UpdateACL(&UpdateACLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -197,7 +197,7 @@ func TestClient_UpdateACL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateACL(&UpdateACLInput{
+	_, err = TestClient.UpdateACL(&UpdateACLInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -205,7 +205,7 @@ func TestClient_UpdateACL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateACL(&UpdateACLInput{
+	_, err = TestClient.UpdateACL(&UpdateACLInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -217,7 +217,7 @@ func TestClient_UpdateACL_validation(t *testing.T) {
 func TestClient_DeleteACL_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteACL(&DeleteACLInput{
+	err = TestClient.DeleteACL(&DeleteACLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -225,7 +225,7 @@ func TestClient_DeleteACL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteACL(&DeleteACLInput{
+	err = TestClient.DeleteACL(&DeleteACLInput{
 		Name:           "test",
 		ServiceVersion: 0,
 	})
@@ -233,7 +233,7 @@ func TestClient_DeleteACL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteACL(&DeleteACLInput{
+	err = TestClient.DeleteACL(&DeleteACLInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/alerts_test.go
+++ b/fastly/alerts_test.go
@@ -24,13 +24,13 @@ func TestClient_FastlyAlerts(t *testing.T) {
 		IntegrationIDs:     []string{},
 		Metric:             ToPointer("status_5xx"),
 		Name:               ToPointer("test name"),
-		ServiceID:          ToPointer(testDeliveryServiceID),
+		ServiceID:          ToPointer(TestDeliveryServiceID),
 		Source:             ToPointer("domains"),
 	}
 
 	// Test
 	var err error
-	record(t, "alerts/test_alert_definition", func(c *Client) {
+	Record(t, "alerts/test_alert_definition", func(c *Client) {
 		err = c.TestAlertDefinition(&TestAlertDefinitionInput{
 			CreateAlertDefinitionInput: *cadi,
 		})
@@ -41,7 +41,7 @@ func TestClient_FastlyAlerts(t *testing.T) {
 
 	// Create
 	var ad *AlertDefinition
-	record(t, "alerts/create_alert_definition", func(c *Client) {
+	Record(t, "alerts/create_alert_definition", func(c *Client) {
 		ad, err = c.CreateAlertDefinition(cadi)
 	})
 	if err != nil {
@@ -49,7 +49,7 @@ func TestClient_FastlyAlerts(t *testing.T) {
 	}
 	// Ensure deleted
 	defer func() {
-		record(t, "alerts/cleanup_alert_definition", func(c *Client) {
+		Record(t, "alerts/cleanup_alert_definition", func(c *Client) {
 			err = c.DeleteAlertDefinition(&DeleteAlertDefinitionInput{
 				ID: &ad.ID,
 			})
@@ -68,7 +68,7 @@ func TestClient_FastlyAlerts(t *testing.T) {
 		t.Errorf("bad name: %v", ad.Name)
 	}
 
-	if ad.ServiceID != testDeliveryServiceID {
+	if ad.ServiceID != TestDeliveryServiceID {
 		t.Errorf("bad service_id: %v", ad.ServiceID)
 	}
 
@@ -86,12 +86,12 @@ func TestClient_FastlyAlerts(t *testing.T) {
 
 	// List Definitions
 	var adr *AlertDefinitionsResponse
-	record(t, "alerts/list_alert_definitions", func(c *Client) {
+	Record(t, "alerts/list_alert_definitions", func(c *Client) {
 		adr, err = c.ListAlertDefinitions(&ListAlertDefinitionsInput{
 			Cursor:    ToPointer(""),
 			Limit:     ToPointer(10),
 			Name:      ToPointer(ad.Name),
-			ServiceID: ToPointer(testDeliveryServiceID),
+			ServiceID: ToPointer(TestDeliveryServiceID),
 			Sort:      ToPointer("name"),
 		})
 	})
@@ -104,7 +104,7 @@ func TestClient_FastlyAlerts(t *testing.T) {
 
 	// Get
 	var gad *AlertDefinition
-	record(t, "alerts/get_alert_definition", func(c *Client) {
+	Record(t, "alerts/get_alert_definition", func(c *Client) {
 		gad, err = c.GetAlertDefinition(&GetAlertDefinitionInput{
 			ID: &ad.ID,
 		})
@@ -118,7 +118,7 @@ func TestClient_FastlyAlerts(t *testing.T) {
 
 	// Update
 	var uad *AlertDefinition
-	record(t, "alerts/update_alert_definition", func(c *Client) {
+	Record(t, "alerts/update_alert_definition", func(c *Client) {
 		uad, err = c.UpdateAlertDefinition(&UpdateAlertDefinitionInput{
 			Description:        ToPointer("test description"),
 			Dimensions:         testDimensions,
@@ -137,7 +137,7 @@ func TestClient_FastlyAlerts(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "alerts/delete_alert_definition", func(c *Client) {
+	Record(t, "alerts/delete_alert_definition", func(c *Client) {
 		err = c.DeleteAlertDefinition(&DeleteAlertDefinitionInput{
 			ID: &ad.ID,
 		})
@@ -147,14 +147,14 @@ func TestClient_FastlyAlerts(t *testing.T) {
 	}
 
 	// List History
-	record(t, "alerts/list_alert_history", func(c *Client) {
+	Record(t, "alerts/list_alert_history", func(c *Client) {
 		_, err = c.ListAlertHistory(&ListAlertHistoryInput{
 			After:        ToPointer("2006-01-02T15:04:05Z"),
 			Before:       ToPointer("2056-01-02T15:04:05Z"),
 			Cursor:       ToPointer(""),
 			DefinitionID: ToPointer(ad.ID),
 			Limit:        ToPointer(10),
-			ServiceID:    ToPointer(testDeliveryServiceID),
+			ServiceID:    ToPointer(TestDeliveryServiceID),
 			Sort:         ToPointer("-start"),
 			Status:       ToPointer(""),
 		})
@@ -181,14 +181,14 @@ func TestClient_FastlyPercentAlerts(t *testing.T) {
 		IntegrationIDs:     []string{},
 		Metric:             ToPointer("status_5xx"),
 		Name:               ToPointer("test name"),
-		ServiceID:          ToPointer(testDeliveryServiceID),
+		ServiceID:          ToPointer(TestDeliveryServiceID),
 		Source:             ToPointer("stats"),
 	}
 
 	// Create
 	var ad *AlertDefinition
 	var err error
-	record(t, "alerts/create_alert_definition_stats_percent", func(c *Client) {
+	Record(t, "alerts/create_alert_definition_stats_percent", func(c *Client) {
 		ad, err = c.CreateAlertDefinition(cadi)
 
 	})
@@ -197,7 +197,7 @@ func TestClient_FastlyPercentAlerts(t *testing.T) {
 	}
 	// Ensure deleted
 	defer func() {
-		record(t, "alerts/cleanup_alert_definition_stats_percent", func(c *Client) {
+		Record(t, "alerts/cleanup_alert_definition_stats_percent", func(c *Client) {
 			err = c.DeleteAlertDefinition(&DeleteAlertDefinitionInput{
 				ID: &ad.ID,
 			})
@@ -216,7 +216,7 @@ func TestClient_FastlyPercentAlerts(t *testing.T) {
 		t.Errorf("bad name: %v", ad.Name)
 	}
 
-	if ad.ServiceID != testDeliveryServiceID {
+	if ad.ServiceID != TestDeliveryServiceID {
 		t.Errorf("bad service_id: %v", ad.ServiceID)
 	}
 
@@ -235,7 +235,7 @@ func TestClient_FastlyPercentAlerts(t *testing.T) {
 
 func TestClient_GetAlertDefinition_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetAlertDefinition(&GetAlertDefinitionInput{
+	_, err = TestClient.GetAlertDefinition(&GetAlertDefinitionInput{
 		ID: nil,
 	})
 	if err != ErrMissingID {
@@ -245,7 +245,7 @@ func TestClient_GetAlertDefinition_validation(t *testing.T) {
 
 func TestClient_UpdateAlertDefinition_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateAlertDefinition(&UpdateAlertDefinitionInput{
+	_, err = TestClient.UpdateAlertDefinition(&UpdateAlertDefinitionInput{
 		ID: nil,
 	})
 	if err != ErrMissingID {
@@ -254,7 +254,7 @@ func TestClient_UpdateAlertDefinition_validation(t *testing.T) {
 }
 
 func TestClient_DeleteAlertDefinition_validation(t *testing.T) {
-	err := testClient.DeleteAlertDefinition(&DeleteAlertDefinitionInput{
+	err := TestClient.DeleteAlertDefinition(&DeleteAlertDefinitionInput{
 		ID: nil,
 	})
 	if err != ErrMissingID {

--- a/fastly/automation_token.go
+++ b/fastly/automation_token.go
@@ -111,7 +111,7 @@ func (c *Client) GetAutomationToken(i *GetAutomationTokenInput) (*AutomationToke
 	defer resp.Body.Close()
 
 	var t *AutomationToken
-	if err := decodeBodyMap(resp.Body, &t); err != nil {
+	if err := DecodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 	return t, nil
@@ -154,7 +154,7 @@ func (c *Client) CreateAutomationToken(i *CreateAutomationTokenInput) (*Automati
 	defer resp.Body.Close()
 
 	var t *AutomationToken
-	if err := decodeBodyMap(resp.Body, &t); err != nil {
+	if err := DecodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 	return t, nil

--- a/fastly/automation_token_test.go
+++ b/fastly/automation_token_test.go
@@ -9,7 +9,7 @@ func TestClient_ListAutomationTokens(t *testing.T) {
 
 	var tokens []*AutomationToken
 	var err error
-	record(t, "automation_tokens/list", func(c *Client) {
+	Record(t, "automation_tokens/list", func(c *Client) {
 		tokens, err = c.ListAutomationTokens()
 	})
 	if err != nil {
@@ -29,7 +29,7 @@ func TestClient_GetAutomationToken(t *testing.T) {
 
 	var token *AutomationToken
 	var err error
-	record(t, "automation_tokens/get", func(c *Client) {
+	Record(t, "automation_tokens/get", func(c *Client) {
 		token, err = c.GetAutomationToken(input)
 	})
 	if err != nil {
@@ -51,7 +51,7 @@ func TestClient_CreateAutomationToken(t *testing.T) {
 
 	var token *AutomationToken
 	var err error
-	record(t, "automation_tokens/create", func(c *Client) {
+	Record(t, "automation_tokens/create", func(c *Client) {
 		token, err = c.CreateAutomationToken(input)
 	})
 	if err != nil {
@@ -74,7 +74,7 @@ func TestClient_DeleteAutomationToken(t *testing.T) {
 	}
 
 	var err error
-	record(t, "automation_tokens/delete", func(c *Client) {
+	Record(t, "automation_tokens/delete", func(c *Client) {
 		err = c.DeleteAutomationToken(input)
 	})
 	if err != nil {

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -73,7 +73,7 @@ func (c *Client) ListBackends(i *ListBackendsInput) ([]*Backend, error) {
 	defer resp.Body.Close()
 
 	var bs []*Backend
-	if err := decodeBodyMap(resp.Body, &bs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	return bs, nil
@@ -167,7 +167,7 @@ func (c *Client) CreateBackend(i *CreateBackendInput) (*Backend, error) {
 	defer resp.Body.Close()
 
 	var b *Backend
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -204,7 +204,7 @@ func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
 	defer resp.Body.Close()
 
 	var b *Backend
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -303,7 +303,7 @@ func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
 	defer resp.Body.Close()
 
 	var b *Backend
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -340,7 +340,7 @@ func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/backend_test.go
+++ b/fastly/backend_test.go
@@ -9,15 +9,15 @@ func TestClient_Backends(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "backends/version", func(c *Client) {
+	Record(t, "backends/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var b *Backend
-	record(t, "backends/create", func(c *Client) {
+	Record(t, "backends/create", func(c *Client) {
 		b, err = c.CreateBackend(&CreateBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-backend"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
@@ -34,15 +34,15 @@ func TestClient_Backends(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "backends/cleanup", func(c *Client) {
+		Record(t, "backends/cleanup", func(c *Client) {
 			_ = c.DeleteBackend(&DeleteBackendInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-backend",
 			})
 
 			_ = c.DeleteBackend(&DeleteBackendInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-backend",
 			})
@@ -76,9 +76,9 @@ func TestClient_Backends(t *testing.T) {
 
 	// List
 	var bs []*Backend
-	record(t, "backends/list", func(c *Client) {
+	Record(t, "backends/list", func(c *Client) {
 		bs, err = c.ListBackends(&ListBackendsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -91,9 +91,9 @@ func TestClient_Backends(t *testing.T) {
 
 	// Get
 	var nb *Backend
-	record(t, "backends/get", func(c *Client) {
+	Record(t, "backends/get", func(c *Client) {
 		nb, err = c.GetBackend(&GetBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-backend",
 		})
@@ -119,9 +119,9 @@ func TestClient_Backends(t *testing.T) {
 
 	// Update
 	var ub *Backend
-	record(t, "backends/update", func(c *Client) {
+	Record(t, "backends/update", func(c *Client) {
 		ub, err = c.UpdateBackend(&UpdateBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-backend",
 			NewName:        ToPointer("new-test-backend"),
@@ -156,9 +156,9 @@ func TestClient_Backends(t *testing.T) {
 	}
 
 	// NOTE: The following test validates empty values are NOT sent.
-	record(t, "backends/update_ignore_empty_values", func(c *Client) {
+	Record(t, "backends/update_ignore_empty_values", func(c *Client) {
 		ub, err = c.UpdateBackend(&UpdateBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-backend",
 		})
@@ -178,9 +178,9 @@ func TestClient_Backends(t *testing.T) {
 	// e.g. Although OverrideHost and Port are set to the type's zero values, and
 	// the UpdateBackendInput struct fields set omitempty, they're pointer types
 	// and so the JSON unmarshal recognises that empty values are allowed.
-	record(t, "backends/update_allow_empty_values", func(c *Client) {
+	Record(t, "backends/update_allow_empty_values", func(c *Client) {
 		ub, err = c.UpdateBackend(&UpdateBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-backend",
 			OverrideHost:   ToPointer(""),
@@ -198,9 +198,9 @@ func TestClient_Backends(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "backends/delete", func(c *Client) {
+	Record(t, "backends/delete", func(c *Client) {
 		err = c.DeleteBackend(&DeleteBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-backend",
 		})
@@ -212,14 +212,14 @@ func TestClient_Backends(t *testing.T) {
 
 func TestClient_ListBackends_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListBackends(&ListBackendsInput{
+	_, err = TestClient.ListBackends(&ListBackendsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListBackends(&ListBackendsInput{
+	_, err = TestClient.ListBackends(&ListBackendsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -230,14 +230,14 @@ func TestClient_ListBackends_validation(t *testing.T) {
 
 func TestClient_CreateBackend_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateBackend(&CreateBackendInput{
+	_, err = TestClient.CreateBackend(&CreateBackendInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateBackend(&CreateBackendInput{
+	_, err = TestClient.CreateBackend(&CreateBackendInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -249,7 +249,7 @@ func TestClient_CreateBackend_validation(t *testing.T) {
 func TestClient_GetBackend_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetBackend(&GetBackendInput{
+	_, err = TestClient.GetBackend(&GetBackendInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -257,7 +257,7 @@ func TestClient_GetBackend_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetBackend(&GetBackendInput{
+	_, err = TestClient.GetBackend(&GetBackendInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -265,7 +265,7 @@ func TestClient_GetBackend_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetBackend(&GetBackendInput{
+	_, err = TestClient.GetBackend(&GetBackendInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -277,7 +277,7 @@ func TestClient_GetBackend_validation(t *testing.T) {
 func TestClient_UpdateBackend_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateBackend(&UpdateBackendInput{
+	_, err = TestClient.UpdateBackend(&UpdateBackendInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -285,7 +285,7 @@ func TestClient_UpdateBackend_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateBackend(&UpdateBackendInput{
+	_, err = TestClient.UpdateBackend(&UpdateBackendInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -293,7 +293,7 @@ func TestClient_UpdateBackend_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateBackend(&UpdateBackendInput{
+	_, err = TestClient.UpdateBackend(&UpdateBackendInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -305,7 +305,7 @@ func TestClient_UpdateBackend_validation(t *testing.T) {
 func TestClient_DeleteBackend_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteBackend(&DeleteBackendInput{
+	err = TestClient.DeleteBackend(&DeleteBackendInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -313,7 +313,7 @@ func TestClient_DeleteBackend_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteBackend(&DeleteBackendInput{
+	err = TestClient.DeleteBackend(&DeleteBackendInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -321,7 +321,7 @@ func TestClient_DeleteBackend_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteBackend(&DeleteBackendInput{
+	err = TestClient.DeleteBackend(&DeleteBackendInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/billing.go
+++ b/fastly/billing.go
@@ -78,7 +78,7 @@ func (c *Client) GetBilling(i *GetBillingInput) (*Billing, error) {
 	defer resp.Body.Close()
 
 	var b *Billing
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -651,8 +651,8 @@ func checkResp(resp *http.Response, err error) (*http.Response, error) {
 	}
 }
 
-// decodeBodyMap is used to decode an HTTP response body into a mapstructure struct.
-func decodeBodyMap(body io.Reader, out any) error {
+// DecodeBodyMap is used to decode an HTTP response body into a mapstructure struct.
+func DecodeBodyMap(body io.Reader, out any) error {
 	var parsed any
 	dec := json.NewDecoder(body)
 	if err := dec.Decode(&parsed); err != nil {

--- a/fastly/compute_package.go
+++ b/fastly/compute_package.go
@@ -113,7 +113,7 @@ func MakePackagePath(serviceID string, serviceVersion int) (string, error) {
 // PopulatePackage encapsulates the decoding of returned package data.
 func PopulatePackage(body io.ReadCloser) (*Package, error) {
 	var p *Package
-	if err := decodeBodyMap(body, &p); err != nil {
+	if err := DecodeBodyMap(body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil

--- a/fastly/compute_package_test.go
+++ b/fastly/compute_package_test.go
@@ -10,7 +10,7 @@ func TestClient_Package(t *testing.T) {
 	nameSuffix := "package"
 
 	testService := createTestServiceWasm(t, fixtureBase+"service_create", nameSuffix)
-	testVersion := createTestVersion(t, fixtureBase+"service_version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"service_version", *testService.ServiceID)
 	defer deleteTestService(t, fixtureBase+"service_delete", *testService.ServiceID)
 
 	testData := Package{
@@ -30,7 +30,7 @@ func TestClient_Package(t *testing.T) {
 
 	// Update with valid package file path
 
-	recordIgnoreBody(t, fixtureBase+"update", func(c *Client) {
+	RecordIgnoreBody(t, fixtureBase+"update", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      *testService.ServiceID,
 			ServiceVersion: *testVersion.Number,
@@ -48,7 +48,7 @@ func TestClient_Package(t *testing.T) {
 	}
 
 	// Get
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		wp, err = c.GetPackage(&GetPackageInput{
 			ServiceID:      *testService.ServiceID,
 			ServiceVersion: *testVersion.Number,
@@ -90,7 +90,7 @@ func TestClient_Package(t *testing.T) {
 	// Update with valid package bytes
 
 	validPackageContent, _ := os.ReadFile("test_assets/package/valid.tar.gz")
-	recordIgnoreBody(t, fixtureBase+"update", func(c *Client) {
+	RecordIgnoreBody(t, fixtureBase+"update", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      *testService.ServiceID,
 			ServiceVersion: *testVersion.Number,
@@ -108,7 +108,7 @@ func TestClient_Package(t *testing.T) {
 	}
 
 	// Get
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		wp, err = c.GetPackage(&GetPackageInput{
 			ServiceID:      *testService.ServiceID,
 			ServiceVersion: *testVersion.Number,
@@ -146,7 +146,7 @@ func TestClient_Package(t *testing.T) {
 
 	// Update with invalid package file path
 
-	recordIgnoreBody(t, fixtureBase+"update_invalid", func(c *Client) {
+	RecordIgnoreBody(t, fixtureBase+"update_invalid", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      *testService.ServiceID,
 			ServiceVersion: *testVersion.Number,
@@ -160,7 +160,7 @@ func TestClient_Package(t *testing.T) {
 	// Update with invalid package bytes
 
 	invalidPackageContent, _ := os.ReadFile("test_assets/package/invalid.tar.gz")
-	recordIgnoreBody(t, fixtureBase+"update_invalid", func(c *Client) {
+	RecordIgnoreBody(t, fixtureBase+"update_invalid", func(c *Client) {
 		wp, err = c.UpdatePackage(&UpdatePackageInput{
 			ServiceID:      *testService.ServiceID,
 			ServiceVersion: *testVersion.Number,
@@ -174,14 +174,14 @@ func TestClient_Package(t *testing.T) {
 
 func TestClient_GetPackage_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetPackage(&GetPackageInput{
+	_, err = TestClient.GetPackage(&GetPackageInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetPackage(&GetPackageInput{
+	_, err = TestClient.GetPackage(&GetPackageInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -192,14 +192,14 @@ func TestClient_GetPackage_validation(t *testing.T) {
 
 func TestClient_UpdatePackage_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdatePackage(&UpdatePackageInput{
+	_, err = TestClient.UpdatePackage(&UpdatePackageInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdatePackage(&UpdatePackageInput{
+	_, err = TestClient.UpdatePackage(&UpdatePackageInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})

--- a/fastly/config_store.go
+++ b/fastly/config_store.go
@@ -216,7 +216,7 @@ func (c *Client) ListConfigStoreServices(i *ListConfigStoreServicesInput) ([]*Se
 	defer resp.Body.Close()
 
 	var ss []*Service
-	if err = decodeBodyMap(resp.Body, &ss); err != nil {
+	if err = DecodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 

--- a/fastly/config_store_item.go
+++ b/fastly/config_store_item.go
@@ -251,5 +251,5 @@ func (c *Client) BatchModifyConfigStoreItems(i *BatchModifyConfigStoreItemsInput
 	defer resp.Body.Close()
 
 	var batchModifyResult map[string]string
-	return decodeBodyMap(resp.Body, &batchModifyResult)
+	return DecodeBodyMap(resp.Body, &batchModifyResult)
 }

--- a/fastly/config_store_item_batch_test.go
+++ b/fastly/config_store_item_batch_test.go
@@ -12,7 +12,7 @@ func TestClient_ConfigStoreBatch(t *testing.T) {
 
 	var err error
 
-	record(t, "config_store_batch/create_and_upsert", func(c *Client) {
+	Record(t, "config_store_batch/create_and_upsert", func(c *Client) {
 		err = c.BatchModifyConfigStoreItems(&BatchModifyConfigStoreItemsInput{
 			StoreID: cs.StoreID,
 			Items: []*BatchConfigStoreItem{
@@ -33,7 +33,7 @@ func TestClient_ConfigStoreBatch(t *testing.T) {
 		t.Fatalf("error batch creating config store items: %v", err)
 	}
 
-	record(t, "config_store_batch/update_and_upsert", func(c *Client) {
+	Record(t, "config_store_batch/update_and_upsert", func(c *Client) {
 		err = c.BatchModifyConfigStoreItems(&BatchModifyConfigStoreItemsInput{
 			StoreID: cs.StoreID,
 			Items: []*BatchConfigStoreItem{
@@ -54,7 +54,7 @@ func TestClient_ConfigStoreBatch(t *testing.T) {
 		t.Fatalf("error batch updating config store items: %v", err)
 	}
 
-	record(t, "config_store_batch/delete", func(c *Client) {
+	Record(t, "config_store_batch/delete", func(c *Client) {
 		err = c.BatchModifyConfigStoreItems(&BatchModifyConfigStoreItemsInput{
 			StoreID: cs.StoreID,
 			Items: []*BatchConfigStoreItem{
@@ -81,7 +81,7 @@ func createConfigStoreForBatch(t *testing.T) *ConfigStore {
 		cs  *ConfigStore
 		err error
 	)
-	record(t, fmt.Sprintf("config_store_batch/%s/create_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_batch/%s/create_store", t.Name()), func(c *Client) {
 		cs, err = c.CreateConfigStore(&CreateConfigStoreInput{
 			Name: t.Name(),
 		})
@@ -92,7 +92,7 @@ func createConfigStoreForBatch(t *testing.T) *ConfigStore {
 
 	// Ensure Config Store is cleaned up.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("config_store_batch/%s/delete_store", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("config_store_batch/%s/delete_store", t.Name()), func(c *Client) {
 			err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 				StoreID: cs.StoreID,
 			})

--- a/fastly/config_store_item_test.go
+++ b/fastly/config_store_item_test.go
@@ -16,7 +16,7 @@ func TestClient_CreateConfigStoreItem(t *testing.T) {
 	)
 	const value = "testing 123"
 
-	record(t, fmt.Sprintf("config_store_item/%s/create_item", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/create_item", t.Name()), func(c *Client) {
 		item, err = c.CreateConfigStoreItem(&CreateConfigStoreItemInput{
 			StoreID: cs.StoreID,
 			Key:     t.Name(),
@@ -48,7 +48,7 @@ func TestClient_DeleteConfigStoreItem(t *testing.T) {
 
 	var err error
 
-	record(t, fmt.Sprintf("config_store_item/%s/create_item", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/create_item", t.Name()), func(c *Client) {
 		_, err = c.CreateConfigStoreItem(&CreateConfigStoreItemInput{
 			StoreID: cs.StoreID,
 			Key:     t.Name(),
@@ -59,7 +59,7 @@ func TestClient_DeleteConfigStoreItem(t *testing.T) {
 		t.Fatalf("error creating config store item: %v", err)
 	}
 
-	record(t, fmt.Sprintf("config_store_item/%s/delete_item", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/delete_item", t.Name()), func(c *Client) {
 		err = c.DeleteConfigStoreItem(&DeleteConfigStoreItemInput{
 			StoreID: cs.StoreID,
 			Key:     t.Name(),
@@ -81,7 +81,7 @@ func TestClient_GetConfigStoreItem(t *testing.T) {
 		err     error
 	)
 
-	record(t, fmt.Sprintf("config_store_item/%s/create_item", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/create_item", t.Name()), func(c *Client) {
 		item, err = c.CreateConfigStoreItem(&CreateConfigStoreItemInput{
 			StoreID: cs.StoreID,
 			Key:     t.Name(),
@@ -92,7 +92,7 @@ func TestClient_GetConfigStoreItem(t *testing.T) {
 		t.Fatalf("error creating config store item: %v", err)
 	}
 
-	record(t, fmt.Sprintf("config_store_item/%s/get_item", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/get_item", t.Name()), func(c *Client) {
 		gotItem, err = c.GetConfigStoreItem(&GetConfigStoreItemInput{
 			StoreID: cs.StoreID,
 			Key:     t.Name(),
@@ -130,7 +130,7 @@ func TestClient_ListConfigStoreItems(t *testing.T) {
 		keys[i] = fmt.Sprintf("%s-key-%02d", t.Name(), i)
 	}
 
-	record(t, fmt.Sprintf("config_store_item/%s/create_items", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/create_items", t.Name()), func(c *Client) {
 		for i, key := range keys {
 			_, err = c.CreateConfigStoreItem(&CreateConfigStoreItemInput{
 				StoreID: cs.StoreID,
@@ -147,7 +147,7 @@ func TestClient_ListConfigStoreItems(t *testing.T) {
 	}
 
 	var list []*ConfigStoreItem
-	record(t, fmt.Sprintf("config_store_item/%s/list_items", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/list_items", t.Name()), func(c *Client) {
 		list, err = c.ListConfigStoreItems(&ListConfigStoreItemsInput{
 			StoreID: cs.StoreID,
 		})
@@ -181,7 +181,7 @@ func TestClient_UpdateConfigStoreItem(t *testing.T) {
 	)
 
 	const newValue = "I'm a new value"
-	record(t, fmt.Sprintf("config_store_item/%s/create_and_update_item", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/create_and_update_item", t.Name()), func(c *Client) {
 		_, err = c.CreateConfigStoreItem(&CreateConfigStoreItemInput{
 			StoreID: cs.StoreID,
 			Key:     t.Name(),
@@ -214,7 +214,7 @@ func TestClient_UpdateConfigStoreItem(t *testing.T) {
 	// Upsert.
 
 	const upsertValue = "i was upserted"
-	record(t, fmt.Sprintf("config_store_item/%s/upsert_item", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/upsert_item", t.Name()), func(c *Client) {
 		gotItem, err = c.UpdateConfigStoreItem(&UpdateConfigStoreItemInput{
 			Upsert:  true,
 			StoreID: cs.StoreID,
@@ -242,7 +242,7 @@ func createConfigStore(t *testing.T) *ConfigStore {
 		cs  *ConfigStore
 		err error
 	)
-	record(t, fmt.Sprintf("config_store_item/%s/create_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store_item/%s/create_store", t.Name()), func(c *Client) {
 		cs, err = c.CreateConfigStore(&CreateConfigStoreInput{
 			Name: t.Name(),
 		})
@@ -253,7 +253,7 @@ func createConfigStore(t *testing.T) *ConfigStore {
 
 	// Ensure Config Store is cleaned up.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("config_store_item/%s/delete_store", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("config_store_item/%s/delete_store", t.Name()), func(c *Client) {
 			err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 				StoreID: cs.StoreID,
 			})

--- a/fastly/config_store_test.go
+++ b/fastly/config_store_test.go
@@ -14,7 +14,7 @@ func TestClient_CreateConfigStore(t *testing.T) {
 		cs  *ConfigStore
 		err error
 	)
-	record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
 		cs, err = c.CreateConfigStore(&CreateConfigStoreInput{
 			Name: t.Name(),
 		})
@@ -25,7 +25,7 @@ func TestClient_CreateConfigStore(t *testing.T) {
 
 	// Ensure Config Store is cleaned up.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
 			err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 				StoreID: cs.StoreID,
 			})
@@ -53,7 +53,7 @@ func TestClient_DeleteConfigStore(t *testing.T) {
 		cs  *ConfigStore
 		err error
 	)
-	record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
 		cs, err = c.CreateConfigStore(&CreateConfigStoreInput{
 			Name: t.Name(),
 		})
@@ -62,7 +62,7 @@ func TestClient_DeleteConfigStore(t *testing.T) {
 		t.Fatalf("error creating config store: %v", err)
 	}
 
-	record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
 		err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 			StoreID: cs.StoreID,
 		})
@@ -73,7 +73,7 @@ func TestClient_DeleteConfigStore(t *testing.T) {
 
 	// Verify that deleting a non-existent store gives an error.
 
-	record(t, fmt.Sprintf("config_store/%s/delete_store_404", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/delete_store_404", t.Name()), func(c *Client) {
 		err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 			StoreID: cs.StoreID,
 		})
@@ -97,7 +97,7 @@ func TestClient_GetConfigStore(t *testing.T) {
 		cs  *ConfigStore
 		err error
 	)
-	record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
 		cs, err = c.CreateConfigStore(&CreateConfigStoreInput{
 			Name: t.Name(),
 		})
@@ -108,7 +108,7 @@ func TestClient_GetConfigStore(t *testing.T) {
 
 	// Ensure Config Stores are cleaned up.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
 			err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 				StoreID: cs.StoreID,
 			})
@@ -119,7 +119,7 @@ func TestClient_GetConfigStore(t *testing.T) {
 	})
 
 	var getResult *ConfigStore
-	record(t, fmt.Sprintf("config_store/%s/get_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/get_store", t.Name()), func(c *Client) {
 		getResult, err = c.GetConfigStore(&GetConfigStoreInput{
 			StoreID: cs.StoreID,
 		})
@@ -137,7 +137,7 @@ func TestClient_GetConfigStore(t *testing.T) {
 
 	// Verify that getting a non-existent store gives an error.
 
-	record(t, fmt.Sprintf("config_store/%s/get_store_404", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/get_store_404", t.Name()), func(c *Client) {
 		getResult, err = c.GetConfigStore(&GetConfigStoreInput{
 			StoreID: "DOES-NOT-EXIST",
 		})
@@ -161,7 +161,7 @@ func TestClient_GetConfigStoreMetadata(t *testing.T) {
 		cs  *ConfigStore
 		err error
 	)
-	record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
 		cs, err = c.CreateConfigStore(&CreateConfigStoreInput{
 			Name: t.Name(),
 		})
@@ -172,7 +172,7 @@ func TestClient_GetConfigStoreMetadata(t *testing.T) {
 
 	// Ensure Config Stores are cleaned up.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
 			err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 				StoreID: cs.StoreID,
 			})
@@ -183,7 +183,7 @@ func TestClient_GetConfigStoreMetadata(t *testing.T) {
 	})
 
 	var metadataResult *ConfigStoreMetadata
-	record(t, fmt.Sprintf("config_store/%s/get_store_metadata", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/get_store_metadata", t.Name()), func(c *Client) {
 		metadataResult, err = c.GetConfigStoreMetadata(&GetConfigStoreMetadataInput{
 			StoreID: cs.StoreID,
 		})
@@ -198,7 +198,7 @@ func TestClient_GetConfigStoreMetadata(t *testing.T) {
 
 	// Verify that getting a non-existent store gives an error.
 
-	record(t, fmt.Sprintf("config_store/%s/get_store_metadata_404", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/get_store_metadata_404", t.Name()), func(c *Client) {
 		metadataResult, err = c.GetConfigStoreMetadata(&GetConfigStoreMetadataInput{
 			StoreID: "DOES-NOT-EXIST",
 		})
@@ -222,7 +222,7 @@ func TestClient_ListConfigStores(t *testing.T) {
 	)
 
 	// Verify list works when there are no stores.
-	record(t, fmt.Sprintf("config_store/%s/empty", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/empty", t.Name()), func(c *Client) {
 		css, err = c.ListConfigStores(&ListConfigStoresInput{})
 	})
 	if err != nil {
@@ -237,7 +237,7 @@ func TestClient_ListConfigStores(t *testing.T) {
 		stores []*ConfigStore
 		cs     *ConfigStore
 	)
-	record(t, fmt.Sprintf("config_store/%s/create_stores", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/create_stores", t.Name()), func(c *Client) {
 		for i := 0; i < 5; i++ {
 			cs, err = c.CreateConfigStore(&CreateConfigStoreInput{
 				Name: fmt.Sprintf("%s-%02d", t.Name(), i),
@@ -251,7 +251,7 @@ func TestClient_ListConfigStores(t *testing.T) {
 	})
 	// Ensure Config Stores are cleaned up.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("config_store/%s/delete_stores", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("config_store/%s/delete_stores", t.Name()), func(c *Client) {
 			for _, cs := range stores {
 				err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 					StoreID: cs.StoreID,
@@ -263,7 +263,7 @@ func TestClient_ListConfigStores(t *testing.T) {
 		})
 	})
 
-	record(t, fmt.Sprintf("config_store/%s/list", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/list", t.Name()), func(c *Client) {
 		css, err = c.ListConfigStores(&ListConfigStoresInput{})
 	})
 
@@ -277,7 +277,7 @@ func TestClient_ListConfigStores(t *testing.T) {
 		}
 	}
 
-	record(t, fmt.Sprintf("config_store/%s/list-with-name", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/list-with-name", t.Name()), func(c *Client) {
 		css, err = c.ListConfigStores(&ListConfigStoresInput{Name: stores[0].Name})
 	})
 
@@ -295,7 +295,7 @@ func TestClient_ListConfigStoreServices(t *testing.T) {
 		cs  *ConfigStore
 		err error
 	)
-	record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
 		cs, err = c.CreateConfigStore(&CreateConfigStoreInput{
 			Name: t.Name(),
 		})
@@ -306,7 +306,7 @@ func TestClient_ListConfigStoreServices(t *testing.T) {
 
 	// Ensure Config Stores are cleaned up.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
 			err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 				StoreID: cs.StoreID,
 			})
@@ -317,7 +317,7 @@ func TestClient_ListConfigStoreServices(t *testing.T) {
 	})
 
 	var servicesResult []*Service
-	record(t, fmt.Sprintf("config_store/%s/list_services", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/list_services", t.Name()), func(c *Client) {
 		servicesResult, err = c.ListConfigStoreServices(&ListConfigStoreServicesInput{
 			StoreID: cs.StoreID,
 		})
@@ -335,7 +335,7 @@ func TestClient_UpdateConfigStore(t *testing.T) {
 		cs  *ConfigStore
 		err error
 	)
-	record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/create_store", t.Name()), func(c *Client) {
 		cs, err = c.CreateConfigStore(&CreateConfigStoreInput{
 			Name: t.Name(),
 		})
@@ -346,7 +346,7 @@ func TestClient_UpdateConfigStore(t *testing.T) {
 
 	// Ensure Config Stores are cleaned up.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("config_store/%s/delete_store", t.Name()), func(c *Client) {
 			err = c.DeleteConfigStore(&DeleteConfigStoreInput{
 				StoreID: cs.StoreID,
 			})
@@ -358,7 +358,7 @@ func TestClient_UpdateConfigStore(t *testing.T) {
 
 	const updatedName = "UPDATED NAME!"
 	var updateResult *ConfigStore
-	record(t, fmt.Sprintf("config_store/%s/update_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("config_store/%s/update_store", t.Name()), func(c *Client) {
 		updateResult, err = c.UpdateConfigStore(&UpdateConfigStoreInput{
 			StoreID: cs.StoreID,
 			Name:    updatedName,

--- a/fastly/datacenters.go
+++ b/fastly/datacenters.go
@@ -26,7 +26,7 @@ func (c *Client) AllDatacenters() (datacenters []Datacenter, err error) {
 	defer resp.Body.Close()
 
 	var m []Datacenter
-	if err := decodeBodyMap(resp.Body, &m); err != nil {
+	if err := DecodeBodyMap(resp.Body, &m); err != nil {
 		return nil, err
 	}
 

--- a/fastly/datacenters_test.go
+++ b/fastly/datacenters_test.go
@@ -7,7 +7,7 @@ func TestDatacenters(t *testing.T) {
 
 	var err error
 	var datacenters []Datacenter
-	record(t, "datacenters/list", func(c *Client) {
+	Record(t, "datacenters/list", func(c *Client) {
 		datacenters, err = c.AllDatacenters()
 	})
 	if err != nil {

--- a/fastly/dictionary.go
+++ b/fastly/dictionary.go
@@ -43,7 +43,7 @@ func (c *Client) ListDictionaries(i *ListDictionariesInput) ([]*Dictionary, erro
 	defer resp.Body.Close()
 
 	var bs []*Dictionary
-	if err := decodeBodyMap(resp.Body, &bs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	return bs, nil
@@ -79,7 +79,7 @@ func (c *Client) CreateDictionary(i *CreateDictionaryInput) (*Dictionary, error)
 	defer resp.Body.Close()
 
 	var b *Dictionary
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -116,7 +116,7 @@ func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
 	defer resp.Body.Close()
 
 	var b *Dictionary
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -157,7 +157,7 @@ func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error)
 	defer resp.Body.Close()
 
 	var b *Dictionary
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/dictionary_info.go
+++ b/fastly/dictionary_info.go
@@ -46,7 +46,7 @@ func (c *Client) GetDictionaryInfo(i *GetDictionaryInfoInput) (*DictionaryInfo, 
 	defer resp.Body.Close()
 
 	var b *DictionaryInfo
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/dictionary_info_test.go
+++ b/fastly/dictionary_info_test.go
@@ -11,7 +11,7 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"version", *testService.ServiceID)
 
 	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
@@ -21,7 +21,7 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 		info *DictionaryInfo
 	)
 
-	record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
+	Record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(&BatchModifyDictionaryItemsInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,
@@ -43,7 +43,7 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		info, err = c.GetDictionaryInfo(&GetDictionaryInfoInput{
 			ServiceID:      *testService.ServiceID,
 			ServiceVersion: *testVersion.Number,
@@ -61,19 +61,19 @@ func TestClient_GetDictionaryInfo(t *testing.T) {
 
 func TestClient_GetDictionaryInfo_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetDictionaryInfo(&GetDictionaryInfoInput{})
+	_, err = TestClient.GetDictionaryInfo(&GetDictionaryInfoInput{})
 	if err != ErrMissingDictionaryID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDictionaryInfo(&GetDictionaryInfoInput{
+	_, err = TestClient.GetDictionaryInfo(&GetDictionaryInfoInput{
 		DictionaryID: "123",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDictionaryInfo(&GetDictionaryInfoInput{
+	_, err = TestClient.GetDictionaryInfo(&GetDictionaryInfoInput{
 		DictionaryID:   "123",
 		ServiceID:      "foo",
 		ServiceVersion: 0,

--- a/fastly/dictionary_item.go
+++ b/fastly/dictionary_item.go
@@ -121,7 +121,7 @@ func (c *Client) CreateDictionaryItem(i *CreateDictionaryItemInput) (*Dictionary
 	defer resp.Body.Close()
 
 	var b *DictionaryItem
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -175,7 +175,7 @@ func (c *Client) GetDictionaryItem(i *GetDictionaryItemInput) (*DictionaryItem, 
 	defer resp.Body.Close()
 
 	var b *DictionaryItem
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -214,7 +214,7 @@ func (c *Client) UpdateDictionaryItem(i *UpdateDictionaryItemInput) (*Dictionary
 	defer resp.Body.Close()
 
 	var b *DictionaryItem
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -262,7 +262,7 @@ func (c *Client) BatchModifyDictionaryItems(i *BatchModifyDictionaryItemsInput) 
 	defer resp.Body.Close()
 
 	var batchModifyResult map[string]string
-	return decodeBodyMap(resp.Body, &batchModifyResult)
+	return DecodeBodyMap(resp.Body, &batchModifyResult)
 }
 
 // DeleteDictionaryItemInput is the input parameter to DeleteDictionaryItem.

--- a/fastly/dictionary_item_batch_test.go
+++ b/fastly/dictionary_item_batch_test.go
@@ -12,7 +12,7 @@ func TestClient_BatchModifyDictionaryItems_Create(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
 
 	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
@@ -36,7 +36,7 @@ func TestClient_BatchModifyDictionaryItems_Create(t *testing.T) {
 
 	// When: I execute the batch create operations against the Fastly API,
 	var err error
-	record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
+	Record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(batchCreateOperations)
 	})
 	if err != nil {
@@ -45,7 +45,7 @@ func TestClient_BatchModifyDictionaryItems_Create(t *testing.T) {
 
 	// Then: I expect to be able to list all of the created dictionary items.
 	var actualDictionaryItems []*DictionaryItem
-	record(t, fixtureBase+"list_after_create", func(c *Client) {
+	Record(t, fixtureBase+"list_after_create", func(c *Client) {
 		actualDictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,
@@ -84,7 +84,7 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
 
 	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
@@ -107,7 +107,7 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 	}
 
 	var err error
-	record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
+	Record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(batchCreateOperations)
 	})
 	if err != nil {
@@ -127,7 +127,7 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 		},
 	}
 
-	record(t, fixtureBase+"delete_dictionary_items", func(c *Client) {
+	Record(t, fixtureBase+"delete_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(batchDeleteOperations)
 	})
 	if err != nil {
@@ -136,7 +136,7 @@ func TestClient_BatchModifyDictionaryItems_Delete(t *testing.T) {
 
 	// Then: I expect to be able to list a single dictionary item.
 	var actualDictionaryItems []*DictionaryItem
-	record(t, fixtureBase+"list_after_delete", func(client *Client) {
+	Record(t, fixtureBase+"list_after_delete", func(client *Client) {
 		actualDictionaryItems, err = client.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,
@@ -161,7 +161,7 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
 
 	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
@@ -184,7 +184,7 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 	}
 
 	var err error
-	record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
+	Record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(batchCreateOperations)
 	})
 	if err != nil {
@@ -204,7 +204,7 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 		},
 	}
 
-	record(t, fixtureBase+"update_dictionary_items", func(c *Client) {
+	Record(t, fixtureBase+"update_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(batchUpdateOperations)
 	})
 	if err != nil {
@@ -213,7 +213,7 @@ func TestClient_BatchModifyDictionaryItems_Update(t *testing.T) {
 
 	// Then: I expect to be able to list all of the dictionary items with modifications applied to a single item.
 	var actualDictionaryItems []*DictionaryItem
-	record(t, fixtureBase+"list_after_update", func(c *Client) {
+	Record(t, fixtureBase+"list_after_update", func(c *Client) {
 		actualDictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,
@@ -267,7 +267,7 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"create_version", *testService.ServiceID)
 
 	testDictionary := createTestDictionary(t, fixtureBase+"create_dictionary", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
@@ -285,7 +285,7 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 	}
 
 	var err error
-	record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
+	Record(t, fixtureBase+"create_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(batchCreateOperations)
 	})
 	if err != nil {
@@ -310,7 +310,7 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 		},
 	}
 
-	record(t, fixtureBase+"upsert_dictionary_items", func(c *Client) {
+	Record(t, fixtureBase+"upsert_dictionary_items", func(c *Client) {
 		err = c.BatchModifyDictionaryItems(batchUpsertOperations)
 	})
 	if err != nil {
@@ -319,7 +319,7 @@ func TestClient_BatchModifyDictionaryItems_Upsert(t *testing.T) {
 
 	// Then: I expect to be able to list all of the dictionary items with the modification present.
 	var actualDictionaryItems []*DictionaryItem
-	record(t, fixtureBase+"list_after_upsert", func(c *Client) {
+	Record(t, fixtureBase+"list_after_upsert", func(c *Client) {
 		actualDictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,

--- a/fastly/dictionary_item_test.go
+++ b/fastly/dictionary_item_test.go
@@ -11,7 +11,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"create_service", nameSuffix)
 	defer deleteTestService(t, fixtureBase+"delete_service", *testService.ServiceID)
 
-	testVersion := createTestVersion(t, fixtureBase+"version", *testService.ServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"version", *testService.ServiceID)
 
 	testDictionary := createTestDictionary(t, fixtureBase+"dictionary", *testService.ServiceID, *testVersion.Number, nameSuffix)
 	defer deleteTestDictionary(t, testDictionary, fixtureBase+"delete_dictionary")
@@ -19,7 +19,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	// Create
 	var err error
 	var createdDictionaryItem *DictionaryItem
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		createdDictionaryItem, err = c.CreateDictionaryItem(&CreateDictionaryItemInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,
@@ -33,7 +33,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"cleanup", func(c *Client) {
+		Record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteDictionaryItem(&DeleteDictionaryItemInput{
 				ServiceID:    *testService.ServiceID,
 				DictionaryID: *testDictionary.DictionaryID,
@@ -51,7 +51,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 
 	// List
 	var dictionaryItems []*DictionaryItem
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		dictionaryItems, err = c.ListDictionaryItems(&ListDictionaryItemsInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,
@@ -67,7 +67,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	// List with paginator
 	var dictionaryItems2 []*DictionaryItem
 	var paginator *ListPaginator[DictionaryItem]
-	record(t, fixtureBase+"list2", func(c *Client) {
+	Record(t, fixtureBase+"list2", func(c *Client) {
 		paginator = c.GetDictionaryItems(&GetDictionaryItemsInput{
 			DictionaryID: *testDictionary.DictionaryID,
 			Direction:    ToPointer("ascend"),
@@ -97,7 +97,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 
 	// Get
 	var retrievedDictionaryItem *DictionaryItem
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		retrievedDictionaryItem, err = c.GetDictionaryItem(&GetDictionaryItemInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,
@@ -116,7 +116,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 
 	// Update
 	var updatedDictionaryItem *DictionaryItem
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		updatedDictionaryItem, err = c.UpdateDictionaryItem(&UpdateDictionaryItemInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,
@@ -132,7 +132,7 @@ func TestClient_DictionaryItems(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteDictionaryItem(&DeleteDictionaryItemInput{
 			ServiceID:    *testService.ServiceID,
 			DictionaryID: *testDictionary.DictionaryID,
@@ -147,12 +147,12 @@ func TestClient_DictionaryItems(t *testing.T) {
 func TestClient_ListDictionaryItems_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListDictionaryItems(&ListDictionaryItemsInput{})
+	_, err = TestClient.ListDictionaryItems(&ListDictionaryItemsInput{})
 	if err != ErrMissingDictionaryID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListDictionaryItems(&ListDictionaryItemsInput{
+	_, err = TestClient.ListDictionaryItems(&ListDictionaryItemsInput{
 		DictionaryID: "123",
 	})
 	if err != ErrMissingServiceID {
@@ -163,12 +163,12 @@ func TestClient_ListDictionaryItems_validation(t *testing.T) {
 func TestClient_CreateDictionaryItem_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateDictionaryItem(&CreateDictionaryItemInput{})
+	_, err = TestClient.CreateDictionaryItem(&CreateDictionaryItemInput{})
 	if err != ErrMissingDictionaryID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateDictionaryItem(&CreateDictionaryItemInput{
+	_, err = TestClient.CreateDictionaryItem(&CreateDictionaryItemInput{
 		DictionaryID: "123",
 	})
 	if err != ErrMissingServiceID {
@@ -179,19 +179,19 @@ func TestClient_CreateDictionaryItem_validation(t *testing.T) {
 func TestClient_GetDictionaryItem_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetDictionaryItem(&GetDictionaryItemInput{})
+	_, err = TestClient.GetDictionaryItem(&GetDictionaryItemInput{})
 	if err != ErrMissingDictionaryID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDictionaryItem(&GetDictionaryItemInput{
+	_, err = TestClient.GetDictionaryItem(&GetDictionaryItemInput{
 		DictionaryID: "test",
 	})
 	if err != ErrMissingItemKey {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDictionaryItem(&GetDictionaryItemInput{
+	_, err = TestClient.GetDictionaryItem(&GetDictionaryItemInput{
 		DictionaryID: "test",
 		ItemKey:      "123",
 	})
@@ -203,19 +203,19 @@ func TestClient_GetDictionaryItem_validation(t *testing.T) {
 func TestClient_UpdateDictionaryItem_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateDictionaryItem(&UpdateDictionaryItemInput{})
+	_, err = TestClient.UpdateDictionaryItem(&UpdateDictionaryItemInput{})
 	if err != ErrMissingDictionaryID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDictionaryItem(&UpdateDictionaryItemInput{
+	_, err = TestClient.UpdateDictionaryItem(&UpdateDictionaryItemInput{
 		DictionaryID: "test",
 	})
 	if err != ErrMissingItemKey {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDictionaryItem(&UpdateDictionaryItemInput{
+	_, err = TestClient.UpdateDictionaryItem(&UpdateDictionaryItemInput{
 		DictionaryID: "test",
 		ItemKey:      "123",
 	})
@@ -227,19 +227,19 @@ func TestClient_UpdateDictionaryItem_validation(t *testing.T) {
 func TestClient_DeleteDictionaryItem_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteDictionaryItem(&DeleteDictionaryItemInput{})
+	err = TestClient.DeleteDictionaryItem(&DeleteDictionaryItemInput{})
 	if err != ErrMissingDictionaryID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDictionaryItem(&DeleteDictionaryItemInput{
+	err = TestClient.DeleteDictionaryItem(&DeleteDictionaryItemInput{
 		DictionaryID: "test",
 	})
 	if err != ErrMissingItemKey {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDictionaryItem(&DeleteDictionaryItemInput{
+	err = TestClient.DeleteDictionaryItem(&DeleteDictionaryItemInput{
 		DictionaryID: "test",
 		ItemKey:      "123",
 	})
@@ -251,13 +251,13 @@ func TestClient_DeleteDictionaryItem_validation(t *testing.T) {
 func TestClient_BatchModifyDictionaryItem_validation(t *testing.T) {
 	var err error
 
-	err = testClient.BatchModifyDictionaryItems(&BatchModifyDictionaryItemsInput{})
+	err = TestClient.BatchModifyDictionaryItems(&BatchModifyDictionaryItemsInput{})
 	if err != ErrMissingDictionaryID {
 		t.Errorf("bad error: %s", err)
 	}
 
 	oversizedDictionaryItems := make([]*BatchDictionaryItem, BatchModifyMaximumOperations+1)
-	err = testClient.BatchModifyDictionaryItems(&BatchModifyDictionaryItemsInput{
+	err = TestClient.BatchModifyDictionaryItems(&BatchModifyDictionaryItemsInput{
 		DictionaryID: "bar",
 		Items:        oversizedDictionaryItems,
 	})
@@ -266,7 +266,7 @@ func TestClient_BatchModifyDictionaryItem_validation(t *testing.T) {
 	}
 
 	validDictionaryItems := make([]*BatchDictionaryItem, BatchModifyMaximumOperations)
-	err = testClient.BatchModifyDictionaryItems(&BatchModifyDictionaryItemsInput{
+	err = TestClient.BatchModifyDictionaryItems(&BatchModifyDictionaryItemsInput{
 		DictionaryID: "bar",
 		Items:        validDictionaryItems,
 	})

--- a/fastly/dictionary_test.go
+++ b/fastly/dictionary_test.go
@@ -9,14 +9,14 @@ func TestClient_Dictionaries(t *testing.T) {
 
 	fixtureBase := "dictionaries/"
 
-	testVersion := createTestVersion(t, fixtureBase+"version", testDeliveryServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"version", TestDeliveryServiceID)
 
 	// Create
 	var err error
 	var d *Dictionary
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		d, err = c.CreateDictionary(&CreateDictionaryInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           ToPointer("test_dictionary"),
 		})
@@ -27,15 +27,15 @@ func TestClient_Dictionaries(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"cleanup", func(c *Client) {
+		Record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteDictionary(&DeleteDictionaryInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *testVersion.Number,
 				Name:           "test_dictionary",
 			})
 
 			_ = c.DeleteDictionary(&DeleteDictionaryInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *testVersion.Number,
 				Name:           "new_test_dictionary",
 			})
@@ -48,9 +48,9 @@ func TestClient_Dictionaries(t *testing.T) {
 
 	// List
 	var ds []*Dictionary
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		ds, err = c.ListDictionaries(&ListDictionariesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 		})
 	})
@@ -63,9 +63,9 @@ func TestClient_Dictionaries(t *testing.T) {
 
 	// Get
 	var nd *Dictionary
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		nd, err = c.GetDictionary(&GetDictionaryInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           "test_dictionary",
 		})
@@ -79,9 +79,9 @@ func TestClient_Dictionaries(t *testing.T) {
 
 	// Update
 	var ud *Dictionary
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		ud, err = c.UpdateDictionary(&UpdateDictionaryInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           "test_dictionary",
 			NewName:        ToPointer("new_test_dictionary"),
@@ -95,9 +95,9 @@ func TestClient_Dictionaries(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteDictionary(&DeleteDictionaryInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           "new_test_dictionary",
 		})
@@ -109,14 +109,14 @@ func TestClient_Dictionaries(t *testing.T) {
 
 func TestClient_ListDictionaries_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListDictionaries(&ListDictionariesInput{
+	_, err = TestClient.ListDictionaries(&ListDictionariesInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListDictionaries(&ListDictionariesInput{
+	_, err = TestClient.ListDictionaries(&ListDictionariesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -127,14 +127,14 @@ func TestClient_ListDictionaries_validation(t *testing.T) {
 
 func TestClient_CreateDictionary_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateDictionary(&CreateDictionaryInput{
+	_, err = TestClient.CreateDictionary(&CreateDictionaryInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateDictionary(&CreateDictionaryInput{
+	_, err = TestClient.CreateDictionary(&CreateDictionaryInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -146,7 +146,7 @@ func TestClient_CreateDictionary_validation(t *testing.T) {
 func TestClient_GetDictionary_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetDictionary(&GetDictionaryInput{
+	_, err = TestClient.GetDictionary(&GetDictionaryInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -154,7 +154,7 @@ func TestClient_GetDictionary_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDictionary(&GetDictionaryInput{
+	_, err = TestClient.GetDictionary(&GetDictionaryInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -162,7 +162,7 @@ func TestClient_GetDictionary_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDictionary(&GetDictionaryInput{
+	_, err = TestClient.GetDictionary(&GetDictionaryInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -174,7 +174,7 @@ func TestClient_GetDictionary_validation(t *testing.T) {
 func TestClient_UpdateDictionary_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateDictionary(&UpdateDictionaryInput{
+	_, err = TestClient.UpdateDictionary(&UpdateDictionaryInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -182,7 +182,7 @@ func TestClient_UpdateDictionary_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDictionary(&UpdateDictionaryInput{
+	_, err = TestClient.UpdateDictionary(&UpdateDictionaryInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -190,7 +190,7 @@ func TestClient_UpdateDictionary_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDictionary(&UpdateDictionaryInput{
+	_, err = TestClient.UpdateDictionary(&UpdateDictionaryInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -202,7 +202,7 @@ func TestClient_UpdateDictionary_validation(t *testing.T) {
 func TestClient_DeleteDictionary_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteDictionary(&DeleteDictionaryInput{
+	err = TestClient.DeleteDictionary(&DeleteDictionaryInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -210,7 +210,7 @@ func TestClient_DeleteDictionary_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDictionary(&DeleteDictionaryInput{
+	err = TestClient.DeleteDictionary(&DeleteDictionaryInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -218,7 +218,7 @@ func TestClient_DeleteDictionary_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDictionary(&DeleteDictionaryInput{
+	err = TestClient.DeleteDictionary(&DeleteDictionaryInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/diff.go
+++ b/fastly/diff.go
@@ -49,7 +49,7 @@ func (c *Client) GetDiff(i *GetDiffInput) (*Diff, error) {
 	defer resp.Body.Close()
 
 	var d *Diff
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil

--- a/fastly/diff_test.go
+++ b/fastly/diff_test.go
@@ -9,20 +9,20 @@ func TestClient_Diff(t *testing.T) {
 
 	var err error
 	var tv1 *Version
-	record(t, "diff/version_1", func(c *Client) {
+	Record(t, "diff/version_1", func(c *Client) {
 		tv1 = testVersion(t, c)
 	})
 
 	var tv2 *Version
-	record(t, "diff/version_2", func(c *Client) {
+	Record(t, "diff/version_2", func(c *Client) {
 		tv2 = testVersion(t, c)
 	})
 
 	// Diff should be empty
 	var d *Diff
-	record(t, "diff/get", func(c *Client) {
+	Record(t, "diff/get", func(c *Client) {
 		d, err = c.GetDiff(&GetDiffInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			From:      *tv1.Number,
 			To:        *tv2.Number,
 		})
@@ -32,9 +32,9 @@ func TestClient_Diff(t *testing.T) {
 	}
 
 	// Create a diff
-	record(t, "diff/create_backend", func(c *Client) {
+	Record(t, "diff/create_backend", func(c *Client) {
 		_, err = c.CreateBackend(&CreateBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv2.Number,
 			Name:           ToPointer("test-backend"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
@@ -46,9 +46,9 @@ func TestClient_Diff(t *testing.T) {
 
 	// Ensure we delete the backend we just created
 	defer func() {
-		record(t, "diff/cleanup", func(c *Client) {
+		Record(t, "diff/cleanup", func(c *Client) {
 			_ = c.DeleteBackend(&DeleteBackendInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv2.Number,
 				Name:           "test-backend",
 			})
@@ -56,9 +56,9 @@ func TestClient_Diff(t *testing.T) {
 	}()
 
 	// Diff should mot be empty
-	record(t, "diff/get_again", func(c *Client) {
+	Record(t, "diff/get_again", func(c *Client) {
 		d, err = c.GetDiff(&GetDiffInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			From:      *tv1.Number,
 			To:        *tv2.Number,
 		})
@@ -73,14 +73,14 @@ func TestClient_Diff(t *testing.T) {
 
 func TestClient_Diff_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetDiff(&GetDiffInput{
+	_, err = TestClient.GetDiff(&GetDiffInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDiff(&GetDiffInput{
+	_, err = TestClient.GetDiff(&GetDiffInput{
 		ServiceID: "foo",
 		From:      0,
 	})
@@ -88,7 +88,7 @@ func TestClient_Diff_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDiff(&GetDiffInput{
+	_, err = TestClient.GetDiff(&GetDiffInput{
 		ServiceID: "foo",
 		From:      1,
 		To:        0,

--- a/fastly/domain.go
+++ b/fastly/domain.go
@@ -45,7 +45,7 @@ func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 	defer resp.Body.Close()
 
 	var ds []*Domain
-	if err := decodeBodyMap(resp.Body, &ds); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ds); err != nil {
 		return nil, err
 	}
 	return ds, nil
@@ -81,7 +81,7 @@ func (c *Client) CreateDomain(i *CreateDomainInput) (*Domain, error) {
 	defer resp.Body.Close()
 
 	var d *Domain
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -118,7 +118,7 @@ func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
 	defer resp.Body.Close()
 
 	var d *Domain
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -159,7 +159,7 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 	defer resp.Body.Close()
 
 	var d *Domain
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil

--- a/fastly/domain_test.go
+++ b/fastly/domain_test.go
@@ -9,7 +9,7 @@ func TestClient_Domains(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "domains/version", func(c *Client) {
+	Record(t, "domains/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -22,9 +22,9 @@ func TestClient_Domains(t *testing.T) {
 
 	// Create
 	var d *Domain
-	record(t, "domains/create", func(c *Client) {
+	Record(t, "domains/create", func(c *Client) {
 		d, err = c.CreateDomain(&CreateDomainInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer(domain1),
 			Comment:        ToPointer("comment"),
@@ -35,9 +35,9 @@ func TestClient_Domains(t *testing.T) {
 	}
 
 	var d2 *Domain
-	record(t, "domains/create2", func(c *Client) {
+	Record(t, "domains/create2", func(c *Client) {
 		d2, err = c.CreateDomain(&CreateDomainInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer(domain2),
 			Comment:        ToPointer("comment"),
@@ -49,15 +49,15 @@ func TestClient_Domains(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "domains/cleanup", func(c *Client) {
+		Record(t, "domains/cleanup", func(c *Client) {
 			_ = c.DeleteDomain(&DeleteDomainInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           domain1,
 			})
 
 			_ = c.DeleteDomain(&DeleteDomainInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           domain3,
 			})
@@ -76,9 +76,9 @@ func TestClient_Domains(t *testing.T) {
 
 	// List
 	var ds []*Domain
-	record(t, "domains/list", func(c *Client) {
+	Record(t, "domains/list", func(c *Client) {
 		ds, err = c.ListDomains(&ListDomainsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -91,9 +91,9 @@ func TestClient_Domains(t *testing.T) {
 
 	// Get
 	var nd *Domain
-	record(t, "domains/get", func(c *Client) {
+	Record(t, "domains/get", func(c *Client) {
 		nd, err = c.GetDomain(&GetDomainInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           domain1,
 		})
@@ -110,9 +110,9 @@ func TestClient_Domains(t *testing.T) {
 
 	// Update
 	var ud *Domain
-	record(t, "domains/update", func(c *Client) {
+	Record(t, "domains/update", func(c *Client) {
 		ud, err = c.UpdateDomain(&UpdateDomainInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           domain1,
 			NewName:        ToPointer(domain3),
@@ -127,9 +127,9 @@ func TestClient_Domains(t *testing.T) {
 
 	// Validate
 	var vd *DomainValidationResult
-	record(t, "domains/validation", func(c *Client) {
+	Record(t, "domains/validation", func(c *Client) {
 		vd, err = c.ValidateDomain(&ValidateDomainInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           domain3,
 		})
@@ -142,9 +142,9 @@ func TestClient_Domains(t *testing.T) {
 	}
 
 	var vds []*DomainValidationResult
-	record(t, "domains/validate-all", func(c *Client) {
+	Record(t, "domains/validate-all", func(c *Client) {
 		vds, err = c.ValidateAllDomains(&ValidateAllDomainsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -161,9 +161,9 @@ func TestClient_Domains(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "domains/delete", func(c *Client) {
+	Record(t, "domains/delete", func(c *Client) {
 		err = c.DeleteDomain(&DeleteDomainInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           domain3,
 		})
@@ -175,14 +175,14 @@ func TestClient_Domains(t *testing.T) {
 
 func TestClient_ListDomains_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListDomains(&ListDomainsInput{
+	_, err = TestClient.ListDomains(&ListDomainsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListDomains(&ListDomainsInput{
+	_, err = TestClient.ListDomains(&ListDomainsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -193,14 +193,14 @@ func TestClient_ListDomains_validation(t *testing.T) {
 
 func TestClient_CreateDomain_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateDomain(&CreateDomainInput{
+	_, err = TestClient.CreateDomain(&CreateDomainInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateDomain(&CreateDomainInput{
+	_, err = TestClient.CreateDomain(&CreateDomainInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -212,7 +212,7 @@ func TestClient_CreateDomain_validation(t *testing.T) {
 func TestClient_GetDomain_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetDomain(&GetDomainInput{
+	_, err = TestClient.GetDomain(&GetDomainInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -220,7 +220,7 @@ func TestClient_GetDomain_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDomain(&GetDomainInput{
+	_, err = TestClient.GetDomain(&GetDomainInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -228,7 +228,7 @@ func TestClient_GetDomain_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDomain(&GetDomainInput{
+	_, err = TestClient.GetDomain(&GetDomainInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -240,7 +240,7 @@ func TestClient_GetDomain_validation(t *testing.T) {
 func TestClient_UpdateDomain_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateDomain(&UpdateDomainInput{
+	_, err = TestClient.UpdateDomain(&UpdateDomainInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -248,7 +248,7 @@ func TestClient_UpdateDomain_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDomain(&UpdateDomainInput{
+	_, err = TestClient.UpdateDomain(&UpdateDomainInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -256,7 +256,7 @@ func TestClient_UpdateDomain_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDomain(&UpdateDomainInput{
+	_, err = TestClient.UpdateDomain(&UpdateDomainInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -268,7 +268,7 @@ func TestClient_UpdateDomain_validation(t *testing.T) {
 func TestClient_DeleteDomain_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteDomain(&DeleteDomainInput{
+	err = TestClient.DeleteDomain(&DeleteDomainInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -276,7 +276,7 @@ func TestClient_DeleteDomain_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDomain(&DeleteDomainInput{
+	err = TestClient.DeleteDomain(&DeleteDomainInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -284,7 +284,7 @@ func TestClient_DeleteDomain_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDomain(&DeleteDomainInput{
+	err = TestClient.DeleteDomain(&DeleteDomainInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -296,7 +296,7 @@ func TestClient_DeleteDomain_validation(t *testing.T) {
 func TestClient_ValidateDomain_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ValidateDomain(&ValidateDomainInput{
+	_, err = TestClient.ValidateDomain(&ValidateDomainInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -304,7 +304,7 @@ func TestClient_ValidateDomain_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ValidateDomain(&ValidateDomainInput{
+	_, err = TestClient.ValidateDomain(&ValidateDomainInput{
 		Name:           "test",
 		ServiceVersion: 0,
 	})
@@ -312,7 +312,7 @@ func TestClient_ValidateDomain_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ValidateDomain(&ValidateDomainInput{
+	_, err = TestClient.ValidateDomain(&ValidateDomainInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/edge_check.go
+++ b/fastly/edge_check.go
@@ -47,7 +47,7 @@ func (c *Client) EdgeCheck(i *EdgeCheckInput) ([]*EdgeCheck, error) {
 	defer resp.Body.Close()
 
 	var e []*EdgeCheck
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil

--- a/fastly/edge_check_test.go
+++ b/fastly/edge_check_test.go
@@ -7,7 +7,7 @@ func TestClient_EdgeCheck(t *testing.T) {
 
 	var err error
 	var edges []*EdgeCheck
-	record(t, "content/check", func(c *Client) {
+	Record(t, "content/check", func(c *Client) {
 		edges, err = c.EdgeCheck(&EdgeCheckInput{
 			URL: "releases.hashicorp.com",
 		})

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -411,7 +411,7 @@ func NewHTTPError(resp *http.Response) *HTTPError {
 	switch resp.Header.Get("Content-Type") {
 	case jsonapi.MediaType:
 		// If this is a jsonapi response, decode it accordingly.
-		if err := decodeBodyMap(body, &e); err != nil {
+		if err := DecodeBodyMap(body, &e); err != nil {
 			addDecodeErr()
 		}
 
@@ -435,7 +435,7 @@ func NewHTTPError(resp *http.Response) *HTTPError {
 
 	default:
 		var lerr *legacyError
-		if err := decodeBodyMap(body, &lerr); err != nil {
+		if err := DecodeBodyMap(body, &lerr); err != nil {
 			addDecodeErr()
 		} else if lerr != nil {
 			// This is for better handling the KV Store Bulk Insert endpoint.

--- a/fastly/fastly_test_utils.go
+++ b/fastly/fastly_test_utils.go
@@ -10,23 +10,29 @@ import (
 	"github.com/dnaeon/go-vcr/recorder"
 )
 
-// testClient is the test client.
-var testClient = DefaultClient()
+// TestClient is the test client.
+var TestClient = DefaultClient()
 
-// testStatsClient is the test client for realtime stats.
-var testStatsClient = NewRealtimeStatsClient()
+// TestStatsClient is the test client for realtime stats.
+var TestStatsClient = NewRealtimeStatsClient()
 
 // ID of the Delivery service for testing.
-var testDeliveryServiceID = deliveryServiceIDForTest()
+var TestDeliveryServiceID = deliveryServiceIDForTest()
 
 // ID of the Compute service for testing.
-var testComputeServiceID = computeServiceIDForTest()
+var TestComputeServiceID = computeServiceIDForTest()
+
+// ID of the NGWAF workspace for testing.
+var TestNGWAFWorkspaceID = ngwafWorkspaceIDForTest()
 
 // ID of the default Delivery service for testing.
 var defaultDeliveryTestServiceID = "kKJb5bOFI47uHeBVluGfX1"
 
 // ID of the default Compute service for testing.
 var defaultComputeTestServiceID = "XsjdElScZGjmfCcTwsYRC1"
+
+// ID of the default NGWAF workspace for testing.
+var defaultNGWAFWorkspaceID = "alk6DTsYKHKucJCOIavaJM"
 
 const (
 	// ServiceTypeVCL is the type for VCL services.
@@ -55,13 +61,21 @@ func computeServiceIDForTest() string {
 	return defaultComputeTestServiceID
 }
 
+func ngwafWorkspaceIDForTest() string {
+	if tsid := os.Getenv("FASTLY_TEST_NGWAF_WORKSPACE_ID"); tsid != "" {
+		return tsid
+	}
+
+	return defaultNGWAFWorkspaceID
+}
+
 func vcrDisabled() bool {
 	vcrDisable := os.Getenv("VCR_DISABLE")
 
 	return vcrDisable != ""
 }
 
-func record(t *testing.T, fixture string, f func(*Client)) {
+func Record(t *testing.T, fixture string, f func(*Client)) {
 	client := DefaultClient()
 
 	if vcrDisabled() {
@@ -74,7 +88,7 @@ func record(t *testing.T, fixture string, f func(*Client)) {
 	}
 }
 
-func recordIgnoreBody(t *testing.T, fixture string, f func(*Client)) {
+func RecordIgnoreBody(t *testing.T, fixture string, f func(*Client)) {
 	client := DefaultClient()
 
 	if vcrDisabled() {
@@ -114,7 +128,7 @@ func stopRecorder(t *testing.T, r *recorder.Recorder) {
 	}
 }
 
-func recordRealtimeStats(t *testing.T, fixture string, f func(*RTSClient)) {
+func RecordRealtimeStats(t *testing.T, fixture string, f func(*RTSClient)) {
 	r, err := recorder.New("fixtures/" + fixture)
 	if err != nil {
 		t.Fatal(err)
@@ -135,7 +149,7 @@ func createTestService(t *testing.T, serviceFixture, serviceNameSuffix string) *
 	var err error
 	var service *Service
 
-	record(t, serviceFixture, func(client *Client) {
+	Record(t, serviceFixture, func(client *Client) {
 		service, err = client.CreateService(&CreateServiceInput{
 			Name:    ToPointer(fmt.Sprintf("test_service_%s", serviceNameSuffix)),
 			Comment: ToPointer("go-fastly client test"),
@@ -153,7 +167,7 @@ func createTestServiceWasm(t *testing.T, serviceFixture, serviceNameSuffix strin
 	var err error
 	var service *Service
 
-	record(t, serviceFixture, func(client *Client) {
+	Record(t, serviceFixture, func(client *Client) {
 		service, err = client.CreateService(&CreateServiceInput{
 			Name:    ToPointer(fmt.Sprintf("test_service_wasm_%s", serviceNameSuffix)),
 			Comment: ToPointer("go-fastly wasm client test"),
@@ -173,7 +187,7 @@ func testVersion(t *testing.T, c *Client) *Version {
 	defer testVersionLock.Unlock()
 
 	v, err := c.CreateVersion(&CreateVersionInput{
-		ServiceID: testDeliveryServiceID,
+		ServiceID: TestDeliveryServiceID,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -181,11 +195,11 @@ func testVersion(t *testing.T, c *Client) *Version {
 	return v
 }
 
-func createTestVersion(t *testing.T, versionFixture, serviceID string) *Version {
+func CreateTestVersion(t *testing.T, versionFixture, serviceID string) *Version {
 	var err error
 	var version *Version
 
-	record(t, versionFixture, func(client *Client) {
+	Record(t, versionFixture, func(client *Client) {
 		testVersionLock.Lock()
 		defer testVersionLock.Unlock()
 
@@ -204,7 +218,7 @@ func createTestDictionary(t *testing.T, dictionaryFixture, serviceID string, ver
 	var err error
 	var dictionary *Dictionary
 
-	record(t, dictionaryFixture, func(client *Client) {
+	Record(t, dictionaryFixture, func(client *Client) {
 		dictionary, err = client.CreateDictionary(&CreateDictionaryInput{
 			ServiceID:      serviceID,
 			ServiceVersion: version,
@@ -220,7 +234,7 @@ func createTestDictionary(t *testing.T, dictionaryFixture, serviceID string, ver
 func deleteTestDictionary(t *testing.T, dictionary *Dictionary, deleteFixture string) {
 	var err error
 
-	record(t, deleteFixture, func(client *Client) {
+	Record(t, deleteFixture, func(client *Client) {
 		err = client.DeleteDictionary(&DeleteDictionaryInput{
 			ServiceID:      *dictionary.ServiceID,
 			ServiceVersion: *dictionary.ServiceVersion,
@@ -236,7 +250,7 @@ func createTestACL(t *testing.T, createFixture, serviceID string, version int, a
 	var err error
 	var acl *ACL
 
-	record(t, createFixture, func(client *Client) {
+	Record(t, createFixture, func(client *Client) {
 		acl, err = client.CreateACL(&CreateACLInput{
 			ServiceID:      serviceID,
 			ServiceVersion: version,
@@ -252,7 +266,7 @@ func createTestACL(t *testing.T, createFixture, serviceID string, version int, a
 func deleteTestACL(t *testing.T, acl *ACL, deleteFixture string) {
 	var err error
 
-	record(t, deleteFixture, func(client *Client) {
+	Record(t, deleteFixture, func(client *Client) {
 		err = client.DeleteACL(&DeleteACLInput{
 			ServiceID:      *acl.ServiceID,
 			ServiceVersion: *acl.ServiceVersion,
@@ -268,7 +282,7 @@ func createTestPool(t *testing.T, createFixture, serviceID string, version int, 
 	var err error
 	var pool *Pool
 
-	record(t, createFixture, func(client *Client) {
+	Record(t, createFixture, func(client *Client) {
 		pool, err = client.CreatePool(&CreatePoolInput{
 			ServiceID:      serviceID,
 			ServiceVersion: version,
@@ -284,7 +298,7 @@ func createTestPool(t *testing.T, createFixture, serviceID string, version int, 
 func createTestLogging(t *testing.T, fixture, serviceID string, serviceNumber int) {
 	var err error
 
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		_, err = c.CreateSyslog(&CreateSyslogInput{
 			ServiceID:      serviceID,
 			ServiceVersion: serviceNumber,
@@ -306,7 +320,7 @@ func createTestLogging(t *testing.T, fixture, serviceID string, serviceNumber in
 func deleteTestPool(t *testing.T, pool *Pool, deleteFixture string) {
 	var err error
 
-	record(t, deleteFixture, func(client *Client) {
+	Record(t, deleteFixture, func(client *Client) {
 		err = client.DeletePool(&DeletePoolInput{
 			ServiceID:      *pool.ServiceID,
 			ServiceVersion: *pool.ServiceVersion,
@@ -321,7 +335,7 @@ func deleteTestPool(t *testing.T, pool *Pool, deleteFixture string) {
 func deleteTestLogging(t *testing.T, fixture, serviceID string, serviceNumber int) {
 	var err error
 
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		err = c.DeleteSyslog(&DeleteSyslogInput{
 			ServiceID:      serviceID,
 			ServiceVersion: serviceNumber,
@@ -337,7 +351,7 @@ func createTestWAFCondition(t *testing.T, fixture, serviceID, name string, servi
 	var err error
 	var condition *Condition
 
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		condition, err = c.CreateCondition(&CreateConditionInput{
 			ServiceID:      serviceID,
 			ServiceVersion: serviceNumber,
@@ -356,7 +370,7 @@ func createTestWAFCondition(t *testing.T, fixture, serviceID, name string, servi
 func deleteTestCondition(t *testing.T, fixture, serviceID, name string, serviceNumber int) {
 	var err error
 
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		err = c.DeleteCondition(&DeleteConditionInput{
 			ServiceID:      serviceID,
 			ServiceVersion: serviceNumber,
@@ -372,7 +386,7 @@ func createTestWAFResponseObject(t *testing.T, fixture, serviceID, name string, 
 	var err error
 	var ro *ResponseObject
 
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		ro, err = c.CreateResponseObject(&CreateResponseObjectInput{
 			ServiceID:      serviceID,
 			ServiceVersion: serviceNumber,
@@ -389,7 +403,7 @@ func createTestWAFResponseObject(t *testing.T, fixture, serviceID, name string, 
 func deleteTestResponseObject(t *testing.T, fixture, serviceID, name string, serviceNumber int) {
 	var err error
 
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		err = c.DeleteResponseObject(&DeleteResponseObjectInput{
 			ServiceID:      serviceID,
 			ServiceVersion: serviceNumber,
@@ -405,7 +419,7 @@ func createWAF(t *testing.T, fixture, serviceID, condition, response string, ser
 	var err error
 	var waf *WAF
 
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		waf, err = c.CreateWAF(&CreateWAFInput{
 			ServiceID:         serviceID,
 			ServiceVersion:    serviceNumber,
@@ -422,7 +436,7 @@ func createWAF(t *testing.T, fixture, serviceID, condition, response string, ser
 func deleteWAF(t *testing.T, fixture, wafID string) {
 	var err error
 
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		err = c.DeleteWAF(&DeleteWAFInput{
 			ID:             wafID,
 			ServiceVersion: 1,
@@ -436,7 +450,7 @@ func deleteWAF(t *testing.T, fixture, wafID string) {
 func deleteTestService(t *testing.T, cleanupFixture, serviceID string) {
 	var err error
 
-	record(t, cleanupFixture, func(client *Client) {
+	Record(t, cleanupFixture, func(client *Client) {
 		err = client.DeleteService(&DeleteServiceInput{
 			ServiceID: serviceID,
 		})

--- a/fastly/fastly_test_utils.go
+++ b/fastly/fastly_test_utils.go
@@ -65,7 +65,6 @@ func ngwafWorkspaceIDForTest() string {
 	if tsid := os.Getenv("FASTLY_TEST_NGWAF_WORKSPACE_ID"); tsid != "" {
 		return tsid
 	}
-
 	return defaultNGWAFWorkspaceID
 }
 

--- a/fastly/health_check.go
+++ b/fastly/health_check.go
@@ -53,7 +53,7 @@ func (c *Client) ListHealthChecks(i *ListHealthChecksInput) ([]*HealthCheck, err
 	defer resp.Body.Close()
 
 	var hcs []*HealthCheck
-	if err := decodeBodyMap(resp.Body, &hcs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &hcs); err != nil {
 		return nil, err
 	}
 	return hcs, nil
@@ -114,7 +114,7 @@ func (c *Client) CreateHealthCheck(i *CreateHealthCheckInput) (*HealthCheck, err
 	defer resp.Body.Close()
 
 	var h *HealthCheck
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -151,7 +151,7 @@ func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
 	defer resp.Body.Close()
 
 	var h *HealthCheck
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -217,7 +217,7 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 	defer resp.Body.Close()
 
 	var h *HealthCheck
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -254,7 +254,7 @@ func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/health_check_test.go
+++ b/fastly/health_check_test.go
@@ -9,15 +9,15 @@ func TestClient_HealthChecks(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "health_checks/version", func(c *Client) {
+	Record(t, "health_checks/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var hc *HealthCheck
-	record(t, "health_checks/create", func(c *Client) {
+	Record(t, "health_checks/create", func(c *Client) {
 		hc, err = c.CreateHealthCheck(&CreateHealthCheckInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-healthcheck"),
 			Method:         ToPointer("HEAD"),
@@ -42,15 +42,15 @@ func TestClient_HealthChecks(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "health_checks/cleanup", func(c *Client) {
+		Record(t, "health_checks/cleanup", func(c *Client) {
 			_ = c.DeleteHealthCheck(&DeleteHealthCheckInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-healthcheck",
 			})
 
 			_ = c.DeleteHealthCheck(&DeleteHealthCheckInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-healthcheck",
 			})
@@ -96,9 +96,9 @@ func TestClient_HealthChecks(t *testing.T) {
 
 	// List
 	var hcs []*HealthCheck
-	record(t, "health_checks/list", func(c *Client) {
+	Record(t, "health_checks/list", func(c *Client) {
 		hcs, err = c.ListHealthChecks(&ListHealthChecksInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -111,9 +111,9 @@ func TestClient_HealthChecks(t *testing.T) {
 
 	// Get
 	var nhc *HealthCheck
-	record(t, "health_checks/get", func(c *Client) {
+	Record(t, "health_checks/get", func(c *Client) {
 		nhc, err = c.GetHealthCheck(&GetHealthCheckInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-healthcheck",
 		})
@@ -163,9 +163,9 @@ func TestClient_HealthChecks(t *testing.T) {
 
 	// Update
 	var uhc *HealthCheck
-	record(t, "health_checks/update", func(c *Client) {
+	Record(t, "health_checks/update", func(c *Client) {
 		uhc, err = c.UpdateHealthCheck(&UpdateHealthCheckInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-healthcheck",
 			NewName:        ToPointer("new-test-healthcheck"),
@@ -183,9 +183,9 @@ func TestClient_HealthChecks(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "health_checks/delete", func(c *Client) {
+	Record(t, "health_checks/delete", func(c *Client) {
 		err = c.DeleteHealthCheck(&DeleteHealthCheckInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-healthcheck",
 		})
@@ -197,14 +197,14 @@ func TestClient_HealthChecks(t *testing.T) {
 
 func TestClient_ListHealthChecks_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListHealthChecks(&ListHealthChecksInput{
+	_, err = TestClient.ListHealthChecks(&ListHealthChecksInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListHealthChecks(&ListHealthChecksInput{
+	_, err = TestClient.ListHealthChecks(&ListHealthChecksInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -215,14 +215,14 @@ func TestClient_ListHealthChecks_validation(t *testing.T) {
 
 func TestClient_CreateHealthCheck_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateHealthCheck(&CreateHealthCheckInput{
+	_, err = TestClient.CreateHealthCheck(&CreateHealthCheckInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateHealthCheck(&CreateHealthCheckInput{
+	_, err = TestClient.CreateHealthCheck(&CreateHealthCheckInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -234,7 +234,7 @@ func TestClient_CreateHealthCheck_validation(t *testing.T) {
 func TestClient_GetHealthCheck_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetHealthCheck(&GetHealthCheckInput{
+	_, err = TestClient.GetHealthCheck(&GetHealthCheckInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -242,7 +242,7 @@ func TestClient_GetHealthCheck_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHealthCheck(&GetHealthCheckInput{
+	_, err = TestClient.GetHealthCheck(&GetHealthCheckInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -250,7 +250,7 @@ func TestClient_GetHealthCheck_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHealthCheck(&GetHealthCheckInput{
+	_, err = TestClient.GetHealthCheck(&GetHealthCheckInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -262,7 +262,7 @@ func TestClient_GetHealthCheck_validation(t *testing.T) {
 func TestClient_UpdateHealthCheck_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateHealthCheck(&UpdateHealthCheckInput{
+	_, err = TestClient.UpdateHealthCheck(&UpdateHealthCheckInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -270,7 +270,7 @@ func TestClient_UpdateHealthCheck_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHealthCheck(&UpdateHealthCheckInput{
+	_, err = TestClient.UpdateHealthCheck(&UpdateHealthCheckInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -278,7 +278,7 @@ func TestClient_UpdateHealthCheck_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHealthCheck(&UpdateHealthCheckInput{
+	_, err = TestClient.UpdateHealthCheck(&UpdateHealthCheckInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -290,7 +290,7 @@ func TestClient_UpdateHealthCheck_validation(t *testing.T) {
 func TestClient_DeleteHealthCheck_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteHealthCheck(&DeleteHealthCheckInput{
+	err = TestClient.DeleteHealthCheck(&DeleteHealthCheckInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -298,7 +298,7 @@ func TestClient_DeleteHealthCheck_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHealthCheck(&DeleteHealthCheckInput{
+	err = TestClient.DeleteHealthCheck(&DeleteHealthCheckInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -306,7 +306,7 @@ func TestClient_DeleteHealthCheck_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHealthCheck(&DeleteHealthCheckInput{
+	err = TestClient.DeleteHealthCheck(&DeleteHealthCheckInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/image_optimizer_default_settings_test.go
+++ b/fastly/image_optimizer_default_settings_test.go
@@ -14,15 +14,15 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 
 	fixtureBase := "image_optimizer_default_settings/"
 
-	testVersion := createTestVersion(t, fixtureBase+"version", testDeliveryServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"version", TestDeliveryServiceID)
 
 	var err error
 
 	// Enable IO
-	record(t, fixtureBase+"enable_product", func(c *Client) {
+	Record(t, fixtureBase+"enable_product", func(c *Client) {
 		_, err = c.EnableProduct(&ProductEnablementInput{
 			ProductID: ProductImageOptimizer,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -31,10 +31,10 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 
 	// Ensure we disable IO on the service after the test
 	defer func() {
-		record(t, fixtureBase+"disable_product", func(c *Client) {
+		Record(t, fixtureBase+"disable_product", func(c *Client) {
 			err = c.DisableProduct(&ProductEnablementInput{
 				ProductID: ProductImageOptimizer,
-				ServiceID: testDeliveryServiceID,
+				ServiceID: TestDeliveryServiceID,
 			})
 		})
 
@@ -46,9 +46,9 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 	var defaultSettings *ImageOptimizerDefaultSettings
 
 	// Fetch
-	record(t, fixtureBase+"original_fetch", func(c *Client) {
+	Record(t, fixtureBase+"original_fetch", func(c *Client) {
 		defaultSettings, err = c.GetImageOptimizerDefaultSettings(&GetImageOptimizerDefaultSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 		})
 	})
@@ -60,10 +60,10 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 
 	// Reset our settings back to the original
 	defer func() {
-		record(t, fixtureBase+"final_reset", func(c *Client) {
+		Record(t, fixtureBase+"final_reset", func(c *Client) {
 			if originalSettings != nil {
 				_, err = c.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
-					ServiceID:      testDeliveryServiceID,
+					ServiceID:      TestDeliveryServiceID,
 					ServiceVersion: *testVersion.Number,
 					// just use default resizefilter & jpegtype since it doesn't matter much, and it's annoying
 					// to parse the API output strings back into enums.
@@ -87,9 +87,9 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 	newUpscale := false
 
 	// Change some stuff
-	record(t, fixtureBase+"update_1_patch", func(c *Client) {
+	Record(t, fixtureBase+"update_1_patch", func(c *Client) {
 		defaultSettings, err = c.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Webp:           &newWebp,
 			WebpQuality:    &newWebpQuality,
@@ -111,9 +111,9 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 	}
 
 	// Confirm our changes were applied permanently
-	record(t, fixtureBase+"update_1_get", func(c *Client) {
+	Record(t, fixtureBase+"update_1_get", func(c *Client) {
 		defaultSettings, err = c.GetImageOptimizerDefaultSettings(&GetImageOptimizerDefaultSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 		})
 	})
@@ -136,9 +136,9 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 	newWebpQuality = 42
 	newUpscale = true
 
-	record(t, fixtureBase+"update_2_patch", func(c *Client) {
+	Record(t, fixtureBase+"update_2_patch", func(c *Client) {
 		defaultSettings, err = c.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Webp:           &newWebp,
 			WebpQuality:    &newWebpQuality,
@@ -160,9 +160,9 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 	}
 
 	// Confirm our changes were applied permanently (again)
-	record(t, fixtureBase+"update_2_get", func(c *Client) {
+	Record(t, fixtureBase+"update_2_get", func(c *Client) {
 		defaultSettings, err = c.GetImageOptimizerDefaultSettings(&GetImageOptimizerDefaultSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 		})
 	})
@@ -183,9 +183,9 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 	// Apply a setting that produces a server-side error, and confirm it's handled well.
 	newWebpQuality = 105
 
-	record(t, fixtureBase+"incorrect_fetch", func(c *Client) {
+	Record(t, fixtureBase+"incorrect_fetch", func(c *Client) {
 		_, err = c.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			WebpQuality:    &newWebpQuality,
 		})
@@ -200,9 +200,9 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 
 	// Confirm all resize_filter & jpeg_type values are accepted
 	for _, resizeFilter := range []ImageOptimizerResizeFilter{ImageOptimizerLanczos3, ImageOptimizerLanczos2, ImageOptimizerBicubic, ImageOptimizerBilinear, ImageOptimizerNearest} {
-		record(t, fixtureBase+"set_resize_filter/"+resizeFilter.String(), func(c *Client) {
+		Record(t, fixtureBase+"set_resize_filter/"+resizeFilter.String(), func(c *Client) {
 			defaultSettings, err = c.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *testVersion.Number,
 				ResizeFilter:   &resizeFilter,
 			})
@@ -213,9 +213,9 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 	}
 
 	for _, jpegType := range []ImageOptimizerJpegType{ImageOptimizerAuto, ImageOptimizerBaseline, ImageOptimizerProgressive} {
-		record(t, fixtureBase+"set_jpeg_type/"+jpegType.String(), func(c *Client) {
+		Record(t, fixtureBase+"set_jpeg_type/"+jpegType.String(), func(c *Client) {
 			defaultSettings, err = c.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *testVersion.Number,
 				JpegType:       &jpegType,
 			})
@@ -226,9 +226,9 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 	}
 
 	// Confirm a full request is accepted - that all parameters in our library match the API's expectations
-	record(t, fixtureBase+"set_full", func(c *Client) {
+	Record(t, fixtureBase+"set_full", func(c *Client) {
 		defaultSettings, err = c.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			ResizeFilter:   ToPointer(ImageOptimizerLanczos3),
 			Webp:           ToPointer(false),
@@ -243,7 +243,7 @@ func TestClient_ImageOptimizerDefaultSettings(t *testing.T) {
 
 func TestClient_GetImageOptimizerDefaultSettings_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetImageOptimizerDefaultSettings(&GetImageOptimizerDefaultSettingsInput{
+	_, err = TestClient.GetImageOptimizerDefaultSettings(&GetImageOptimizerDefaultSettingsInput{
 		ServiceID:      "",
 		ServiceVersion: 3,
 	})
@@ -251,7 +251,7 @@ func TestClient_GetImageOptimizerDefaultSettings_validation(t *testing.T) {
 		t.Errorf("expected error %v; got: %v", ErrMissingServiceID, err)
 	}
 
-	_, err = testClient.GetImageOptimizerDefaultSettings(&GetImageOptimizerDefaultSettingsInput{
+	_, err = TestClient.GetImageOptimizerDefaultSettings(&GetImageOptimizerDefaultSettingsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -264,7 +264,7 @@ func TestClient_UpdateImageOptimizerDefaultSettings_validation(t *testing.T) {
 	newUpscale := true
 
 	var err error
-	_, err = testClient.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
+	_, err = TestClient.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
 		ServiceID:      "",
 		ServiceVersion: 3,
 		Upscale:        &newUpscale,
@@ -273,7 +273,7 @@ func TestClient_UpdateImageOptimizerDefaultSettings_validation(t *testing.T) {
 		t.Errorf("expected error %v; got: %v", ErrMissingServiceID, err)
 	}
 
-	_, err = testClient.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
+	_, err = TestClient.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 		Upscale:        &newUpscale,
@@ -282,7 +282,7 @@ func TestClient_UpdateImageOptimizerDefaultSettings_validation(t *testing.T) {
 		t.Errorf("expected error %v; got: %v", ErrMissingServiceVersion, err)
 	}
 
-	_, err = testClient.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
+	_, err = TestClient.UpdateImageOptimizerDefaultSettings(&UpdateImageOptimizerDefaultSettingsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 3,
 	})

--- a/fastly/ip.go
+++ b/fastly/ip.go
@@ -12,7 +12,7 @@ func (c *Client) AllIPs() (v4, v6 IPAddrs, err error) {
 	defer resp.Body.Close()
 
 	var m map[string][]string
-	if err := decodeBodyMap(resp.Body, &m); err != nil {
+	if err := DecodeBodyMap(resp.Body, &m); err != nil {
 		return nil, nil, err
 	}
 

--- a/fastly/ip_test.go
+++ b/fastly/ip_test.go
@@ -7,7 +7,7 @@ func TestClient_IPs(t *testing.T) {
 
 	var err error
 	var ips IPAddrs
-	record(t, "ips/list", func(c *Client) {
+	Record(t, "ips/list", func(c *Client) {
 		ips, err = c.IPs()
 	})
 	if err != nil {
@@ -23,7 +23,7 @@ func TestClient_IPsV6(t *testing.T) {
 
 	var err error
 	var ips IPAddrs
-	record(t, "ips/list", func(c *Client) {
+	Record(t, "ips/list", func(c *Client) {
 		ips, err = c.IPsV6()
 	})
 	if err != nil {
@@ -40,7 +40,7 @@ func TestClient_AllIPs(t *testing.T) {
 	var err error
 	var v4 IPAddrs
 	var v6 IPAddrs
-	record(t, "ips/list", func(c *Client) {
+	Record(t, "ips/list", func(c *Client) {
 		v4, v6, err = c.AllIPs()
 	})
 	if err != nil {

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -49,7 +49,7 @@ func (c *Client) CreateKVStore(i *CreateKVStoreInput) (*KVStore, error) {
 	defer resp.Body.Close()
 
 	var store *KVStore
-	if err := decodeBodyMap(resp.Body, &store); err != nil {
+	if err := DecodeBodyMap(resp.Body, &store); err != nil {
 		return nil, err
 	}
 	return store, nil
@@ -107,7 +107,7 @@ func (c *Client) ListKVStores(i *ListKVStoresInput) (*ListKVStoresResponse, erro
 	defer resp.Body.Close()
 
 	var output *ListKVStoresResponse
-	if err := decodeBodyMap(resp.Body, &output); err != nil {
+	if err := DecodeBodyMap(resp.Body, &output); err != nil {
 		return nil, err
 	}
 	return output, nil
@@ -187,7 +187,7 @@ func (c *Client) GetKVStore(i *GetKVStoreInput) (*KVStore, error) {
 	defer resp.Body.Close()
 
 	var output *KVStore
-	if err := decodeBodyMap(resp.Body, &output); err != nil {
+	if err := DecodeBodyMap(resp.Body, &output); err != nil {
 		return nil, err
 	}
 	return output, nil
@@ -296,7 +296,7 @@ func (c *Client) ListKVStoreKeys(i *ListKVStoreKeysInput) (*ListKVStoreKeysRespo
 	defer resp.Body.Close()
 
 	var output *ListKVStoreKeysResponse
-	if err := decodeBodyMap(resp.Body, &output); err != nil {
+	if err := DecodeBodyMap(resp.Body, &output); err != nil {
 		return nil, err
 	}
 	return output, nil

--- a/fastly/kv_store_test.go
+++ b/fastly/kv_store_test.go
@@ -17,7 +17,7 @@ func TestClient_KVStore(t *testing.T) {
 	// List
 	var kvStoreListResp1 *ListKVStoresResponse
 	var err error
-	record(t, "kv_store/list-store", func(c *Client) {
+	Record(t, "kv_store/list-store", func(c *Client) {
 		kvStoreListResp1, err = c.ListKVStores(nil)
 	})
 	if err != nil {
@@ -36,7 +36,7 @@ func TestClient_KVStore(t *testing.T) {
 	input := &CreateKVStoreInput{
 		Name: createStoreName,
 	}
-	record(t, "kv_store/create-store", func(c *Client) {
+	Record(t, "kv_store/create-store", func(c *Client) {
 		kvStore, err = c.CreateKVStore(input)
 	})
 	if err != nil {
@@ -49,7 +49,7 @@ func TestClient_KVStore(t *testing.T) {
 
 	// ensure we delete it
 	defer func() {
-		record(t, "kv_store/cleanup", func(c *Client) {
+		Record(t, "kv_store/cleanup", func(c *Client) {
 			// first delete all the keys in it
 			p := c.NewListKVStoreKeysPaginator(&ListKVStoreKeysInput{
 				Consistency: ConsistencyEventual,
@@ -78,7 +78,7 @@ func TestClient_KVStore(t *testing.T) {
 
 	// fetch the newly created store and verify it matches
 	var getKVStoreResponse *KVStore
-	record(t, "kv_store/get-store", func(c *Client) {
+	Record(t, "kv_store/get-store", func(c *Client) {
 		getKVStoreResponse, err = c.GetKVStore(&GetKVStoreInput{StoreID: kvStore.StoreID})
 	})
 	if err != nil {
@@ -92,7 +92,7 @@ func TestClient_KVStore(t *testing.T) {
 	// create a bunch of keys in our kv store
 	keys := []string{"apple", "banana", "carrot", "dragonfruit", "eggplant"}
 
-	record(t, "kv_store/create-keys", func(c *Client) {
+	Record(t, "kv_store/create-keys", func(c *Client) {
 		for i, key := range keys {
 			err := c.InsertKVStoreKey(&InsertKVStoreKeyInput{StoreID: kvStore.StoreID, Key: key, Value: key + strconv.Itoa(i)})
 			if err != nil {
@@ -101,7 +101,7 @@ func TestClient_KVStore(t *testing.T) {
 		}
 	})
 
-	record(t, "kv_store/check-keys", func(c *Client) {
+	Record(t, "kv_store/check-keys", func(c *Client) {
 		for i, key := range keys {
 			got, err := c.GetKVStoreKey(&GetKVStoreKeyInput{StoreID: kvStore.StoreID, Key: key})
 			if err != nil {
@@ -114,7 +114,7 @@ func TestClient_KVStore(t *testing.T) {
 		}
 	})
 
-	record(t, "kv_store/batch-create-keys", func(c *Client) {
+	Record(t, "kv_store/batch-create-keys", func(c *Client) {
 		keys := `{"key":"batch-1","value":"VkFMVUU="}
     {"key":"batch-2","value":"VkFMVUU="}`
 		err := c.BatchModifyKVStoreKey(&BatchModifyKVStoreKeyInput{
@@ -132,7 +132,7 @@ func TestClient_KVStore(t *testing.T) {
 
 	// fetch all keys and validate they match our input data
 	var kvStoreListKeys *ListKVStoreKeysResponse
-	record(t, "kv_store/list-keys", func(c *Client) {
+	Record(t, "kv_store/list-keys", func(c *Client) {
 		kvStoreListKeys, err = c.ListKVStoreKeys(&ListKVStoreKeysInput{
 			Consistency: ConsistencyStrong,
 			StoreID:     kvStore.StoreID,
@@ -148,7 +148,7 @@ func TestClient_KVStore(t *testing.T) {
 		t.Errorf("mismatch listing keys: got %q, want %q", kvStoreListKeys.Data, allKeys)
 	}
 
-	record(t, "kv_store/list-keys-pagination", func(c *Client) {
+	Record(t, "kv_store/list-keys-pagination", func(c *Client) {
 		p := c.NewListKVStoreKeysPaginator(&ListKVStoreKeysInput{
 			StoreID: kvStore.StoreID,
 			Limit:   4,
@@ -181,7 +181,7 @@ func TestClient_CreateKVStoresWithLocations(t *testing.T) {
 		err    error
 	)
 
-	record(t, fmt.Sprintf("kv_store/%s/create_stores", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("kv_store/%s/create_stores", t.Name()), func(c *Client) {
 		for _, location := range []string{"US", "EU", "ASIA", "AUS"} {
 			ks, err = c.CreateKVStore(&CreateKVStoreInput{
 				Name:     fmt.Sprintf("%s_%s", t.Name(), location),
@@ -203,7 +203,7 @@ func TestClient_CreateKVStoresWithLocations(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("kv_store/%s/delete_stores", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("kv_store/%s/delete_stores", t.Name()), func(c *Client) {
 			for _, ks := range stores {
 				err = c.DeleteKVStore(&DeleteKVStoreInput{
 					StoreID: ks.StoreID,

--- a/fastly/load_balance_pool.go
+++ b/fastly/load_balance_pool.go
@@ -76,7 +76,7 @@ func (c *Client) ListPools(i *ListPoolsInput) ([]*Pool, error) {
 	defer resp.Body.Close()
 
 	var ps []*Pool
-	if err := decodeBodyMap(resp.Body, &ps); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ps); err != nil {
 		return nil, err
 	}
 	return ps, nil
@@ -149,7 +149,7 @@ func (c *Client) CreatePool(i *CreatePoolInput) (*Pool, error) {
 	defer resp.Body.Close()
 
 	var p *Pool
-	if err := decodeBodyMap(resp.Body, &p); err != nil {
+	if err := DecodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -186,7 +186,7 @@ func (c *Client) GetPool(i *GetPoolInput) (*Pool, error) {
 	defer resp.Body.Close()
 
 	var p *Pool
-	if err := decodeBodyMap(resp.Body, &p); err != nil {
+	if err := DecodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -265,7 +265,7 @@ func (c *Client) UpdatePool(i *UpdatePoolInput) (*Pool, error) {
 	defer resp.Body.Close()
 
 	var p *Pool
-	if err := decodeBodyMap(resp.Body, &p); err != nil {
+	if err := DecodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -302,7 +302,7 @@ func (c *Client) DeletePool(i *DeletePoolInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/load_balance_pool_test.go
+++ b/fastly/load_balance_pool_test.go
@@ -9,18 +9,18 @@ func TestClient_Pools(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "pools/version", func(c *Client) {
+	Record(t, "pools/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var p *Pool
-	record(t, "pools/create", func(c *Client) {
+	Record(t, "pools/create", func(c *Client) {
 		p, err = c.CreatePool(&CreatePoolInput{
 			Comment:         ToPointer("test pool"),
 			Name:            ToPointer("test_pool"),
 			Quorum:          ToPointer(50),
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 			TLSCertHostname: ToPointer("example.com"),
 			Type:            ToPointer(PoolTypeRandom),
@@ -33,15 +33,15 @@ func TestClient_Pools(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "pools/cleanup", func(c *Client) {
+		Record(t, "pools/cleanup", func(c *Client) {
 			_ = c.DeletePool(&DeletePoolInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test_pool",
 			})
 
 			_ = c.DeletePool(&DeletePoolInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new_test_pool",
 			})
@@ -66,9 +66,9 @@ func TestClient_Pools(t *testing.T) {
 
 	// List
 	var ps []*Pool
-	record(t, "pools/list", func(c *Client) {
+	Record(t, "pools/list", func(c *Client) {
 		ps, err = c.ListPools(&ListPoolsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -81,9 +81,9 @@ func TestClient_Pools(t *testing.T) {
 
 	// Get
 	var np *Pool
-	record(t, "pools/get", func(c *Client) {
+	Record(t, "pools/get", func(c *Client) {
 		np, err = c.GetPool(&GetPoolInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test_pool",
 		})
@@ -103,9 +103,9 @@ func TestClient_Pools(t *testing.T) {
 
 	// Update
 	var up *Pool
-	record(t, "pools/update", func(c *Client) {
+	Record(t, "pools/update", func(c *Client) {
 		up, err = c.UpdatePool(&UpdatePoolInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test_pool",
 			NewName:        ToPointer("new_test_pool"),
@@ -124,9 +124,9 @@ func TestClient_Pools(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "pools/delete", func(c *Client) {
+	Record(t, "pools/delete", func(c *Client) {
 		err = c.DeletePool(&DeletePoolInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new_test_pool",
 		})
@@ -138,14 +138,14 @@ func TestClient_Pools(t *testing.T) {
 
 func TestClient_ListPools_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListPools(&ListPoolsInput{
+	_, err = TestClient.ListPools(&ListPoolsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListPools(&ListPoolsInput{
+	_, err = TestClient.ListPools(&ListPoolsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -157,7 +157,7 @@ func TestClient_ListPools_validation(t *testing.T) {
 func TestClient_CreatePool_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreatePool(&CreatePoolInput{
+	_, err = TestClient.CreatePool(&CreatePoolInput{
 		Name:           ToPointer("test"),
 		ServiceVersion: 1,
 	})
@@ -165,7 +165,7 @@ func TestClient_CreatePool_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreatePool(&CreatePoolInput{
+	_, err = TestClient.CreatePool(&CreatePoolInput{
 		Name:      ToPointer("test"),
 		ServiceID: "foo",
 	})
@@ -177,7 +177,7 @@ func TestClient_CreatePool_validation(t *testing.T) {
 func TestClient_GetPool_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetPool(&GetPoolInput{
+	_, err = TestClient.GetPool(&GetPoolInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -185,7 +185,7 @@ func TestClient_GetPool_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetPool(&GetPoolInput{
+	_, err = TestClient.GetPool(&GetPoolInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -193,7 +193,7 @@ func TestClient_GetPool_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetPool(&GetPoolInput{
+	_, err = TestClient.GetPool(&GetPoolInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -205,7 +205,7 @@ func TestClient_GetPool_validation(t *testing.T) {
 func TestClient_UpdatePool_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdatePool(&UpdatePoolInput{
+	_, err = TestClient.UpdatePool(&UpdatePoolInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -213,7 +213,7 @@ func TestClient_UpdatePool_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdatePool(&UpdatePoolInput{
+	_, err = TestClient.UpdatePool(&UpdatePoolInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -221,7 +221,7 @@ func TestClient_UpdatePool_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdatePool(&UpdatePoolInput{
+	_, err = TestClient.UpdatePool(&UpdatePoolInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -233,7 +233,7 @@ func TestClient_UpdatePool_validation(t *testing.T) {
 func TestClient_DeletePool_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeletePool(&DeletePoolInput{
+	err = TestClient.DeletePool(&DeletePoolInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -241,7 +241,7 @@ func TestClient_DeletePool_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeletePool(&DeletePoolInput{
+	err = TestClient.DeletePool(&DeletePoolInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -249,7 +249,7 @@ func TestClient_DeletePool_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeletePool(&DeletePoolInput{
+	err = TestClient.DeletePool(&DeletePoolInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/load_balancer_director.go
+++ b/fastly/load_balancer_director.go
@@ -64,7 +64,7 @@ func (c *Client) ListDirectors(i *ListDirectorsInput) ([]*Director, error) {
 	defer resp.Body.Close()
 
 	var ds []*Director
-	if err := decodeBodyMap(resp.Body, &ds); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ds); err != nil {
 		return nil, err
 	}
 	return ds, nil
@@ -107,7 +107,7 @@ func (c *Client) CreateDirector(i *CreateDirectorInput) (*Director, error) {
 	defer resp.Body.Close()
 
 	var d *Director
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -143,7 +143,7 @@ func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
 	defer resp.Body.Close()
 
 	var d *Director
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -191,7 +191,7 @@ func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
 	defer resp.Body.Close()
 
 	var d *Director
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -227,7 +227,7 @@ func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/load_balancer_director_backend.go
+++ b/fastly/load_balancer_director_backend.go
@@ -54,7 +54,7 @@ func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*Director
 	defer resp.Body.Close()
 
 	var b *DirectorBackend
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -96,7 +96,7 @@ func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBacken
 	defer resp.Body.Close()
 
 	var b *DirectorBackend
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -138,7 +138,7 @@ func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/load_balancer_director_backend_test.go
+++ b/fastly/load_balancer_director_backend_test.go
@@ -9,15 +9,15 @@ func TestClient_DirectorBackends(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "director_backends/version", func(c *Client) {
+	Record(t, "director_backends/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var b *DirectorBackend
-	record(t, "director_backends/create", func(c *Client) {
+	Record(t, "director_backends/create", func(c *Client) {
 		b, err = c.CreateDirectorBackend(&CreateDirectorBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Director:       "director",
 			Backend:        "backend",
@@ -29,9 +29,9 @@ func TestClient_DirectorBackends(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "director_backends/cleanup", func(c *Client) {
+		Record(t, "director_backends/cleanup", func(c *Client) {
 			_ = c.DeleteDirectorBackend(&DeleteDirectorBackendInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Director:       "director",
 				Backend:        "backend",
@@ -48,9 +48,9 @@ func TestClient_DirectorBackends(t *testing.T) {
 
 	// Get
 	var nb *DirectorBackend
-	record(t, "director_backends/get", func(c *Client) {
+	Record(t, "director_backends/get", func(c *Client) {
 		nb, err = c.GetDirectorBackend(&GetDirectorBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Director:       "director",
 			Backend:        "backend",
@@ -68,9 +68,9 @@ func TestClient_DirectorBackends(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "director_backends/delete", func(c *Client) {
+	Record(t, "director_backends/delete", func(c *Client) {
 		err = c.DeleteDirectorBackend(&DeleteDirectorBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Director:       "director",
 			Backend:        "backend",
@@ -83,24 +83,24 @@ func TestClient_DirectorBackends(t *testing.T) {
 
 func TestClient_CreateDirectorBackend_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateDirectorBackend(&CreateDirectorBackendInput{})
+	_, err = TestClient.CreateDirectorBackend(&CreateDirectorBackendInput{})
 	if err != ErrMissingBackend {
 		t.Errorf("bad error: %s", err)
 	}
-	_, err = testClient.CreateDirectorBackend(&CreateDirectorBackendInput{
+	_, err = TestClient.CreateDirectorBackend(&CreateDirectorBackendInput{
 		Backend: "foo",
 	})
 	if err != ErrMissingDirector {
 		t.Errorf("bad error: %s", err)
 	}
-	_, err = testClient.CreateDirectorBackend(&CreateDirectorBackendInput{
+	_, err = TestClient.CreateDirectorBackend(&CreateDirectorBackendInput{
 		Backend:  "foo",
 		Director: "bar",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
-	_, err = testClient.CreateDirectorBackend(&CreateDirectorBackendInput{
+	_, err = TestClient.CreateDirectorBackend(&CreateDirectorBackendInput{
 		Backend:   "foo",
 		Director:  "bar",
 		ServiceID: "baz",
@@ -112,24 +112,24 @@ func TestClient_CreateDirectorBackend_validation(t *testing.T) {
 
 func TestClient_GetDirectorBackend_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{})
+	_, err = TestClient.GetDirectorBackend(&GetDirectorBackendInput{})
 	if err != ErrMissingBackend {
 		t.Errorf("bad error: %s", err)
 	}
-	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
+	_, err = TestClient.GetDirectorBackend(&GetDirectorBackendInput{
 		Backend: "foo",
 	})
 	if err != ErrMissingDirector {
 		t.Errorf("bad error: %s", err)
 	}
-	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
+	_, err = TestClient.GetDirectorBackend(&GetDirectorBackendInput{
 		Backend:  "foo",
 		Director: "bar",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
-	_, err = testClient.GetDirectorBackend(&GetDirectorBackendInput{
+	_, err = TestClient.GetDirectorBackend(&GetDirectorBackendInput{
 		Backend:   "foo",
 		Director:  "bar",
 		ServiceID: "baz",
@@ -141,24 +141,24 @@ func TestClient_GetDirectorBackend_validation(t *testing.T) {
 
 func TestClient_DeleteDirectorBackend_validation(t *testing.T) {
 	var err error
-	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{})
+	err = TestClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{})
 	if err != ErrMissingBackend {
 		t.Errorf("bad error: %s", err)
 	}
-	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
+	err = TestClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 		Backend: "foo",
 	})
 	if err != ErrMissingDirector {
 		t.Errorf("bad error: %s", err)
 	}
-	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
+	err = TestClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 		Backend:  "foo",
 		Director: "bar",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
-	err = testClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
+	err = TestClient.DeleteDirectorBackend(&DeleteDirectorBackendInput{
 		Backend:   "foo",
 		Director:  "bar",
 		ServiceID: "baz",

--- a/fastly/load_balancer_director_test.go
+++ b/fastly/load_balancer_director_test.go
@@ -8,7 +8,7 @@ func TestClient_Directors(t *testing.T) {
 	t.Parallel()
 
 	var tv *Version
-	record(t, "directors/version", func(c *Client) {
+	Record(t, "directors/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -20,9 +20,9 @@ func TestClient_Directors(t *testing.T) {
 		errDirector        error
 		errDirectorBackend error
 	)
-	record(t, "directors/create", func(c *Client) {
+	Record(t, "directors/create", func(c *Client) {
 		b, errBackend = c.CreateBackend(&CreateBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-backend"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
@@ -32,7 +32,7 @@ func TestClient_Directors(t *testing.T) {
 			SSLCiphers:     ToPointer("DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384"),
 		})
 		d, errDirector = c.CreateDirector(&CreateDirectorInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-director"),
 			Quorum:         ToPointer(50),
@@ -40,7 +40,7 @@ func TestClient_Directors(t *testing.T) {
 			Retries:        ToPointer(5),
 		})
 		_, errDirectorBackend = c.CreateDirectorBackend(&CreateDirectorBackendInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Director:       "test-director",
 			Backend:        *b.Name,
@@ -58,28 +58,28 @@ func TestClient_Directors(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "directors/cleanup", func(c *Client) {
+		Record(t, "directors/cleanup", func(c *Client) {
 			_ = c.DeleteDirectorBackend(&DeleteDirectorBackendInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Director:       *d.Name,
 				Backend:        *b.Name,
 			})
 
 			_ = c.DeleteBackend(&DeleteBackendInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           *b.Name,
 			})
 
 			_ = c.DeleteDirector(&DeleteDirectorInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-director",
 			})
 
 			_ = c.DeleteDirector(&DeleteDirectorInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-director",
 			})
@@ -104,9 +104,9 @@ func TestClient_Directors(t *testing.T) {
 		bs  []*Director
 		err error
 	)
-	record(t, "directors/list", func(c *Client) {
+	Record(t, "directors/list", func(c *Client) {
 		bs, err = c.ListDirectors(&ListDirectorsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -119,9 +119,9 @@ func TestClient_Directors(t *testing.T) {
 
 	// Get
 	var nb *Director
-	record(t, "directors/get", func(c *Client) {
+	Record(t, "directors/get", func(c *Client) {
 		nb, err = c.GetDirector(&GetDirectorInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-director",
 		})
@@ -147,9 +147,9 @@ func TestClient_Directors(t *testing.T) {
 
 	// Update
 	var ub *Director
-	record(t, "directors/update", func(c *Client) {
+	Record(t, "directors/update", func(c *Client) {
 		ub, err = c.UpdateDirector(&UpdateDirectorInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-director",
 			NewName:        ToPointer("new-test-director"),
@@ -164,9 +164,9 @@ func TestClient_Directors(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "directors/delete", func(c *Client) {
+	Record(t, "directors/delete", func(c *Client) {
 		err = c.DeleteDirector(&DeleteDirectorInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-director",
 		})
@@ -178,14 +178,14 @@ func TestClient_Directors(t *testing.T) {
 
 func TestClient_ListDirectors_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListDirectors(&ListDirectorsInput{
+	_, err = TestClient.ListDirectors(&ListDirectorsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListDirectors(&ListDirectorsInput{
+	_, err = TestClient.ListDirectors(&ListDirectorsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -196,14 +196,14 @@ func TestClient_ListDirectors_validation(t *testing.T) {
 
 func TestClient_CreateDirector_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateDirector(&CreateDirectorInput{
+	_, err = TestClient.CreateDirector(&CreateDirectorInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateDirector(&CreateDirectorInput{
+	_, err = TestClient.CreateDirector(&CreateDirectorInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -215,7 +215,7 @@ func TestClient_CreateDirector_validation(t *testing.T) {
 func TestClient_GetDirector_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetDirector(&GetDirectorInput{
+	_, err = TestClient.GetDirector(&GetDirectorInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -223,7 +223,7 @@ func TestClient_GetDirector_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDirector(&GetDirectorInput{
+	_, err = TestClient.GetDirector(&GetDirectorInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -231,7 +231,7 @@ func TestClient_GetDirector_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDirector(&GetDirectorInput{
+	_, err = TestClient.GetDirector(&GetDirectorInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -243,7 +243,7 @@ func TestClient_GetDirector_validation(t *testing.T) {
 func TestClient_UpdateDirector_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateDirector(&UpdateDirectorInput{
+	_, err = TestClient.UpdateDirector(&UpdateDirectorInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -251,7 +251,7 @@ func TestClient_UpdateDirector_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDirector(&UpdateDirectorInput{
+	_, err = TestClient.UpdateDirector(&UpdateDirectorInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -259,7 +259,7 @@ func TestClient_UpdateDirector_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDirector(&UpdateDirectorInput{
+	_, err = TestClient.UpdateDirector(&UpdateDirectorInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -271,7 +271,7 @@ func TestClient_UpdateDirector_validation(t *testing.T) {
 func TestClient_DeleteDirector_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteDirector(&DeleteDirectorInput{
+	err = TestClient.DeleteDirector(&DeleteDirectorInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -279,7 +279,7 @@ func TestClient_DeleteDirector_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDirector(&DeleteDirectorInput{
+	err = TestClient.DeleteDirector(&DeleteDirectorInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -287,7 +287,7 @@ func TestClient_DeleteDirector_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDirector(&DeleteDirectorInput{
+	err = TestClient.DeleteDirector(&DeleteDirectorInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/load_balancer_server.go
+++ b/fastly/load_balancer_server.go
@@ -47,7 +47,7 @@ func (c *Client) ListServers(i *ListServersInput) ([]*Server, error) {
 	defer resp.Body.Close()
 
 	var ss []*Server
-	if err := decodeBodyMap(resp.Body, &ss); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 	return ss, nil
@@ -94,7 +94,7 @@ func (c *Client) CreateServer(i *CreateServerInput) (*Server, error) {
 	defer resp.Body.Close()
 
 	var s *Server
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -131,7 +131,7 @@ func (c *Client) GetServer(i *GetServerInput) (*Server, error) {
 	defer resp.Body.Close()
 
 	var s *Server
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -182,7 +182,7 @@ func (c *Client) UpdateServer(i *UpdateServerInput) (*Server, error) {
 	defer resp.Body.Close()
 
 	var s *Server
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -219,7 +219,7 @@ func (c *Client) DeleteServer(i *DeleteServerInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/load_balancer_server_test.go
+++ b/fastly/load_balancer_server_test.go
@@ -7,18 +7,18 @@ import (
 func TestClient_Servers(t *testing.T) {
 	var err error
 	var tv *Version
-	record(t, "servers/version", func(c *Client) {
+	Record(t, "servers/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
-	testPool := createTestPool(t, "servers/create_pool", testDeliveryServiceID, *tv.Number, "servers22")
+	testPool := createTestPool(t, "servers/create_pool", TestDeliveryServiceID, *tv.Number, "servers22")
 
 	// Create
 	var server *Server
 	var altServer *Server
-	record(t, "servers/create", func(c *Client) {
+	Record(t, "servers/create", func(c *Client) {
 		server, err = c.CreateServer(&CreateServerInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			PoolID:    *testPool.PoolID,
 			Address:   ToPointer("127.0.0.1"),
 		})
@@ -28,7 +28,7 @@ func TestClient_Servers(t *testing.T) {
 
 		// additional pool server for DeleteServer usage
 		altServer, err = c.CreateServer(&CreateServerInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			PoolID:    *testPool.PoolID,
 			Address:   ToPointer("altserver.example.com"),
 		})
@@ -42,10 +42,10 @@ func TestClient_Servers(t *testing.T) {
 		// Delete the pool from this version.
 		deleteTestPool(t, testPool, "servers/delete_pool")
 
-		record(t, "servers/cleanup", func(c *Client) {
+		Record(t, "servers/cleanup", func(c *Client) {
 			// Expected to fail as this was explicitly deleted in the test.
 			_ = c.DeleteServer(&DeleteServerInput{
-				ServiceID: testDeliveryServiceID,
+				ServiceID: TestDeliveryServiceID,
 				PoolID:    *testPool.PoolID,
 				Server:    *altServer.ServerID,
 			})
@@ -54,14 +54,14 @@ func TestClient_Servers(t *testing.T) {
 			// the pool. The pool is deleted from this version but it still
 			// exists as it may be associated with other versions.
 			_ = c.DeleteServer(&DeleteServerInput{
-				ServiceID: testDeliveryServiceID,
+				ServiceID: TestDeliveryServiceID,
 				PoolID:    *testPool.PoolID,
 				Server:    *server.ServerID,
 			})
 		})
 	}()
 
-	if *server.ServiceID != testDeliveryServiceID {
+	if *server.ServiceID != TestDeliveryServiceID {
 		t.Errorf("bad server service: %q", *server.ServiceID)
 	}
 	if *server.PoolID != *testPool.PoolID {
@@ -73,9 +73,9 @@ func TestClient_Servers(t *testing.T) {
 
 	// List
 	var ss []*Server
-	record(t, "servers/list", func(c *Client) {
+	Record(t, "servers/list", func(c *Client) {
 		ss, err = c.ListServers(&ListServersInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			PoolID:    *testPool.PoolID,
 		})
 	})
@@ -88,9 +88,9 @@ func TestClient_Servers(t *testing.T) {
 
 	// Get
 	var ns *Server
-	record(t, "servers/get", func(c *Client) {
+	Record(t, "servers/get", func(c *Client) {
 		ns, err = c.GetServer(&GetServerInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			PoolID:    *testPool.PoolID,
 			Server:    *server.ServerID,
 		})
@@ -104,9 +104,9 @@ func TestClient_Servers(t *testing.T) {
 
 	// Update
 	var us *Server
-	record(t, "servers/update", func(c *Client) {
+	Record(t, "servers/update", func(c *Client) {
 		us, err = c.UpdateServer(&UpdateServerInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			PoolID:    *testPool.PoolID,
 			Server:    *server.ServerID,
 			Address:   ToPointer("0.0.0.0"),
@@ -124,9 +124,9 @@ func TestClient_Servers(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "servers/delete", func(c *Client) {
+	Record(t, "servers/delete", func(c *Client) {
 		err = c.DeleteServer(&DeleteServerInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			PoolID:    *testPool.PoolID,
 			Server:    *altServer.ServerID,
 		})
@@ -139,14 +139,14 @@ func TestClient_Servers(t *testing.T) {
 func TestClient_ListServers_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListServers(&ListServersInput{
+	_, err = TestClient.ListServers(&ListServersInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingPoolID {
 		t.Errorf("bad error: %q", err)
 	}
 
-	_, err = testClient.ListServers(&ListServersInput{
+	_, err = TestClient.ListServers(&ListServersInput{
 		PoolID: "123",
 	})
 	if err != ErrMissingServiceID {
@@ -157,14 +157,14 @@ func TestClient_ListServers_validation(t *testing.T) {
 func TestClient_CreateServer_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateServer(&CreateServerInput{
+	_, err = TestClient.CreateServer(&CreateServerInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingPoolID {
 		t.Errorf("bad error: %q", err)
 	}
 
-	_, err = testClient.CreateServer(&CreateServerInput{
+	_, err = TestClient.CreateServer(&CreateServerInput{
 		PoolID: "123",
 	})
 	if err != ErrMissingServiceID {
@@ -175,7 +175,7 @@ func TestClient_CreateServer_validation(t *testing.T) {
 func TestClient_GetServer_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetServer(&GetServerInput{
+	_, err = TestClient.GetServer(&GetServerInput{
 		Server:    "test",
 		ServiceID: "foo",
 	})
@@ -183,7 +183,7 @@ func TestClient_GetServer_validation(t *testing.T) {
 		t.Errorf("bad error: %q", err)
 	}
 
-	_, err = testClient.GetServer(&GetServerInput{
+	_, err = TestClient.GetServer(&GetServerInput{
 		PoolID:    "bar",
 		ServiceID: "foo",
 	})
@@ -191,7 +191,7 @@ func TestClient_GetServer_validation(t *testing.T) {
 		t.Errorf("bad error: %q", err)
 	}
 
-	_, err = testClient.GetServer(&GetServerInput{
+	_, err = TestClient.GetServer(&GetServerInput{
 		PoolID: "bar",
 		Server: "test",
 	})
@@ -203,7 +203,7 @@ func TestClient_GetServer_validation(t *testing.T) {
 func TestClient_UpdateServer_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateServer(&UpdateServerInput{
+	_, err = TestClient.UpdateServer(&UpdateServerInput{
 		Server:    "test",
 		ServiceID: "foo",
 	})
@@ -211,7 +211,7 @@ func TestClient_UpdateServer_validation(t *testing.T) {
 		t.Errorf("bad error: %q", err)
 	}
 
-	_, err = testClient.UpdateServer(&UpdateServerInput{
+	_, err = TestClient.UpdateServer(&UpdateServerInput{
 		PoolID:    "bar",
 		ServiceID: "foo",
 	})
@@ -219,7 +219,7 @@ func TestClient_UpdateServer_validation(t *testing.T) {
 		t.Errorf("bad error: %q", err)
 	}
 
-	_, err = testClient.UpdateServer(&UpdateServerInput{
+	_, err = TestClient.UpdateServer(&UpdateServerInput{
 		PoolID: "bar",
 		Server: "test",
 	})
@@ -231,7 +231,7 @@ func TestClient_UpdateServer_validation(t *testing.T) {
 func TestClient_DeleteServer_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteServer(&DeleteServerInput{
+	err = TestClient.DeleteServer(&DeleteServerInput{
 		Server:    "test",
 		ServiceID: "foo",
 	})
@@ -239,7 +239,7 @@ func TestClient_DeleteServer_validation(t *testing.T) {
 		t.Errorf("bad error: %q", err)
 	}
 
-	err = testClient.DeleteServer(&DeleteServerInput{
+	err = TestClient.DeleteServer(&DeleteServerInput{
 		PoolID:    "bar",
 		ServiceID: "foo",
 	})
@@ -247,7 +247,7 @@ func TestClient_DeleteServer_validation(t *testing.T) {
 		t.Errorf("bad error: %q", err)
 	}
 
-	err = testClient.DeleteServer(&DeleteServerInput{
+	err = TestClient.DeleteServer(&DeleteServerInput{
 		PoolID: "bar",
 		Server: "test",
 	})

--- a/fastly/logging_bigquery.go
+++ b/fastly/logging_bigquery.go
@@ -52,7 +52,7 @@ func (c *Client) ListBigQueries(i *ListBigQueriesInput) ([]*BigQuery, error) {
 	defer resp.Body.Close()
 
 	var bigQueries []*BigQuery
-	if err := decodeBodyMap(resp.Body, &bigQueries); err != nil {
+	if err := DecodeBodyMap(resp.Body, &bigQueries); err != nil {
 		return nil, err
 	}
 	return bigQueries, nil
@@ -107,7 +107,7 @@ func (c *Client) CreateBigQuery(i *CreateBigQueryInput) (*BigQuery, error) {
 	defer resp.Body.Close()
 
 	var bigQuery *BigQuery
-	if err := decodeBodyMap(resp.Body, &bigQuery); err != nil {
+	if err := DecodeBodyMap(resp.Body, &bigQuery); err != nil {
 		return nil, err
 	}
 	return bigQuery, nil
@@ -143,7 +143,7 @@ func (c *Client) GetBigQuery(i *GetBigQueryInput) (*BigQuery, error) {
 	defer resp.Body.Close()
 
 	var bigQuery *BigQuery
-	if err := decodeBodyMap(resp.Body, &bigQuery); err != nil {
+	if err := DecodeBodyMap(resp.Body, &bigQuery); err != nil {
 		return nil, err
 	}
 	return bigQuery, nil
@@ -203,7 +203,7 @@ func (c *Client) UpdateBigQuery(i *UpdateBigQueryInput) (*BigQuery, error) {
 	defer resp.Body.Close()
 
 	var bigQuery *BigQuery
-	if err := decodeBodyMap(resp.Body, &bigQuery); err != nil {
+	if err := DecodeBodyMap(resp.Body, &bigQuery); err != nil {
 		return nil, err
 	}
 	return bigQuery, nil
@@ -239,7 +239,7 @@ func (c *Client) DeleteBigQuery(i *DeleteBigQueryInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_bigquery_test.go
+++ b/fastly/logging_bigquery_test.go
@@ -10,7 +10,7 @@ func TestClient_Bigqueries(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "bigqueries/version", func(c *Client) {
+	Record(t, "bigqueries/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -18,9 +18,9 @@ func TestClient_Bigqueries(t *testing.T) {
 
 	// Create
 	var bq *BigQuery
-	record(t, "bigqueries/create", func(c *Client) {
+	Record(t, "bigqueries/create", func(c *Client) {
 		bq, err = c.CreateBigQuery(&CreateBigQueryInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-bigquery"),
 			ProjectID:      ToPointer("example-fastly-log"),
@@ -41,15 +41,15 @@ func TestClient_Bigqueries(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "bigqueries/cleanup", func(c *Client) {
+		Record(t, "bigqueries/cleanup", func(c *Client) {
 			_ = c.DeleteBigQuery(&DeleteBigQueryInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-bigquery",
 			})
 
 			_ = c.DeleteBigQuery(&DeleteBigQueryInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-bigquery",
 			})
@@ -95,9 +95,9 @@ func TestClient_Bigqueries(t *testing.T) {
 
 	// List
 	var bqs []*BigQuery
-	record(t, "bigqueries/list", func(c *Client) {
+	Record(t, "bigqueries/list", func(c *Client) {
 		bqs, err = c.ListBigQueries(&ListBigQueriesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -110,9 +110,9 @@ func TestClient_Bigqueries(t *testing.T) {
 
 	// Get
 	var nbq *BigQuery
-	record(t, "bigqueries/get", func(c *Client) {
+	Record(t, "bigqueries/get", func(c *Client) {
 		nbq, err = c.GetBigQuery(&GetBigQueryInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-bigquery",
 		})
@@ -156,9 +156,9 @@ func TestClient_Bigqueries(t *testing.T) {
 
 	// Update
 	var ubq *BigQuery
-	record(t, "bigqueries/update", func(c *Client) {
+	Record(t, "bigqueries/update", func(c *Client) {
 		ubq, err = c.UpdateBigQuery(&UpdateBigQueryInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-bigquery",
 			NewName:        ToPointer("new-test-bigquery"),
@@ -172,9 +172,9 @@ func TestClient_Bigqueries(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "bigqueries/delete", func(c *Client) {
+	Record(t, "bigqueries/delete", func(c *Client) {
 		err = c.DeleteBigQuery(&DeleteBigQueryInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-bigquery",
 		})
@@ -186,14 +186,14 @@ func TestClient_Bigqueries(t *testing.T) {
 
 func TestClient_ListBigQueries_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListBigQueries(&ListBigQueriesInput{
+	_, err = TestClient.ListBigQueries(&ListBigQueriesInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListBigQueries(&ListBigQueriesInput{
+	_, err = TestClient.ListBigQueries(&ListBigQueriesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -204,14 +204,14 @@ func TestClient_ListBigQueries_validation(t *testing.T) {
 
 func TestClient_CreateBigQuery_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateBigQuery(&CreateBigQueryInput{
+	_, err = TestClient.CreateBigQuery(&CreateBigQueryInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateBigQuery(&CreateBigQueryInput{
+	_, err = TestClient.CreateBigQuery(&CreateBigQueryInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -223,7 +223,7 @@ func TestClient_CreateBigQuery_validation(t *testing.T) {
 func TestClient_GetBigQuery_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetBigQuery(&GetBigQueryInput{
+	_, err = TestClient.GetBigQuery(&GetBigQueryInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -231,7 +231,7 @@ func TestClient_GetBigQuery_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetBigQuery(&GetBigQueryInput{
+	_, err = TestClient.GetBigQuery(&GetBigQueryInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -239,7 +239,7 @@ func TestClient_GetBigQuery_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetBigQuery(&GetBigQueryInput{
+	_, err = TestClient.GetBigQuery(&GetBigQueryInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -251,7 +251,7 @@ func TestClient_GetBigQuery_validation(t *testing.T) {
 func TestClient_UpdateBigQuery_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateBigQuery(&UpdateBigQueryInput{
+	_, err = TestClient.UpdateBigQuery(&UpdateBigQueryInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -259,7 +259,7 @@ func TestClient_UpdateBigQuery_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateBigQuery(&UpdateBigQueryInput{
+	_, err = TestClient.UpdateBigQuery(&UpdateBigQueryInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -267,7 +267,7 @@ func TestClient_UpdateBigQuery_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateBigQuery(&UpdateBigQueryInput{
+	_, err = TestClient.UpdateBigQuery(&UpdateBigQueryInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -279,7 +279,7 @@ func TestClient_UpdateBigQuery_validation(t *testing.T) {
 func TestClient_DeleteBigQuery_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteBigQuery(&DeleteBigQueryInput{
+	err = TestClient.DeleteBigQuery(&DeleteBigQueryInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -287,7 +287,7 @@ func TestClient_DeleteBigQuery_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteBigQuery(&DeleteBigQueryInput{
+	err = TestClient.DeleteBigQuery(&DeleteBigQueryInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -295,7 +295,7 @@ func TestClient_DeleteBigQuery_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteBigQuery(&DeleteBigQueryInput{
+	err = TestClient.DeleteBigQuery(&DeleteBigQueryInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_blobstorage.go
+++ b/fastly/logging_blobstorage.go
@@ -55,7 +55,7 @@ func (c *Client) ListBlobStorages(i *ListBlobStoragesInput) ([]*BlobStorage, err
 	defer resp.Body.Close()
 
 	var as []*BlobStorage
-	if err := decodeBodyMap(resp.Body, &as); err != nil {
+	if err := DecodeBodyMap(resp.Body, &as); err != nil {
 		return nil, err
 	}
 	return as, nil
@@ -118,7 +118,7 @@ func (c *Client) CreateBlobStorage(i *CreateBlobStorageInput) (*BlobStorage, err
 	defer resp.Body.Close()
 
 	var a *BlobStorage
-	if err := decodeBodyMap(resp.Body, &a); err != nil {
+	if err := DecodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -154,7 +154,7 @@ func (c *Client) GetBlobStorage(i *GetBlobStorageInput) (*BlobStorage, error) {
 	defer resp.Body.Close()
 
 	var a *BlobStorage
-	if err := decodeBodyMap(resp.Body, &a); err != nil {
+	if err := DecodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -222,7 +222,7 @@ func (c *Client) UpdateBlobStorage(i *UpdateBlobStorageInput) (*BlobStorage, err
 	defer resp.Body.Close()
 
 	var a *BlobStorage
-	if err := decodeBodyMap(resp.Body, &a); err != nil {
+	if err := DecodeBodyMap(resp.Body, &a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -258,7 +258,7 @@ func (c *Client) DeleteBlobStorage(i *DeleteBlobStorageInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_blobstorage_test.go
+++ b/fastly/logging_blobstorage_test.go
@@ -13,15 +13,15 @@ func TestClient_BlobStorages(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "blobstorages/version", func(c *Client) {
+	Record(t, "blobstorages/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var bsCreateResp1, bsCreateResp2, bsCreateResp3 *BlobStorage
-	record(t, "blobstorages/create", func(c *Client) {
+	Record(t, "blobstorages/create", func(c *Client) {
 		bsCreateResp1, err = c.CreateBlobStorage(&CreateBlobStorageInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-blobstorage"),
 			Path:             ToPointer("/logs"),
@@ -43,9 +43,9 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "blobstorages/create2", func(c *Client) {
+	Record(t, "blobstorages/create2", func(c *Client) {
 		bsCreateResp2, err = c.CreateBlobStorage(&CreateBlobStorageInput{
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-blobstorage-2"),
 			Path:            ToPointer("/logs"),
@@ -67,9 +67,9 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "blobstorages/create3", func(c *Client) {
+	Record(t, "blobstorages/create3", func(c *Client) {
 		bsCreateResp3, err = c.CreateBlobStorage(&CreateBlobStorageInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-blobstorage-3"),
 			Path:             ToPointer("/logs"),
@@ -92,9 +92,9 @@ func TestClient_BlobStorages(t *testing.T) {
 
 	// This case is expected to fail because both CompressionCodec and
 	// GzipLevel are present.
-	record(t, "blobstorages/create4", func(c *Client) {
+	Record(t, "blobstorages/create4", func(c *Client) {
 		_, err = c.CreateBlobStorage(&CreateBlobStorageInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-blobstorage-4"),
 			Path:             ToPointer("/logs"),
@@ -119,27 +119,27 @@ func TestClient_BlobStorages(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "blobstorages/cleanup", func(c *Client) {
+		Record(t, "blobstorages/cleanup", func(c *Client) {
 			_ = c.DeleteBlobStorage(&DeleteBlobStorageInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-blobstorage",
 			})
 
 			_ = c.DeleteBlobStorage(&DeleteBlobStorageInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-blobstorage-2",
 			})
 
 			_ = c.DeleteBlobStorage(&DeleteBlobStorageInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-blobstorage-3",
 			})
 
 			_ = c.DeleteBlobStorage(&DeleteBlobStorageInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-blobstorage",
 			})
@@ -212,9 +212,9 @@ func TestClient_BlobStorages(t *testing.T) {
 
 	// List
 	var bsl []*BlobStorage
-	record(t, "blobstorages/list", func(c *Client) {
+	Record(t, "blobstorages/list", func(c *Client) {
 		bsl, err = c.ListBlobStorages(&ListBlobStoragesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -227,9 +227,9 @@ func TestClient_BlobStorages(t *testing.T) {
 
 	// Get
 	var bsGetResp *BlobStorage
-	record(t, "blobstorages/get", func(c *Client) {
+	Record(t, "blobstorages/get", func(c *Client) {
 		bsGetResp, err = c.GetBlobStorage(&GetBlobStorageInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-blobstorage",
 		})
@@ -282,9 +282,9 @@ func TestClient_BlobStorages(t *testing.T) {
 
 	// Update
 	var bsUpdateResp1, bsUpdateResp2, bsUpdateResp3 *BlobStorage
-	record(t, "blobstorages/update", func(c *Client) {
+	Record(t, "blobstorages/update", func(c *Client) {
 		bsUpdateResp1, err = c.UpdateBlobStorage(&UpdateBlobStorageInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-blobstorage",
 			NewName:          ToPointer("new-test-blobstorage"),
@@ -298,9 +298,9 @@ func TestClient_BlobStorages(t *testing.T) {
 
 	// Test that CompressionCodec can be set for a an endpoint where
 	// GzipLevel was specified at creation time.
-	record(t, "blobstorages/update2", func(c *Client) {
+	Record(t, "blobstorages/update2", func(c *Client) {
 		bsUpdateResp2, err = c.UpdateBlobStorage(&UpdateBlobStorageInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-blobstorage-2",
 			CompressionCodec: ToPointer("zstd"),
@@ -312,9 +312,9 @@ func TestClient_BlobStorages(t *testing.T) {
 
 	// Test that GzipLevel can be set for an endpoint where CompressionCodec
 	// was set at creation time.
-	record(t, "blobstorages/update3", func(c *Client) {
+	Record(t, "blobstorages/update3", func(c *Client) {
 		bsUpdateResp3, err = c.UpdateBlobStorage(&UpdateBlobStorageInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-blobstorage-3",
 			GzipLevel:      ToPointer(9),
@@ -347,9 +347,9 @@ func TestClient_BlobStorages(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "blobstorages/delete", func(c *Client) {
+	Record(t, "blobstorages/delete", func(c *Client) {
 		err = c.DeleteBlobStorage(&DeleteBlobStorageInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-blobstorage",
 		})
@@ -362,14 +362,14 @@ func TestClient_BlobStorages(t *testing.T) {
 func TestClient_ListBlobStorages_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListBlobStorages(&ListBlobStoragesInput{
+	_, err = TestClient.ListBlobStorages(&ListBlobStoragesInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListBlobStorages(&ListBlobStoragesInput{
+	_, err = TestClient.ListBlobStorages(&ListBlobStoragesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -381,14 +381,14 @@ func TestClient_ListBlobStorages_validation(t *testing.T) {
 func TestClient_CreateBlobStorage_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateBlobStorage(&CreateBlobStorageInput{
+	_, err = TestClient.CreateBlobStorage(&CreateBlobStorageInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateBlobStorage(&CreateBlobStorageInput{
+	_, err = TestClient.CreateBlobStorage(&CreateBlobStorageInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -400,7 +400,7 @@ func TestClient_CreateBlobStorage_validation(t *testing.T) {
 func TestClient_GetBlobStorage_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetBlobStorage(&GetBlobStorageInput{
+	_, err = TestClient.GetBlobStorage(&GetBlobStorageInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -408,7 +408,7 @@ func TestClient_GetBlobStorage_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetBlobStorage(&GetBlobStorageInput{
+	_, err = TestClient.GetBlobStorage(&GetBlobStorageInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -416,7 +416,7 @@ func TestClient_GetBlobStorage_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetBlobStorage(&GetBlobStorageInput{
+	_, err = TestClient.GetBlobStorage(&GetBlobStorageInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -428,7 +428,7 @@ func TestClient_GetBlobStorage_validation(t *testing.T) {
 func TestClient_UpdateBlobStorage_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateBlobStorage(&UpdateBlobStorageInput{
+	_, err = TestClient.UpdateBlobStorage(&UpdateBlobStorageInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -436,7 +436,7 @@ func TestClient_UpdateBlobStorage_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateBlobStorage(&UpdateBlobStorageInput{
+	_, err = TestClient.UpdateBlobStorage(&UpdateBlobStorageInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -444,7 +444,7 @@ func TestClient_UpdateBlobStorage_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateBlobStorage(&UpdateBlobStorageInput{
+	_, err = TestClient.UpdateBlobStorage(&UpdateBlobStorageInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -456,7 +456,7 @@ func TestClient_UpdateBlobStorage_validation(t *testing.T) {
 func TestClient_DeleteBlobStorage_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteBlobStorage(&DeleteBlobStorageInput{
+	err = TestClient.DeleteBlobStorage(&DeleteBlobStorageInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -464,7 +464,7 @@ func TestClient_DeleteBlobStorage_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteBlobStorage(&DeleteBlobStorageInput{
+	err = TestClient.DeleteBlobStorage(&DeleteBlobStorageInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -472,7 +472,7 @@ func TestClient_DeleteBlobStorage_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteBlobStorage(&DeleteBlobStorageInput{
+	err = TestClient.DeleteBlobStorage(&DeleteBlobStorageInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_cloudfiles.go
+++ b/fastly/logging_cloudfiles.go
@@ -55,7 +55,7 @@ func (c *Client) ListCloudfiles(i *ListCloudfilesInput) ([]*Cloudfiles, error) {
 	defer resp.Body.Close()
 
 	var cloudfiles []*Cloudfiles
-	if err := decodeBodyMap(resp.Body, &cloudfiles); err != nil {
+	if err := DecodeBodyMap(resp.Body, &cloudfiles); err != nil {
 		return nil, err
 	}
 	return cloudfiles, nil
@@ -118,7 +118,7 @@ func (c *Client) CreateCloudfiles(i *CreateCloudfilesInput) (*Cloudfiles, error)
 	defer resp.Body.Close()
 
 	var cloudfiles *Cloudfiles
-	if err := decodeBodyMap(resp.Body, &cloudfiles); err != nil {
+	if err := DecodeBodyMap(resp.Body, &cloudfiles); err != nil {
 		return nil, err
 	}
 	return cloudfiles, nil
@@ -154,7 +154,7 @@ func (c *Client) GetCloudfiles(i *GetCloudfilesInput) (*Cloudfiles, error) {
 	defer resp.Body.Close()
 
 	var cloudfiles *Cloudfiles
-	if err := decodeBodyMap(resp.Body, &cloudfiles); err != nil {
+	if err := DecodeBodyMap(resp.Body, &cloudfiles); err != nil {
 		return nil, err
 	}
 	return cloudfiles, nil
@@ -222,7 +222,7 @@ func (c *Client) UpdateCloudfiles(i *UpdateCloudfilesInput) (*Cloudfiles, error)
 	defer resp.Body.Close()
 
 	var cloudfiles *Cloudfiles
-	if err := decodeBodyMap(resp.Body, &cloudfiles); err != nil {
+	if err := DecodeBodyMap(resp.Body, &cloudfiles); err != nil {
 		return nil, err
 	}
 	return cloudfiles, nil
@@ -258,7 +258,7 @@ func (c *Client) DeleteCloudfiles(i *DeleteCloudfilesInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_cloudfiles_test.go
+++ b/fastly/logging_cloudfiles_test.go
@@ -9,15 +9,15 @@ func TestClient_Cloudfiles(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "cloudfiles/version", func(c *Client) {
+	Record(t, "cloudfiles/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var cloudfilesCreateResp1, cloudfilesCreateResp2, cloudfilesCreateResp3 *Cloudfiles
-	record(t, "cloudfiles/create", func(c *Client) {
+	Record(t, "cloudfiles/create", func(c *Client) {
 		cloudfilesCreateResp1, err = c.CreateCloudfiles(&CreateCloudfilesInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-cloudfiles"),
 			User:             ToPointer("user"),
@@ -39,9 +39,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "cloudfiles/create2", func(c *Client) {
+	Record(t, "cloudfiles/create2", func(c *Client) {
 		cloudfilesCreateResp2, err = c.CreateCloudfiles(&CreateCloudfilesInput{
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-cloudfiles-2"),
 			User:            ToPointer("user"),
@@ -63,9 +63,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "cloudfiles/create3", func(c *Client) {
+	Record(t, "cloudfiles/create3", func(c *Client) {
 		cloudfilesCreateResp3, err = c.CreateCloudfiles(&CreateCloudfilesInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-cloudfiles-3"),
 			User:             ToPointer("user"),
@@ -89,9 +89,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 
 	// This case is expected to fail because both CompressionCodec and
 	// GzipLevel are present.
-	record(t, "cloudfiles/create4", func(c *Client) {
+	Record(t, "cloudfiles/create4", func(c *Client) {
 		_, err = c.CreateCloudfiles(&CreateCloudfilesInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-cloudfiles-4"),
 			User:             ToPointer("user"),
@@ -116,27 +116,27 @@ func TestClient_Cloudfiles(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "cloudfiles/cleanup", func(c *Client) {
+		Record(t, "cloudfiles/cleanup", func(c *Client) {
 			_ = c.DeleteCloudfiles(&DeleteCloudfilesInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-cloudfiles",
 			})
 
 			_ = c.DeleteCloudfiles(&DeleteCloudfilesInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-cloudfiles-2",
 			})
 
 			_ = c.DeleteCloudfiles(&DeleteCloudfilesInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-cloudfiles-3",
 			})
 
 			_ = c.DeleteCloudfiles(&DeleteCloudfilesInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-cloudfiles",
 			})
@@ -200,9 +200,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 
 	// List
 	var lc []*Cloudfiles
-	record(t, "cloudfiles/list", func(c *Client) {
+	Record(t, "cloudfiles/list", func(c *Client) {
 		lc, err = c.ListCloudfiles(&ListCloudfilesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -215,9 +215,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 
 	// Get
 	var cloudfilesGetResp *Cloudfiles
-	record(t, "cloudfiles/get", func(c *Client) {
+	Record(t, "cloudfiles/get", func(c *Client) {
 		cloudfilesGetResp, err = c.GetCloudfiles(&GetCloudfilesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-cloudfiles",
 		})
@@ -273,9 +273,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 
 	// Update
 	var cloudfilesUpdateResp1, cloudfilesUpdateResp2, cloudfilesUpdateResp3 *Cloudfiles
-	record(t, "cloudfiles/update", func(c *Client) {
+	Record(t, "cloudfiles/update", func(c *Client) {
 		cloudfilesUpdateResp1, err = c.UpdateCloudfiles(&UpdateCloudfilesInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-cloudfiles",
 			NewName:          ToPointer("new-test-cloudfiles"),
@@ -289,9 +289,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "cloudfiles/update2", func(c *Client) {
+	Record(t, "cloudfiles/update2", func(c *Client) {
 		cloudfilesUpdateResp2, err = c.UpdateCloudfiles(&UpdateCloudfilesInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-cloudfiles-2",
 			CompressionCodec: ToPointer("zstd"),
@@ -301,9 +301,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "cloudfiles/update3", func(c *Client) {
+	Record(t, "cloudfiles/update3", func(c *Client) {
 		cloudfilesUpdateResp3, err = c.UpdateCloudfiles(&UpdateCloudfilesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-cloudfiles-3",
 			GzipLevel:      ToPointer(9),
@@ -348,9 +348,9 @@ func TestClient_Cloudfiles(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "cloudfiles/delete", func(c *Client) {
+	Record(t, "cloudfiles/delete", func(c *Client) {
 		err = c.DeleteCloudfiles(&DeleteCloudfilesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-cloudfiles",
 		})
@@ -362,14 +362,14 @@ func TestClient_Cloudfiles(t *testing.T) {
 
 func TestClient_ListCloudfiles_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListCloudfiles(&ListCloudfilesInput{
+	_, err = TestClient.ListCloudfiles(&ListCloudfilesInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListCloudfiles(&ListCloudfilesInput{
+	_, err = TestClient.ListCloudfiles(&ListCloudfilesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -380,14 +380,14 @@ func TestClient_ListCloudfiles_validation(t *testing.T) {
 
 func TestClient_CreateCloudfiles_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateCloudfiles(&CreateCloudfilesInput{
+	_, err = TestClient.CreateCloudfiles(&CreateCloudfilesInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateCloudfiles(&CreateCloudfilesInput{
+	_, err = TestClient.CreateCloudfiles(&CreateCloudfilesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -399,7 +399,7 @@ func TestClient_CreateCloudfiles_validation(t *testing.T) {
 func TestClient_GetCloudfiles_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetCloudfiles(&GetCloudfilesInput{
+	_, err = TestClient.GetCloudfiles(&GetCloudfilesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -407,7 +407,7 @@ func TestClient_GetCloudfiles_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetCloudfiles(&GetCloudfilesInput{
+	_, err = TestClient.GetCloudfiles(&GetCloudfilesInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -415,7 +415,7 @@ func TestClient_GetCloudfiles_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetCloudfiles(&GetCloudfilesInput{
+	_, err = TestClient.GetCloudfiles(&GetCloudfilesInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -427,7 +427,7 @@ func TestClient_GetCloudfiles_validation(t *testing.T) {
 func TestClient_UpdateCloudfiles_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateCloudfiles(&UpdateCloudfilesInput{
+	_, err = TestClient.UpdateCloudfiles(&UpdateCloudfilesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -435,7 +435,7 @@ func TestClient_UpdateCloudfiles_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateCloudfiles(&UpdateCloudfilesInput{
+	_, err = TestClient.UpdateCloudfiles(&UpdateCloudfilesInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -443,7 +443,7 @@ func TestClient_UpdateCloudfiles_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateCloudfiles(&UpdateCloudfilesInput{
+	_, err = TestClient.UpdateCloudfiles(&UpdateCloudfilesInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -455,7 +455,7 @@ func TestClient_UpdateCloudfiles_validation(t *testing.T) {
 func TestClient_DeleteCloudfiles_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteCloudfiles(&DeleteCloudfilesInput{
+	err = TestClient.DeleteCloudfiles(&DeleteCloudfilesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -463,7 +463,7 @@ func TestClient_DeleteCloudfiles_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteCloudfiles(&DeleteCloudfilesInput{
+	err = TestClient.DeleteCloudfiles(&DeleteCloudfilesInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -471,7 +471,7 @@ func TestClient_DeleteCloudfiles_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteCloudfiles(&DeleteCloudfilesInput{
+	err = TestClient.DeleteCloudfiles(&DeleteCloudfilesInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_datadog.go
+++ b/fastly/logging_datadog.go
@@ -46,7 +46,7 @@ func (c *Client) ListDatadog(i *ListDatadogInput) ([]*Datadog, error) {
 	defer resp.Body.Close()
 
 	var d []*Datadog
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -91,7 +91,7 @@ func (c *Client) CreateDatadog(i *CreateDatadogInput) (*Datadog, error) {
 	defer resp.Body.Close()
 
 	var d *Datadog
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -127,7 +127,7 @@ func (c *Client) GetDatadog(i *GetDatadogInput) (*Datadog, error) {
 	defer resp.Body.Close()
 
 	var d *Datadog
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -177,7 +177,7 @@ func (c *Client) UpdateDatadog(i *UpdateDatadogInput) (*Datadog, error) {
 	defer resp.Body.Close()
 
 	var d *Datadog
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -213,7 +213,7 @@ func (c *Client) DeleteDatadog(i *DeleteDatadogInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_datadog_test.go
+++ b/fastly/logging_datadog_test.go
@@ -9,15 +9,15 @@ func TestClient_Datadog(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "datadog/version", func(c *Client) {
+	Record(t, "datadog/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var d *Datadog
-	record(t, "datadog/create", func(c *Client) {
+	Record(t, "datadog/create", func(c *Client) {
 		d, err = c.CreateDatadog(&CreateDatadogInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-datadog"),
 			Region:         ToPointer("US"),
@@ -32,15 +32,15 @@ func TestClient_Datadog(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "datadog/delete", func(c *Client) {
+		Record(t, "datadog/delete", func(c *Client) {
 			_ = c.DeleteDatadog(&DeleteDatadogInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-datadog",
 			})
 
 			_ = c.DeleteDatadog(&DeleteDatadogInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-datadog",
 			})
@@ -68,9 +68,9 @@ func TestClient_Datadog(t *testing.T) {
 
 	// List
 	var ld []*Datadog
-	record(t, "datadog/list", func(c *Client) {
+	Record(t, "datadog/list", func(c *Client) {
 		ld, err = c.ListDatadog(&ListDatadogInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -83,9 +83,9 @@ func TestClient_Datadog(t *testing.T) {
 
 	// Get
 	var nd *Datadog
-	record(t, "datadog/get", func(c *Client) {
+	Record(t, "datadog/get", func(c *Client) {
 		nd, err = c.GetDatadog(&GetDatadogInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-datadog",
 		})
@@ -111,9 +111,9 @@ func TestClient_Datadog(t *testing.T) {
 
 	// Update
 	var ud *Datadog
-	record(t, "datadog/update", func(c *Client) {
+	Record(t, "datadog/update", func(c *Client) {
 		ud, err = c.UpdateDatadog(&UpdateDatadogInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-datadog",
 			NewName:        ToPointer("new-test-datadog"),
@@ -135,9 +135,9 @@ func TestClient_Datadog(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "datadog/delete", func(c *Client) {
+	Record(t, "datadog/delete", func(c *Client) {
 		err = c.DeleteDatadog(&DeleteDatadogInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-datadog",
 		})
@@ -150,14 +150,14 @@ func TestClient_Datadog(t *testing.T) {
 func TestClient_ListDatadog_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListDatadog(&ListDatadogInput{
+	_, err = TestClient.ListDatadog(&ListDatadogInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListDatadog(&ListDatadogInput{
+	_, err = TestClient.ListDatadog(&ListDatadogInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -169,14 +169,14 @@ func TestClient_ListDatadog_validation(t *testing.T) {
 func TestClient_CreateDatadog_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateDatadog(&CreateDatadogInput{
+	_, err = TestClient.CreateDatadog(&CreateDatadogInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateDatadog(&CreateDatadogInput{
+	_, err = TestClient.CreateDatadog(&CreateDatadogInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -188,7 +188,7 @@ func TestClient_CreateDatadog_validation(t *testing.T) {
 func TestClient_GetDatadog_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetDatadog(&GetDatadogInput{
+	_, err = TestClient.GetDatadog(&GetDatadogInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -196,7 +196,7 @@ func TestClient_GetDatadog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDatadog(&GetDatadogInput{
+	_, err = TestClient.GetDatadog(&GetDatadogInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -204,7 +204,7 @@ func TestClient_GetDatadog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDatadog(&GetDatadogInput{
+	_, err = TestClient.GetDatadog(&GetDatadogInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -216,7 +216,7 @@ func TestClient_GetDatadog_validation(t *testing.T) {
 func TestClient_UpdateDatadog_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateDatadog(&UpdateDatadogInput{
+	_, err = TestClient.UpdateDatadog(&UpdateDatadogInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -224,7 +224,7 @@ func TestClient_UpdateDatadog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDatadog(&UpdateDatadogInput{
+	_, err = TestClient.UpdateDatadog(&UpdateDatadogInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -232,7 +232,7 @@ func TestClient_UpdateDatadog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDatadog(&UpdateDatadogInput{
+	_, err = TestClient.UpdateDatadog(&UpdateDatadogInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -244,7 +244,7 @@ func TestClient_UpdateDatadog_validation(t *testing.T) {
 func TestClient_DeleteDatadog_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteDatadog(&DeleteDatadogInput{
+	err = TestClient.DeleteDatadog(&DeleteDatadogInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -252,7 +252,7 @@ func TestClient_DeleteDatadog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDatadog(&DeleteDatadogInput{
+	err = TestClient.DeleteDatadog(&DeleteDatadogInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -260,7 +260,7 @@ func TestClient_DeleteDatadog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDatadog(&DeleteDatadogInput{
+	err = TestClient.DeleteDatadog(&DeleteDatadogInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_digitalocean.go
+++ b/fastly/logging_digitalocean.go
@@ -55,7 +55,7 @@ func (c *Client) ListDigitalOceans(i *ListDigitalOceansInput) ([]*DigitalOcean, 
 	defer resp.Body.Close()
 
 	var digitaloceans []*DigitalOcean
-	if err := decodeBodyMap(resp.Body, &digitaloceans); err != nil {
+	if err := DecodeBodyMap(resp.Body, &digitaloceans); err != nil {
 		return nil, err
 	}
 	return digitaloceans, nil
@@ -118,7 +118,7 @@ func (c *Client) CreateDigitalOcean(i *CreateDigitalOceanInput) (*DigitalOcean, 
 	defer resp.Body.Close()
 
 	var digitalocean *DigitalOcean
-	if err := decodeBodyMap(resp.Body, &digitalocean); err != nil {
+	if err := DecodeBodyMap(resp.Body, &digitalocean); err != nil {
 		return nil, err
 	}
 	return digitalocean, nil
@@ -154,7 +154,7 @@ func (c *Client) GetDigitalOcean(i *GetDigitalOceanInput) (*DigitalOcean, error)
 	defer resp.Body.Close()
 
 	var digitalocean *DigitalOcean
-	if err := decodeBodyMap(resp.Body, &digitalocean); err != nil {
+	if err := DecodeBodyMap(resp.Body, &digitalocean); err != nil {
 		return nil, err
 	}
 	return digitalocean, nil
@@ -222,7 +222,7 @@ func (c *Client) UpdateDigitalOcean(i *UpdateDigitalOceanInput) (*DigitalOcean, 
 	defer resp.Body.Close()
 
 	var digitalocean *DigitalOcean
-	if err := decodeBodyMap(resp.Body, &digitalocean); err != nil {
+	if err := DecodeBodyMap(resp.Body, &digitalocean); err != nil {
 		return nil, err
 	}
 	return digitalocean, nil
@@ -258,7 +258,7 @@ func (c *Client) DeleteDigitalOcean(i *DeleteDigitalOceanInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_digitalocean_test.go
+++ b/fastly/logging_digitalocean_test.go
@@ -9,15 +9,15 @@ func TestClient_DigitalOceans(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "digitaloceans/version", func(c *Client) {
+	Record(t, "digitaloceans/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var digitaloceanCreateResp1, digitaloceanCreateResp2, digitaloceanCreateResp3 *DigitalOcean
-	record(t, "digitaloceans/create", func(c *Client) {
+	Record(t, "digitaloceans/create", func(c *Client) {
 		digitaloceanCreateResp1, err = c.CreateDigitalOcean(&CreateDigitalOceanInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-digitalocean"),
 			BucketName:       ToPointer("bucket-name"),
@@ -39,9 +39,9 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "digitaloceans/create2", func(c *Client) {
+	Record(t, "digitaloceans/create2", func(c *Client) {
 		digitaloceanCreateResp2, err = c.CreateDigitalOcean(&CreateDigitalOceanInput{
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-digitalocean-2"),
 			BucketName:      ToPointer("bucket-name"),
@@ -63,9 +63,9 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "digitaloceans/create3", func(c *Client) {
+	Record(t, "digitaloceans/create3", func(c *Client) {
 		digitaloceanCreateResp3, err = c.CreateDigitalOcean(&CreateDigitalOceanInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-digitalocean-3"),
 			BucketName:       ToPointer("bucket-name"),
@@ -89,9 +89,9 @@ func TestClient_DigitalOceans(t *testing.T) {
 
 	// This case is expected to fail because both CompressionCodec and
 	// GzipLevel are present.
-	record(t, "digitaloceans/create4", func(c *Client) {
+	Record(t, "digitaloceans/create4", func(c *Client) {
 		_, err = c.CreateDigitalOcean(&CreateDigitalOceanInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-digitalocean-4"),
 			BucketName:       ToPointer("bucket-name"),
@@ -116,27 +116,27 @@ func TestClient_DigitalOceans(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "digitaloceans/cleanup", func(c *Client) {
+		Record(t, "digitaloceans/cleanup", func(c *Client) {
 			_ = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-digitalocean",
 			})
 
 			_ = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-digitalocean-2",
 			})
 
 			_ = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-digitalocean-3",
 			})
 
 			_ = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-digitalocean",
 			})
@@ -200,9 +200,9 @@ func TestClient_DigitalOceans(t *testing.T) {
 
 	// List
 	var digitaloceans []*DigitalOcean
-	record(t, "digitaloceans/list", func(c *Client) {
+	Record(t, "digitaloceans/list", func(c *Client) {
 		digitaloceans, err = c.ListDigitalOceans(&ListDigitalOceansInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -215,9 +215,9 @@ func TestClient_DigitalOceans(t *testing.T) {
 
 	// Get
 	var digitaloceanGetResp *DigitalOcean
-	record(t, "digitaloceans/get", func(c *Client) {
+	Record(t, "digitaloceans/get", func(c *Client) {
 		digitaloceanGetResp, err = c.GetDigitalOcean(&GetDigitalOceanInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-digitalocean",
 		})
@@ -270,9 +270,9 @@ func TestClient_DigitalOceans(t *testing.T) {
 
 	// Update
 	var digitaloceanUpdateResp1, digitaloceanUpdateResp2, digitaloceanUpdateResp3 *DigitalOcean
-	record(t, "digitaloceans/update", func(c *Client) {
+	Record(t, "digitaloceans/update", func(c *Client) {
 		digitaloceanUpdateResp1, err = c.UpdateDigitalOcean(&UpdateDigitalOceanInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-digitalocean",
 			NewName:          ToPointer("new-test-digitalocean"),
@@ -284,9 +284,9 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "digitaloceans/update2", func(c *Client) {
+	Record(t, "digitaloceans/update2", func(c *Client) {
 		digitaloceanUpdateResp2, err = c.UpdateDigitalOcean(&UpdateDigitalOceanInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-digitalocean-2",
 			CompressionCodec: ToPointer("zstd"),
@@ -296,9 +296,9 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "digitaloceans/update3", func(c *Client) {
+	Record(t, "digitaloceans/update3", func(c *Client) {
 		digitaloceanUpdateResp3, err = c.UpdateDigitalOcean(&UpdateDigitalOceanInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-digitalocean-3",
 			GzipLevel:      ToPointer(9),
@@ -334,9 +334,9 @@ func TestClient_DigitalOceans(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "digitaloceans/delete", func(c *Client) {
+	Record(t, "digitaloceans/delete", func(c *Client) {
 		err = c.DeleteDigitalOcean(&DeleteDigitalOceanInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-digitalocean",
 		})
@@ -348,14 +348,14 @@ func TestClient_DigitalOceans(t *testing.T) {
 
 func TestClient_ListDigitalOceans_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListDigitalOceans(&ListDigitalOceansInput{
+	_, err = TestClient.ListDigitalOceans(&ListDigitalOceansInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListDigitalOceans(&ListDigitalOceansInput{
+	_, err = TestClient.ListDigitalOceans(&ListDigitalOceansInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -366,14 +366,14 @@ func TestClient_ListDigitalOceans_validation(t *testing.T) {
 
 func TestClient_CreateDigitalOcean_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateDigitalOcean(&CreateDigitalOceanInput{
+	_, err = TestClient.CreateDigitalOcean(&CreateDigitalOceanInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateDigitalOcean(&CreateDigitalOceanInput{
+	_, err = TestClient.CreateDigitalOcean(&CreateDigitalOceanInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -385,7 +385,7 @@ func TestClient_CreateDigitalOcean_validation(t *testing.T) {
 func TestClient_GetDigitalOcean_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetDigitalOcean(&GetDigitalOceanInput{
+	_, err = TestClient.GetDigitalOcean(&GetDigitalOceanInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -393,7 +393,7 @@ func TestClient_GetDigitalOcean_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDigitalOcean(&GetDigitalOceanInput{
+	_, err = TestClient.GetDigitalOcean(&GetDigitalOceanInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -401,7 +401,7 @@ func TestClient_GetDigitalOcean_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetDigitalOcean(&GetDigitalOceanInput{
+	_, err = TestClient.GetDigitalOcean(&GetDigitalOceanInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -413,7 +413,7 @@ func TestClient_GetDigitalOcean_validation(t *testing.T) {
 func TestClient_UpdateDigitalOcean_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateDigitalOcean(&UpdateDigitalOceanInput{
+	_, err = TestClient.UpdateDigitalOcean(&UpdateDigitalOceanInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -421,7 +421,7 @@ func TestClient_UpdateDigitalOcean_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDigitalOcean(&UpdateDigitalOceanInput{
+	_, err = TestClient.UpdateDigitalOcean(&UpdateDigitalOceanInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -429,7 +429,7 @@ func TestClient_UpdateDigitalOcean_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateDigitalOcean(&UpdateDigitalOceanInput{
+	_, err = TestClient.UpdateDigitalOcean(&UpdateDigitalOceanInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -441,7 +441,7 @@ func TestClient_UpdateDigitalOcean_validation(t *testing.T) {
 func TestClient_DeleteDigitalOcean_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteDigitalOcean(&DeleteDigitalOceanInput{
+	err = TestClient.DeleteDigitalOcean(&DeleteDigitalOceanInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -449,7 +449,7 @@ func TestClient_DeleteDigitalOcean_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDigitalOcean(&DeleteDigitalOceanInput{
+	err = TestClient.DeleteDigitalOcean(&DeleteDigitalOceanInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -457,7 +457,7 @@ func TestClient_DeleteDigitalOcean_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteDigitalOcean(&DeleteDigitalOceanInput{
+	err = TestClient.DeleteDigitalOcean(&DeleteDigitalOceanInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_elasticsearch.go
+++ b/fastly/logging_elasticsearch.go
@@ -55,7 +55,7 @@ func (c *Client) ListElasticsearch(i *ListElasticsearchInput) ([]*Elasticsearch,
 	defer resp.Body.Close()
 
 	var elasticsearch []*Elasticsearch
-	if err := decodeBodyMap(resp.Body, &elasticsearch); err != nil {
+	if err := DecodeBodyMap(resp.Body, &elasticsearch); err != nil {
 		return nil, err
 	}
 	return elasticsearch, nil
@@ -118,7 +118,7 @@ func (c *Client) CreateElasticsearch(i *CreateElasticsearchInput) (*Elasticsearc
 	defer resp.Body.Close()
 
 	var elasticsearch *Elasticsearch
-	if err := decodeBodyMap(resp.Body, &elasticsearch); err != nil {
+	if err := DecodeBodyMap(resp.Body, &elasticsearch); err != nil {
 		return nil, err
 	}
 	return elasticsearch, nil
@@ -154,7 +154,7 @@ func (c *Client) GetElasticsearch(i *GetElasticsearchInput) (*Elasticsearch, err
 	defer resp.Body.Close()
 
 	var es *Elasticsearch
-	if err := decodeBodyMap(resp.Body, &es); err != nil {
+	if err := DecodeBodyMap(resp.Body, &es); err != nil {
 		return nil, err
 	}
 
@@ -224,7 +224,7 @@ func (c *Client) UpdateElasticsearch(i *UpdateElasticsearchInput) (*Elasticsearc
 	defer resp.Body.Close()
 
 	var es *Elasticsearch
-	if err := decodeBodyMap(resp.Body, &es); err != nil {
+	if err := DecodeBodyMap(resp.Body, &es); err != nil {
 		return nil, err
 	}
 	return es, nil
@@ -261,7 +261,7 @@ func (c *Client) DeleteElasticsearch(i *DeleteElasticsearchInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_elasticsearch_test.go
+++ b/fastly/logging_elasticsearch_test.go
@@ -10,7 +10,7 @@ func TestClient_Elasticsearch(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "elasticsearch/version", func(c *Client) {
+	Record(t, "elasticsearch/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -36,9 +36,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Create
 	var es *Elasticsearch
-	record(t, "elasticsearch/create", func(c *Client) {
+	Record(t, "elasticsearch/create", func(c *Client) {
 		es, err = c.CreateElasticsearch(&CreateElasticsearchInput{
-			ServiceID:         testDeliveryServiceID,
+			ServiceID:         TestDeliveryServiceID,
 			ServiceVersion:    *tv.Number,
 			Name:              ToPointer("test-elasticsearch"),
 			Format:            ToPointer("format"),
@@ -63,16 +63,16 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// ensure deleted
 	defer func() {
-		record(t, "elasticsearch/cleanup", func(c *Client) {
+		Record(t, "elasticsearch/cleanup", func(c *Client) {
 			_ = c.DeleteElasticsearch(&DeleteElasticsearchInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-elasticsearch",
 			})
 
 			// ensure that renamed endpoint created in Update test is deleted
 			_ = c.DeleteElasticsearch(&DeleteElasticsearchInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-elasticsearch",
 			})
@@ -127,9 +127,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// List
 	var ess []*Elasticsearch
-	record(t, "elasticsearch/list", func(c *Client) {
+	Record(t, "elasticsearch/list", func(c *Client) {
 		ess, err = c.ListElasticsearch(&ListElasticsearchInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -142,9 +142,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Get
 	var nes *Elasticsearch
-	record(t, "elasticsearch/get", func(c *Client) {
+	Record(t, "elasticsearch/get", func(c *Client) {
 		nes, err = c.GetElasticsearch(&GetElasticsearchInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-elasticsearch",
 		})
@@ -200,9 +200,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Update
 	var ues *Elasticsearch
-	record(t, "elasticsearch/update", func(c *Client) {
+	Record(t, "elasticsearch/update", func(c *Client) {
 		ues, err = c.UpdateElasticsearch(&UpdateElasticsearchInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-elasticsearch",
 			NewName:        ToPointer("new-test-elasticsearch"),
@@ -220,9 +220,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	}
 
 	// Delete
-	record(t, "elasticsearch/delete", func(c *Client) {
+	Record(t, "elasticsearch/delete", func(c *Client) {
 		err = c.DeleteElasticsearch(&DeleteElasticsearchInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-elasticsearch",
 		})
@@ -234,14 +234,14 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 func TestClient_ListElasticsearch_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListElasticsearch(&ListElasticsearchInput{
+	_, err = TestClient.ListElasticsearch(&ListElasticsearchInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListElasticsearch(&ListElasticsearchInput{
+	_, err = TestClient.ListElasticsearch(&ListElasticsearchInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -252,14 +252,14 @@ func TestClient_ListElasticsearch_validation(t *testing.T) {
 
 func TestClient_CreateElasticsearch_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateElasticsearch(&CreateElasticsearchInput{
+	_, err = TestClient.CreateElasticsearch(&CreateElasticsearchInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateElasticsearch(&CreateElasticsearchInput{
+	_, err = TestClient.CreateElasticsearch(&CreateElasticsearchInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -271,7 +271,7 @@ func TestClient_CreateElasticsearch_validation(t *testing.T) {
 func TestClient_GetElasticsearch_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetElasticsearch(&GetElasticsearchInput{
+	_, err = TestClient.GetElasticsearch(&GetElasticsearchInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -279,7 +279,7 @@ func TestClient_GetElasticsearch_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetElasticsearch(&GetElasticsearchInput{
+	_, err = TestClient.GetElasticsearch(&GetElasticsearchInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -287,7 +287,7 @@ func TestClient_GetElasticsearch_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetElasticsearch(&GetElasticsearchInput{
+	_, err = TestClient.GetElasticsearch(&GetElasticsearchInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -299,7 +299,7 @@ func TestClient_GetElasticsearch_validation(t *testing.T) {
 func TestClient_UpdateElasticsearch_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateElasticsearch(&UpdateElasticsearchInput{
+	_, err = TestClient.UpdateElasticsearch(&UpdateElasticsearchInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -307,7 +307,7 @@ func TestClient_UpdateElasticsearch_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateElasticsearch(&UpdateElasticsearchInput{
+	_, err = TestClient.UpdateElasticsearch(&UpdateElasticsearchInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -315,7 +315,7 @@ func TestClient_UpdateElasticsearch_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateElasticsearch(&UpdateElasticsearchInput{
+	_, err = TestClient.UpdateElasticsearch(&UpdateElasticsearchInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -327,7 +327,7 @@ func TestClient_UpdateElasticsearch_validation(t *testing.T) {
 func TestClient_DeleteElasticsearch_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteElasticsearch(&DeleteElasticsearchInput{
+	err = TestClient.DeleteElasticsearch(&DeleteElasticsearchInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -335,7 +335,7 @@ func TestClient_DeleteElasticsearch_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteElasticsearch(&DeleteElasticsearchInput{
+	err = TestClient.DeleteElasticsearch(&DeleteElasticsearchInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -343,7 +343,7 @@ func TestClient_DeleteElasticsearch_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteElasticsearch(&DeleteElasticsearchInput{
+	err = TestClient.DeleteElasticsearch(&DeleteElasticsearchInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_ftp.go
+++ b/fastly/logging_ftp.go
@@ -55,7 +55,7 @@ func (c *Client) ListFTPs(i *ListFTPsInput) ([]*FTP, error) {
 	defer resp.Body.Close()
 
 	var ftps []*FTP
-	if err := decodeBodyMap(resp.Body, &ftps); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ftps); err != nil {
 		return nil, err
 	}
 	return ftps, nil
@@ -118,7 +118,7 @@ func (c *Client) CreateFTP(i *CreateFTPInput) (*FTP, error) {
 	defer resp.Body.Close()
 
 	var ftp *FTP
-	if err := decodeBodyMap(resp.Body, &ftp); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ftp); err != nil {
 		return nil, err
 	}
 	return ftp, nil
@@ -154,7 +154,7 @@ func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
 	defer resp.Body.Close()
 
 	var b *FTP
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -222,7 +222,7 @@ func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
 	defer resp.Body.Close()
 
 	var b *FTP
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -258,7 +258,7 @@ func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_ftp_test.go
+++ b/fastly/logging_ftp_test.go
@@ -9,14 +9,14 @@ func TestClient_FTPs(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "ftps/version", func(c *Client) {
+	Record(t, "ftps/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 	// Create
 	var ftpCreateResp1, ftpCreateResp2, ftpCreateResp3 *FTP
-	record(t, "ftps/create", func(c *Client) {
+	Record(t, "ftps/create", func(c *Client) {
 		ftpCreateResp1, err = c.CreateFTP(&CreateFTPInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-ftp"),
 			Address:          ToPointer("example.com"),
@@ -38,9 +38,9 @@ func TestClient_FTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "ftps/create2", func(c *Client) {
+	Record(t, "ftps/create2", func(c *Client) {
 		ftpCreateResp2, err = c.CreateFTP(&CreateFTPInput{
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-ftp-2"),
 			Address:         ToPointer("example.com"),
@@ -62,9 +62,9 @@ func TestClient_FTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "ftps/create3", func(c *Client) {
+	Record(t, "ftps/create3", func(c *Client) {
 		ftpCreateResp3, err = c.CreateFTP(&CreateFTPInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-ftp-3"),
 			Address:          ToPointer("example.com"),
@@ -88,9 +88,9 @@ func TestClient_FTPs(t *testing.T) {
 
 	// This case is expected to fail because both CompressionCodec and
 	// GzipLevel are present.
-	record(t, "ftps/create4", func(c *Client) {
+	Record(t, "ftps/create4", func(c *Client) {
 		_, err = c.CreateFTP(&CreateFTPInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-ftp-4"),
 			Address:          ToPointer("example.com"),
@@ -115,27 +115,27 @@ func TestClient_FTPs(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "ftps/cleanup", func(c *Client) {
+		Record(t, "ftps/cleanup", func(c *Client) {
 			_ = c.DeleteFTP(&DeleteFTPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-ftp",
 			})
 
 			_ = c.DeleteFTP(&DeleteFTPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-ftp-2",
 			})
 
 			_ = c.DeleteFTP(&DeleteFTPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-ftp-3",
 			})
 
 			_ = c.DeleteFTP(&DeleteFTPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-ftp",
 			})
@@ -202,9 +202,9 @@ func TestClient_FTPs(t *testing.T) {
 
 	// List
 	var ftps []*FTP
-	record(t, "ftps/list", func(c *Client) {
+	Record(t, "ftps/list", func(c *Client) {
 		ftps, err = c.ListFTPs(&ListFTPsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -217,9 +217,9 @@ func TestClient_FTPs(t *testing.T) {
 
 	// Get
 	var ftpGetResp *FTP
-	record(t, "ftps/get", func(c *Client) {
+	Record(t, "ftps/get", func(c *Client) {
 		ftpGetResp, err = c.GetFTP(&GetFTPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-ftp",
 		})
@@ -275,9 +275,9 @@ func TestClient_FTPs(t *testing.T) {
 
 	// Update
 	var ftpUpdateResp1, ftpUpdateResp2, ftpUpdateResp3 *FTP
-	record(t, "ftps/update", func(c *Client) {
+	Record(t, "ftps/update", func(c *Client) {
 		ftpUpdateResp1, err = c.UpdateFTP(&UpdateFTPInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-ftp",
 			NewName:          ToPointer("new-test-ftp"),
@@ -288,9 +288,9 @@ func TestClient_FTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "ftps/update2", func(c *Client) {
+	Record(t, "ftps/update2", func(c *Client) {
 		ftpUpdateResp2, err = c.UpdateFTP(&UpdateFTPInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-ftp-2",
 			CompressionCodec: ToPointer("zstd"),
@@ -300,9 +300,9 @@ func TestClient_FTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "ftps/update3", func(c *Client) {
+	Record(t, "ftps/update3", func(c *Client) {
 		ftpUpdateResp3, err = c.UpdateFTP(&UpdateFTPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-ftp-3",
 			GzipLevel:      ToPointer(9),
@@ -335,9 +335,9 @@ func TestClient_FTPs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "ftps/delete", func(c *Client) {
+	Record(t, "ftps/delete", func(c *Client) {
 		err = c.DeleteFTP(&DeleteFTPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-ftp",
 		})
@@ -350,14 +350,14 @@ func TestClient_FTPs(t *testing.T) {
 func TestClient_ListFTPs_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListFTPs(&ListFTPsInput{
+	_, err = TestClient.ListFTPs(&ListFTPsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListFTPs(&ListFTPsInput{
+	_, err = TestClient.ListFTPs(&ListFTPsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -369,14 +369,14 @@ func TestClient_ListFTPs_validation(t *testing.T) {
 func TestClient_CreateFTP_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateFTP(&CreateFTPInput{
+	_, err = TestClient.CreateFTP(&CreateFTPInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateFTP(&CreateFTPInput{
+	_, err = TestClient.CreateFTP(&CreateFTPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -388,7 +388,7 @@ func TestClient_CreateFTP_validation(t *testing.T) {
 func TestClient_GetFTP_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetFTP(&GetFTPInput{
+	_, err = TestClient.GetFTP(&GetFTPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -396,7 +396,7 @@ func TestClient_GetFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetFTP(&GetFTPInput{
+	_, err = TestClient.GetFTP(&GetFTPInput{
 		ServiceVersion: 1,
 		Name:           "test",
 	})
@@ -404,7 +404,7 @@ func TestClient_GetFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetFTP(&GetFTPInput{
+	_, err = TestClient.GetFTP(&GetFTPInput{
 		ServiceID: "foo",
 		Name:      "test",
 	})
@@ -416,7 +416,7 @@ func TestClient_GetFTP_validation(t *testing.T) {
 func TestClient_UpdateFTP_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateFTP(&UpdateFTPInput{
+	_, err = TestClient.UpdateFTP(&UpdateFTPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -424,7 +424,7 @@ func TestClient_UpdateFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateFTP(&UpdateFTPInput{
+	_, err = TestClient.UpdateFTP(&UpdateFTPInput{
 		ServiceVersion: 1,
 		Name:           "test",
 	})
@@ -432,7 +432,7 @@ func TestClient_UpdateFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateFTP(&UpdateFTPInput{
+	_, err = TestClient.UpdateFTP(&UpdateFTPInput{
 		ServiceID: "foo",
 		Name:      "test",
 	})
@@ -444,7 +444,7 @@ func TestClient_UpdateFTP_validation(t *testing.T) {
 func TestClient_DeleteFTP_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteFTP(&DeleteFTPInput{
+	err = TestClient.DeleteFTP(&DeleteFTPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -452,7 +452,7 @@ func TestClient_DeleteFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteFTP(&DeleteFTPInput{
+	err = TestClient.DeleteFTP(&DeleteFTPInput{
 		ServiceVersion: 1,
 		Name:           "test",
 	})
@@ -460,7 +460,7 @@ func TestClient_DeleteFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteFTP(&DeleteFTPInput{
+	err = TestClient.DeleteFTP(&DeleteFTPInput{
 		ServiceID: "foo",
 		Name:      "test",
 	})

--- a/fastly/logging_gcs.go
+++ b/fastly/logging_gcs.go
@@ -55,7 +55,7 @@ func (c *Client) ListGCSs(i *ListGCSsInput) ([]*GCS, error) {
 	defer resp.Body.Close()
 
 	var gcses []*GCS
-	if err := decodeBodyMap(resp.Body, &gcses); err != nil {
+	if err := DecodeBodyMap(resp.Body, &gcses); err != nil {
 		return nil, err
 	}
 	return gcses, nil
@@ -118,7 +118,7 @@ func (c *Client) CreateGCS(i *CreateGCSInput) (*GCS, error) {
 	defer resp.Body.Close()
 
 	var gcs *GCS
-	if err := decodeBodyMap(resp.Body, &gcs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &gcs); err != nil {
 		return nil, err
 	}
 	return gcs, nil
@@ -154,7 +154,7 @@ func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
 	defer resp.Body.Close()
 
 	var b *GCS
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -222,7 +222,7 @@ func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
 	defer resp.Body.Close()
 
 	var b *GCS
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -258,7 +258,7 @@ func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_gcs_test.go
+++ b/fastly/logging_gcs_test.go
@@ -9,15 +9,15 @@ func TestClient_GCSs(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "gcses/version", func(c *Client) {
+	Record(t, "gcses/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var gcsCreateResp1, gcsCreateResp2, gcsCreateResp3 *GCS
-	record(t, "gcses/create", func(c *Client) {
+	Record(t, "gcses/create", func(c *Client) {
 		gcsCreateResp1, err = c.CreateGCS(&CreateGCSInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-gcs"),
 			ProjectID:        ToPointer("logging-project"),
@@ -39,9 +39,9 @@ func TestClient_GCSs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "gcses/create2", func(c *Client) {
+	Record(t, "gcses/create2", func(c *Client) {
 		gcsCreateResp2, err = c.CreateGCS(&CreateGCSInput{
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-gcs-2"),
 			ProjectID:       ToPointer("logging-project"),
@@ -62,9 +62,9 @@ func TestClient_GCSs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "gcses/create3", func(c *Client) {
+	Record(t, "gcses/create3", func(c *Client) {
 		gcsCreateResp3, err = c.CreateGCS(&CreateGCSInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-gcs-3"),
 			ProjectID:        ToPointer("logging-project"),
@@ -87,9 +87,9 @@ func TestClient_GCSs(t *testing.T) {
 
 	// This case is expected to fail because both CompressionCodec and
 	// GzipLevel are present.
-	record(t, "gcses/create4", func(c *Client) {
+	Record(t, "gcses/create4", func(c *Client) {
 		_, err = c.CreateGCS(&CreateGCSInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-gcs-4"),
 			ProjectID:        ToPointer("logging-project"),
@@ -113,27 +113,27 @@ func TestClient_GCSs(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "gcses/cleanup", func(c *Client) {
+		Record(t, "gcses/cleanup", func(c *Client) {
 			_ = c.DeleteGCS(&DeleteGCSInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-gcs",
 			})
 
 			_ = c.DeleteGCS(&DeleteGCSInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-gcs-2",
 			})
 
 			_ = c.DeleteGCS(&DeleteGCSInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-gcs-3",
 			})
 
 			_ = c.DeleteGCS(&DeleteGCSInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-gcs",
 			})
@@ -200,9 +200,9 @@ func TestClient_GCSs(t *testing.T) {
 
 	// List
 	var gcses []*GCS
-	record(t, "gcses/list", func(c *Client) {
+	Record(t, "gcses/list", func(c *Client) {
 		gcses, err = c.ListGCSs(&ListGCSsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -215,9 +215,9 @@ func TestClient_GCSs(t *testing.T) {
 
 	// Get
 	var gcsGetResp *GCS
-	record(t, "gcses/get", func(c *Client) {
+	Record(t, "gcses/get", func(c *Client) {
 		gcsGetResp, err = c.GetGCS(&GetGCSInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-gcs",
 		})
@@ -270,9 +270,9 @@ func TestClient_GCSs(t *testing.T) {
 
 	// Update
 	var gcsUpdateResp1, gcsUpdateResp2, gcsUpdateResp3 *GCS
-	record(t, "gcses/update", func(c *Client) {
+	Record(t, "gcses/update", func(c *Client) {
 		gcsUpdateResp1, err = c.UpdateGCS(&UpdateGCSInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-gcs",
 			NewName:        ToPointer("new-test-gcs"),
@@ -284,9 +284,9 @@ func TestClient_GCSs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "gcses/update2", func(c *Client) {
+	Record(t, "gcses/update2", func(c *Client) {
 		gcsUpdateResp2, err = c.UpdateGCS(&UpdateGCSInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-gcs-2",
 			CompressionCodec: ToPointer("zstd"),
@@ -296,9 +296,9 @@ func TestClient_GCSs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "gcses/update3", func(c *Client) {
+	Record(t, "gcses/update3", func(c *Client) {
 		gcsUpdateResp3, err = c.UpdateGCS(&UpdateGCSInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-gcs-3",
 			GzipLevel:      ToPointer(9),
@@ -334,9 +334,9 @@ func TestClient_GCSs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "gcses/delete", func(c *Client) {
+	Record(t, "gcses/delete", func(c *Client) {
 		err = c.DeleteGCS(&DeleteGCSInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-gcs",
 		})
@@ -349,14 +349,14 @@ func TestClient_GCSs(t *testing.T) {
 func TestClient_ListGCSs_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListGCSs(&ListGCSsInput{
+	_, err = TestClient.ListGCSs(&ListGCSsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListGCSs(&ListGCSsInput{
+	_, err = TestClient.ListGCSs(&ListGCSsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -368,14 +368,14 @@ func TestClient_ListGCSs_validation(t *testing.T) {
 func TestClient_CreateGCS_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateGCS(&CreateGCSInput{
+	_, err = TestClient.CreateGCS(&CreateGCSInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateGCS(&CreateGCSInput{
+	_, err = TestClient.CreateGCS(&CreateGCSInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -387,7 +387,7 @@ func TestClient_CreateGCS_validation(t *testing.T) {
 func TestClient_GetGCS_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetGCS(&GetGCSInput{
+	_, err = TestClient.GetGCS(&GetGCSInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -395,7 +395,7 @@ func TestClient_GetGCS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetGCS(&GetGCSInput{
+	_, err = TestClient.GetGCS(&GetGCSInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -403,7 +403,7 @@ func TestClient_GetGCS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetGCS(&GetGCSInput{
+	_, err = TestClient.GetGCS(&GetGCSInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -415,7 +415,7 @@ func TestClient_GetGCS_validation(t *testing.T) {
 func TestClient_UpdateGCS_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateGCS(&UpdateGCSInput{
+	_, err = TestClient.UpdateGCS(&UpdateGCSInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -423,7 +423,7 @@ func TestClient_UpdateGCS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateGCS(&UpdateGCSInput{
+	_, err = TestClient.UpdateGCS(&UpdateGCSInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -431,7 +431,7 @@ func TestClient_UpdateGCS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateGCS(&UpdateGCSInput{
+	_, err = TestClient.UpdateGCS(&UpdateGCSInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -443,7 +443,7 @@ func TestClient_UpdateGCS_validation(t *testing.T) {
 func TestClient_DeleteGCS_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteGCS(&DeleteGCSInput{
+	err = TestClient.DeleteGCS(&DeleteGCSInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -451,7 +451,7 @@ func TestClient_DeleteGCS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteGCS(&DeleteGCSInput{
+	err = TestClient.DeleteGCS(&DeleteGCSInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -459,7 +459,7 @@ func TestClient_DeleteGCS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteGCS(&DeleteGCSInput{
+	err = TestClient.DeleteGCS(&DeleteGCSInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_grafanacloudlogs.go
+++ b/fastly/logging_grafanacloudlogs.go
@@ -50,7 +50,7 @@ func (c *Client) ListGrafanaCloudLogs(i *ListGrafanaCloudLogsInput) ([]*GrafanaC
 	defer resp.Body.Close()
 
 	var d []*GrafanaCloudLogs
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -101,7 +101,7 @@ func (c *Client) CreateGrafanaCloudLogs(i *CreateGrafanaCloudLogsInput) (*Grafan
 	defer resp.Body.Close()
 
 	var d *GrafanaCloudLogs
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -137,7 +137,7 @@ func (c *Client) GetGrafanaCloudLogs(i *GetGrafanaCloudLogsInput) (*GrafanaCloud
 	defer resp.Body.Close()
 
 	var d *GrafanaCloudLogs
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -193,7 +193,7 @@ func (c *Client) UpdateGrafanaCloudLogs(i *UpdateGrafanaCloudLogsInput) (*Grafan
 	defer resp.Body.Close()
 
 	var d *GrafanaCloudLogs
-	if err := decodeBodyMap(resp.Body, &d); err != nil {
+	if err := DecodeBodyMap(resp.Body, &d); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -229,7 +229,7 @@ func (c *Client) DeleteGrafanaCloudLogs(i *DeleteGrafanaCloudLogsInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_grafanacloudlogs_test.go
+++ b/fastly/logging_grafanacloudlogs_test.go
@@ -9,15 +9,15 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "grafanacloudlogs/version", func(c *Client) {
+	Record(t, "grafanacloudlogs/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var d *GrafanaCloudLogs
-	record(t, "grafanacloudlogs/create", func(c *Client) {
+	Record(t, "grafanacloudlogs/create", func(c *Client) {
 		d, err = c.CreateGrafanaCloudLogs(&CreateGrafanaCloudLogsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-grafanacloudlogs"),
 			URL:            ToPointer("https://test123.grafana.net"),
@@ -34,15 +34,15 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "grafanacloudlogs/delete", func(c *Client) {
+		Record(t, "grafanacloudlogs/delete", func(c *Client) {
 			_ = c.DeleteGrafanaCloudLogs(&DeleteGrafanaCloudLogsInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-grafanacloudlogs",
 			})
 
 			_ = c.DeleteGrafanaCloudLogs(&DeleteGrafanaCloudLogsInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-grafanacloudlogs",
 			})
@@ -73,9 +73,9 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 
 	// List
 	var ld []*GrafanaCloudLogs
-	record(t, "grafanacloudlogs/list", func(c *Client) {
+	Record(t, "grafanacloudlogs/list", func(c *Client) {
 		ld, err = c.ListGrafanaCloudLogs(&ListGrafanaCloudLogsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -88,9 +88,9 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 
 	// Get
 	var nd *GrafanaCloudLogs
-	record(t, "grafanacloudlogs/get", func(c *Client) {
+	Record(t, "grafanacloudlogs/get", func(c *Client) {
 		nd, err = c.GetGrafanaCloudLogs(&GetGrafanaCloudLogsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-grafanacloudlogs",
 		})
@@ -116,9 +116,9 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 
 	// Update
 	var ud *GrafanaCloudLogs
-	record(t, "grafanacloudlogs/update", func(c *Client) {
+	Record(t, "grafanacloudlogs/update", func(c *Client) {
 		ud, err = c.UpdateGrafanaCloudLogs(&UpdateGrafanaCloudLogsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-grafanacloudlogs",
 			NewName:        ToPointer("new-test-grafanacloudlogs"),
@@ -146,9 +146,9 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "grafanacloudlogs/delete", func(c *Client) {
+	Record(t, "grafanacloudlogs/delete", func(c *Client) {
 		err = c.DeleteGrafanaCloudLogs(&DeleteGrafanaCloudLogsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-grafanacloudlogs",
 		})
@@ -161,14 +161,14 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 func TestClient_ListGrafanaCloudLogs_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListGrafanaCloudLogs(&ListGrafanaCloudLogsInput{
+	_, err = TestClient.ListGrafanaCloudLogs(&ListGrafanaCloudLogsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListGrafanaCloudLogs(&ListGrafanaCloudLogsInput{
+	_, err = TestClient.ListGrafanaCloudLogs(&ListGrafanaCloudLogsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -180,14 +180,14 @@ func TestClient_ListGrafanaCloudLogs_validation(t *testing.T) {
 func TestClient_CreateGrafanaCloudLogs_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateGrafanaCloudLogs(&CreateGrafanaCloudLogsInput{
+	_, err = TestClient.CreateGrafanaCloudLogs(&CreateGrafanaCloudLogsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateGrafanaCloudLogs(&CreateGrafanaCloudLogsInput{
+	_, err = TestClient.CreateGrafanaCloudLogs(&CreateGrafanaCloudLogsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -199,7 +199,7 @@ func TestClient_CreateGrafanaCloudLogs_validation(t *testing.T) {
 func TestClient_GetGrafanaCloudLogs_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetGrafanaCloudLogs(&GetGrafanaCloudLogsInput{
+	_, err = TestClient.GetGrafanaCloudLogs(&GetGrafanaCloudLogsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -207,7 +207,7 @@ func TestClient_GetGrafanaCloudLogs_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetGrafanaCloudLogs(&GetGrafanaCloudLogsInput{
+	_, err = TestClient.GetGrafanaCloudLogs(&GetGrafanaCloudLogsInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -215,7 +215,7 @@ func TestClient_GetGrafanaCloudLogs_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetGrafanaCloudLogs(&GetGrafanaCloudLogsInput{
+	_, err = TestClient.GetGrafanaCloudLogs(&GetGrafanaCloudLogsInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -227,7 +227,7 @@ func TestClient_GetGrafanaCloudLogs_validation(t *testing.T) {
 func TestClient_UpdateGrafanaCloudLogs_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateGrafanaCloudLogs(&UpdateGrafanaCloudLogsInput{
+	_, err = TestClient.UpdateGrafanaCloudLogs(&UpdateGrafanaCloudLogsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -235,7 +235,7 @@ func TestClient_UpdateGrafanaCloudLogs_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateGrafanaCloudLogs(&UpdateGrafanaCloudLogsInput{
+	_, err = TestClient.UpdateGrafanaCloudLogs(&UpdateGrafanaCloudLogsInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -243,7 +243,7 @@ func TestClient_UpdateGrafanaCloudLogs_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateGrafanaCloudLogs(&UpdateGrafanaCloudLogsInput{
+	_, err = TestClient.UpdateGrafanaCloudLogs(&UpdateGrafanaCloudLogsInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -255,7 +255,7 @@ func TestClient_UpdateGrafanaCloudLogs_validation(t *testing.T) {
 func TestClient_DeleteGrafanaCloudLogs_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteGrafanaCloudLogs(&DeleteGrafanaCloudLogsInput{
+	err = TestClient.DeleteGrafanaCloudLogs(&DeleteGrafanaCloudLogsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -263,7 +263,7 @@ func TestClient_DeleteGrafanaCloudLogs_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteGrafanaCloudLogs(&DeleteGrafanaCloudLogsInput{
+	err = TestClient.DeleteGrafanaCloudLogs(&DeleteGrafanaCloudLogsInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -271,7 +271,7 @@ func TestClient_DeleteGrafanaCloudLogs_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteGrafanaCloudLogs(&DeleteGrafanaCloudLogsInput{
+	err = TestClient.DeleteGrafanaCloudLogs(&DeleteGrafanaCloudLogsInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_heroku.go
+++ b/fastly/logging_heroku.go
@@ -46,7 +46,7 @@ func (c *Client) ListHerokus(i *ListHerokusInput) ([]*Heroku, error) {
 	defer resp.Body.Close()
 
 	var hs []*Heroku
-	if err := decodeBodyMap(resp.Body, &hs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &hs); err != nil {
 		return nil, err
 	}
 	return hs, nil
@@ -91,7 +91,7 @@ func (c *Client) CreateHeroku(i *CreateHerokuInput) (*Heroku, error) {
 	defer resp.Body.Close()
 
 	var h *Heroku
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -127,7 +127,7 @@ func (c *Client) GetHeroku(i *GetHerokuInput) (*Heroku, error) {
 	defer resp.Body.Close()
 
 	var h *Heroku
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -177,7 +177,7 @@ func (c *Client) UpdateHeroku(i *UpdateHerokuInput) (*Heroku, error) {
 	defer resp.Body.Close()
 
 	var h *Heroku
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -213,7 +213,7 @@ func (c *Client) DeleteHeroku(i *DeleteHerokuInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_heroku_test.go
+++ b/fastly/logging_heroku_test.go
@@ -9,15 +9,15 @@ func TestClient_Herokus(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "herokus/version", func(c *Client) {
+	Record(t, "herokus/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var h *Heroku
-	record(t, "herokus/create", func(c *Client) {
+	Record(t, "herokus/create", func(c *Client) {
 		h, err = c.CreateHeroku(&CreateHerokuInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-heroku"),
 			Format:         ToPointer("%h %l %u %t \"%r\" %>s %b"),
@@ -33,15 +33,15 @@ func TestClient_Herokus(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "herokus/cleanup", func(c *Client) {
+		Record(t, "herokus/cleanup", func(c *Client) {
 			_ = c.DeleteHeroku(&DeleteHerokuInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-heroku",
 			})
 
 			_ = c.DeleteHeroku(&DeleteHerokuInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-heroku",
 			})
@@ -69,9 +69,9 @@ func TestClient_Herokus(t *testing.T) {
 
 	// List
 	var hs []*Heroku
-	record(t, "herokus/list", func(c *Client) {
+	Record(t, "herokus/list", func(c *Client) {
 		hs, err = c.ListHerokus(&ListHerokusInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -84,9 +84,9 @@ func TestClient_Herokus(t *testing.T) {
 
 	// Get
 	var nh *Heroku
-	record(t, "herokus/get", func(c *Client) {
+	Record(t, "herokus/get", func(c *Client) {
 		nh, err = c.GetHeroku(&GetHerokuInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-heroku",
 		})
@@ -115,9 +115,9 @@ func TestClient_Herokus(t *testing.T) {
 
 	// Update
 	var uh *Heroku
-	record(t, "herokus/update", func(c *Client) {
+	Record(t, "herokus/update", func(c *Client) {
 		uh, err = c.UpdateHeroku(&UpdateHerokuInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-heroku",
 			NewName:        ToPointer("new-test-heroku"),
@@ -135,9 +135,9 @@ func TestClient_Herokus(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "herokus/delete", func(c *Client) {
+	Record(t, "herokus/delete", func(c *Client) {
 		err = c.DeleteHeroku(&DeleteHerokuInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-heroku",
 		})
@@ -149,14 +149,14 @@ func TestClient_Herokus(t *testing.T) {
 
 func TestClient_ListHerokus_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListHerokus(&ListHerokusInput{
+	_, err = TestClient.ListHerokus(&ListHerokusInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListHerokus(&ListHerokusInput{
+	_, err = TestClient.ListHerokus(&ListHerokusInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -167,14 +167,14 @@ func TestClient_ListHerokus_validation(t *testing.T) {
 
 func TestClient_CreateHeroku_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateHeroku(&CreateHerokuInput{
+	_, err = TestClient.CreateHeroku(&CreateHerokuInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateHeroku(&CreateHerokuInput{
+	_, err = TestClient.CreateHeroku(&CreateHerokuInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -186,7 +186,7 @@ func TestClient_CreateHeroku_validation(t *testing.T) {
 func TestClient_GetHeroku_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetHeroku(&GetHerokuInput{
+	_, err = TestClient.GetHeroku(&GetHerokuInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -194,7 +194,7 @@ func TestClient_GetHeroku_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHeroku(&GetHerokuInput{
+	_, err = TestClient.GetHeroku(&GetHerokuInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -202,7 +202,7 @@ func TestClient_GetHeroku_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHeroku(&GetHerokuInput{
+	_, err = TestClient.GetHeroku(&GetHerokuInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -214,7 +214,7 @@ func TestClient_GetHeroku_validation(t *testing.T) {
 func TestClient_UpdateHeroku_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateHeroku(&UpdateHerokuInput{
+	_, err = TestClient.UpdateHeroku(&UpdateHerokuInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -222,7 +222,7 @@ func TestClient_UpdateHeroku_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHeroku(&UpdateHerokuInput{
+	_, err = TestClient.UpdateHeroku(&UpdateHerokuInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -230,7 +230,7 @@ func TestClient_UpdateHeroku_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHeroku(&UpdateHerokuInput{
+	_, err = TestClient.UpdateHeroku(&UpdateHerokuInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -242,7 +242,7 @@ func TestClient_UpdateHeroku_validation(t *testing.T) {
 func TestClient_DeleteHeroku_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteHeroku(&DeleteHerokuInput{
+	err = TestClient.DeleteHeroku(&DeleteHerokuInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -250,7 +250,7 @@ func TestClient_DeleteHeroku_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHeroku(&DeleteHerokuInput{
+	err = TestClient.DeleteHeroku(&DeleteHerokuInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -258,7 +258,7 @@ func TestClient_DeleteHeroku_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHeroku(&DeleteHerokuInput{
+	err = TestClient.DeleteHeroku(&DeleteHerokuInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_honeycomb.go
+++ b/fastly/logging_honeycomb.go
@@ -46,7 +46,7 @@ func (c *Client) ListHoneycombs(i *ListHoneycombsInput) ([]*Honeycomb, error) {
 	defer resp.Body.Close()
 
 	var hs []*Honeycomb
-	if err := decodeBodyMap(resp.Body, &hs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &hs); err != nil {
 		return nil, err
 	}
 	return hs, nil
@@ -91,7 +91,7 @@ func (c *Client) CreateHoneycomb(i *CreateHoneycombInput) (*Honeycomb, error) {
 	defer resp.Body.Close()
 
 	var h *Honeycomb
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -127,7 +127,7 @@ func (c *Client) GetHoneycomb(i *GetHoneycombInput) (*Honeycomb, error) {
 	defer resp.Body.Close()
 
 	var h *Honeycomb
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -177,7 +177,7 @@ func (c *Client) UpdateHoneycomb(i *UpdateHoneycombInput) (*Honeycomb, error) {
 	defer resp.Body.Close()
 
 	var h *Honeycomb
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -213,7 +213,7 @@ func (c *Client) DeleteHoneycomb(i *DeleteHoneycombInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_honeycomb_test.go
+++ b/fastly/logging_honeycomb_test.go
@@ -9,15 +9,15 @@ func TestClient_Honeycombs(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "honeycombs/version", func(c *Client) {
+	Record(t, "honeycombs/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var h *Honeycomb
-	record(t, "honeycombs/create", func(c *Client) {
+	Record(t, "honeycombs/create", func(c *Client) {
 		h, err = c.CreateHoneycomb(&CreateHoneycombInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-honeycomb"),
 			Format:         ToPointer("%h %l %u %t \"%r\" %>s %b"),
@@ -33,15 +33,15 @@ func TestClient_Honeycombs(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "honeycombs/cleanup", func(c *Client) {
+		Record(t, "honeycombs/cleanup", func(c *Client) {
 			_ = c.DeleteHoneycomb(&DeleteHoneycombInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-honeycomb",
 			})
 
 			_ = c.DeleteHoneycomb(&DeleteHoneycombInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-honeycomb",
 			})
@@ -69,9 +69,9 @@ func TestClient_Honeycombs(t *testing.T) {
 
 	// List
 	var hs []*Honeycomb
-	record(t, "honeycombs/list", func(c *Client) {
+	Record(t, "honeycombs/list", func(c *Client) {
 		hs, err = c.ListHoneycombs(&ListHoneycombsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -84,9 +84,9 @@ func TestClient_Honeycombs(t *testing.T) {
 
 	// Get
 	var nh *Honeycomb
-	record(t, "honeycombs/get", func(c *Client) {
+	Record(t, "honeycombs/get", func(c *Client) {
 		nh, err = c.GetHoneycomb(&GetHoneycombInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-honeycomb",
 		})
@@ -115,9 +115,9 @@ func TestClient_Honeycombs(t *testing.T) {
 
 	// Update
 	var us *Honeycomb
-	record(t, "honeycombs/update", func(c *Client) {
+	Record(t, "honeycombs/update", func(c *Client) {
 		us, err = c.UpdateHoneycomb(&UpdateHoneycombInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-honeycomb",
 			NewName:        ToPointer("new-test-honeycomb"),
@@ -139,9 +139,9 @@ func TestClient_Honeycombs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "honeycombs/delete", func(c *Client) {
+	Record(t, "honeycombs/delete", func(c *Client) {
 		err = c.DeleteHoneycomb(&DeleteHoneycombInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-honeycomb",
 		})
@@ -153,14 +153,14 @@ func TestClient_Honeycombs(t *testing.T) {
 
 func TestClient_ListHoneycombs_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListHoneycombs(&ListHoneycombsInput{
+	_, err = TestClient.ListHoneycombs(&ListHoneycombsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListHoneycombs(&ListHoneycombsInput{
+	_, err = TestClient.ListHoneycombs(&ListHoneycombsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -171,14 +171,14 @@ func TestClient_ListHoneycombs_validation(t *testing.T) {
 
 func TestClient_CreateHoneycomb_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateHoneycomb(&CreateHoneycombInput{
+	_, err = TestClient.CreateHoneycomb(&CreateHoneycombInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateHoneycomb(&CreateHoneycombInput{
+	_, err = TestClient.CreateHoneycomb(&CreateHoneycombInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -190,7 +190,7 @@ func TestClient_CreateHoneycomb_validation(t *testing.T) {
 func TestClient_GetHoneycomb_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetHoneycomb(&GetHoneycombInput{
+	_, err = TestClient.GetHoneycomb(&GetHoneycombInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -198,7 +198,7 @@ func TestClient_GetHoneycomb_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHoneycomb(&GetHoneycombInput{
+	_, err = TestClient.GetHoneycomb(&GetHoneycombInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -206,7 +206,7 @@ func TestClient_GetHoneycomb_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHoneycomb(&GetHoneycombInput{
+	_, err = TestClient.GetHoneycomb(&GetHoneycombInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -218,7 +218,7 @@ func TestClient_GetHoneycomb_validation(t *testing.T) {
 func TestClient_UpdateHoneycomb_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateHoneycomb(&UpdateHoneycombInput{
+	_, err = TestClient.UpdateHoneycomb(&UpdateHoneycombInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -226,7 +226,7 @@ func TestClient_UpdateHoneycomb_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHoneycomb(&UpdateHoneycombInput{
+	_, err = TestClient.UpdateHoneycomb(&UpdateHoneycombInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -234,7 +234,7 @@ func TestClient_UpdateHoneycomb_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHoneycomb(&UpdateHoneycombInput{
+	_, err = TestClient.UpdateHoneycomb(&UpdateHoneycombInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -246,7 +246,7 @@ func TestClient_UpdateHoneycomb_validation(t *testing.T) {
 func TestClient_DeleteHoneycomb_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteHoneycomb(&DeleteHoneycombInput{
+	err = TestClient.DeleteHoneycomb(&DeleteHoneycombInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -254,7 +254,7 @@ func TestClient_DeleteHoneycomb_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHoneycomb(&DeleteHoneycombInput{
+	err = TestClient.DeleteHoneycomb(&DeleteHoneycombInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -262,7 +262,7 @@ func TestClient_DeleteHoneycomb_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHoneycomb(&DeleteHoneycombInput{
+	err = TestClient.DeleteHoneycomb(&DeleteHoneycombInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_https.go
+++ b/fastly/logging_https.go
@@ -57,7 +57,7 @@ func (c *Client) ListHTTPS(i *ListHTTPSInput) ([]*HTTPS, error) {
 	defer resp.Body.Close()
 
 	var https []*HTTPS
-	if err := decodeBodyMap(resp.Body, &https); err != nil {
+	if err := DecodeBodyMap(resp.Body, &https); err != nil {
 		return nil, err
 	}
 	return https, nil
@@ -124,7 +124,7 @@ func (c *Client) CreateHTTPS(i *CreateHTTPSInput) (*HTTPS, error) {
 	defer resp.Body.Close()
 
 	var https *HTTPS
-	if err := decodeBodyMap(resp.Body, &https); err != nil {
+	if err := DecodeBodyMap(resp.Body, &https); err != nil {
 		return nil, err
 	}
 	return https, nil
@@ -160,7 +160,7 @@ func (c *Client) GetHTTPS(i *GetHTTPSInput) (*HTTPS, error) {
 	defer resp.Body.Close()
 
 	var h *HTTPS
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 
@@ -233,7 +233,7 @@ func (c *Client) UpdateHTTPS(i *UpdateHTTPSInput) (*HTTPS, error) {
 	defer resp.Body.Close()
 
 	var h *HTTPS
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 	return h, nil
@@ -269,7 +269,7 @@ func (c *Client) DeleteHTTPS(i *DeleteHTTPSInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_https_test.go
+++ b/fastly/logging_https_test.go
@@ -10,7 +10,7 @@ func TestClient_HTTPS(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "https/version", func(c *Client) {
+	Record(t, "https/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -36,9 +36,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Create
 	var h *HTTPS
-	record(t, "https/create", func(c *Client) {
+	Record(t, "https/create", func(c *Client) {
 		h, err = c.CreateHTTPS(&CreateHTTPSInput{
-			ServiceID:         testDeliveryServiceID,
+			ServiceID:         TestDeliveryServiceID,
 			ServiceVersion:    *tv.Number,
 			Name:              ToPointer("test-https"),
 			Format:            ToPointer("format"),
@@ -65,16 +65,16 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// ensure deleted
 	defer func() {
-		record(t, "https/cleanup", func(c *Client) {
+		Record(t, "https/cleanup", func(c *Client) {
 			_ = c.DeleteHTTPS(&DeleteHTTPSInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-https",
 			})
 
 			// ensure that renamed endpoint created in Update test is deleted
 			_ = c.DeleteHTTPS(&DeleteHTTPSInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-https",
 			})
@@ -135,9 +135,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// List
 	var hs []*HTTPS
-	record(t, "https/list", func(c *Client) {
+	Record(t, "https/list", func(c *Client) {
 		hs, err = c.ListHTTPS(&ListHTTPSInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -150,9 +150,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Get
 	var nh *HTTPS
-	record(t, "https/get", func(c *Client) {
+	Record(t, "https/get", func(c *Client) {
 		nh, err = c.GetHTTPS(&GetHTTPSInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-https",
 		})
@@ -214,9 +214,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Update
 	var uh *HTTPS
-	record(t, "https/update", func(c *Client) {
+	Record(t, "https/update", func(c *Client) {
 		uh, err = c.UpdateHTTPS(&UpdateHTTPSInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-https",
 			NewName:        ToPointer("new-test-https"),
@@ -234,9 +234,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	}
 
 	// Delete
-	record(t, "https/delete", func(c *Client) {
+	Record(t, "https/delete", func(c *Client) {
 		err = c.DeleteHTTPS(&DeleteHTTPSInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-https",
 		})
@@ -248,7 +248,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 func TestClient_ListHTTPS_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListHTTPS(&ListHTTPSInput{
+	_, err = TestClient.ListHTTPS(&ListHTTPSInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
@@ -258,14 +258,14 @@ func TestClient_ListHTTPS_validation(t *testing.T) {
 
 func TestClient_CreateHTTPS_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateHTTPS(&CreateHTTPSInput{
+	_, err = TestClient.CreateHTTPS(&CreateHTTPSInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateHTTPS(&CreateHTTPSInput{
+	_, err = TestClient.CreateHTTPS(&CreateHTTPSInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -277,7 +277,7 @@ func TestClient_CreateHTTPS_validation(t *testing.T) {
 func TestClient_GetHTTPS_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetHTTPS(&GetHTTPSInput{
+	_, err = TestClient.GetHTTPS(&GetHTTPSInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -285,7 +285,7 @@ func TestClient_GetHTTPS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHTTPS(&GetHTTPSInput{
+	_, err = TestClient.GetHTTPS(&GetHTTPSInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -293,7 +293,7 @@ func TestClient_GetHTTPS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHTTPS(&GetHTTPSInput{
+	_, err = TestClient.GetHTTPS(&GetHTTPSInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -305,7 +305,7 @@ func TestClient_GetHTTPS_validation(t *testing.T) {
 func TestClient_UpdateHTTPS_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateHTTPS(&UpdateHTTPSInput{
+	_, err = TestClient.UpdateHTTPS(&UpdateHTTPSInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -313,7 +313,7 @@ func TestClient_UpdateHTTPS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHTTPS(&UpdateHTTPSInput{
+	_, err = TestClient.UpdateHTTPS(&UpdateHTTPSInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -321,7 +321,7 @@ func TestClient_UpdateHTTPS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHTTPS(&UpdateHTTPSInput{
+	_, err = TestClient.UpdateHTTPS(&UpdateHTTPSInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -333,7 +333,7 @@ func TestClient_UpdateHTTPS_validation(t *testing.T) {
 func TestClient_DeleteHTTPS_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteHTTPS(&DeleteHTTPSInput{
+	err = TestClient.DeleteHTTPS(&DeleteHTTPSInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -341,7 +341,7 @@ func TestClient_DeleteHTTPS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHTTPS(&DeleteHTTPSInput{
+	err = TestClient.DeleteHTTPS(&DeleteHTTPSInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -349,7 +349,7 @@ func TestClient_DeleteHTTPS_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHTTPS(&DeleteHTTPSInput{
+	err = TestClient.DeleteHTTPS(&DeleteHTTPSInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_kafka.go
+++ b/fastly/logging_kafka.go
@@ -58,7 +58,7 @@ func (c *Client) ListKafkas(i *ListKafkasInput) ([]*Kafka, error) {
 	defer resp.Body.Close()
 
 	var k []*Kafka
-	if err := decodeBodyMap(resp.Body, &k); err != nil {
+	if err := DecodeBodyMap(resp.Body, &k); err != nil {
 		return nil, err
 	}
 	return k, nil
@@ -127,7 +127,7 @@ func (c *Client) CreateKafka(i *CreateKafkaInput) (*Kafka, error) {
 	defer resp.Body.Close()
 
 	var k *Kafka
-	if err := decodeBodyMap(resp.Body, &k); err != nil {
+	if err := DecodeBodyMap(resp.Body, &k); err != nil {
 		return nil, err
 	}
 	return k, nil
@@ -163,7 +163,7 @@ func (c *Client) GetKafka(i *GetKafkaInput) (*Kafka, error) {
 	defer resp.Body.Close()
 
 	var k *Kafka
-	if err := decodeBodyMap(resp.Body, &k); err != nil {
+	if err := DecodeBodyMap(resp.Body, &k); err != nil {
 		return nil, err
 	}
 	return k, nil
@@ -237,7 +237,7 @@ func (c *Client) UpdateKafka(i *UpdateKafkaInput) (*Kafka, error) {
 	defer resp.Body.Close()
 
 	var k *Kafka
-	if err := decodeBodyMap(resp.Body, &k); err != nil {
+	if err := DecodeBodyMap(resp.Body, &k); err != nil {
 		return nil, err
 	}
 	return k, nil
@@ -273,7 +273,7 @@ func (c *Client) DeleteKafka(i *DeleteKafkaInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_kafka_test.go
+++ b/fastly/logging_kafka_test.go
@@ -12,7 +12,7 @@ func TestClient_Kafkas(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "kafkas/version", func(c *Client) {
+	Record(t, "kafkas/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -22,7 +22,7 @@ func TestClient_Kafkas(t *testing.T) {
 
 	// Create
 	var k *Kafka
-	record(t, "kafkas/create", func(c *Client) {
+	Record(t, "kafkas/create", func(c *Client) {
 		k, err = c.CreateKafka(&CreateKafkaInput{
 			AuthMethod:       ToPointer("scram-sha-512"),
 			Brokers:          ToPointer("192.168.1.1,192.168.1.2"),
@@ -35,7 +35,7 @@ func TestClient_Kafkas(t *testing.T) {
 			Placement:        ToPointer("waf_debug"),
 			RequestMaxBytes:  ToPointer(requestMaxBytes),
 			RequiredACKs:     ToPointer("-1"),
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			TLSCACert:        ToPointer(caCert),
 			TLSClientCert:    ToPointer(clientCert),
@@ -52,15 +52,15 @@ func TestClient_Kafkas(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "kafkas/cleanup", func(c *Client) {
+		Record(t, "kafkas/cleanup", func(c *Client) {
 			_ = c.DeleteKafka(&DeleteKafkaInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-kafka",
 			})
 
 			_ = c.DeleteKafka(&DeleteKafkaInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-kafka",
 			})
@@ -124,9 +124,9 @@ func TestClient_Kafkas(t *testing.T) {
 
 	// List
 	var ks []*Kafka
-	record(t, "kafkas/list", func(c *Client) {
+	Record(t, "kafkas/list", func(c *Client) {
 		ks, err = c.ListKafkas(&ListKafkasInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -139,9 +139,9 @@ func TestClient_Kafkas(t *testing.T) {
 
 	// Get
 	var nk *Kafka
-	record(t, "kafkas/get", func(c *Client) {
+	Record(t, "kafkas/get", func(c *Client) {
 		nk, err = c.GetKafka(&GetKafkaInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-kafka",
 		})
@@ -206,9 +206,9 @@ func TestClient_Kafkas(t *testing.T) {
 
 	// Update
 	var uk *Kafka
-	record(t, "kafkas/update", func(c *Client) {
+	Record(t, "kafkas/update", func(c *Client) {
 		uk, err = c.UpdateKafka(&UpdateKafkaInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-kafka",
 			NewName:        ToPointer("new-test-kafka"),
@@ -226,9 +226,9 @@ func TestClient_Kafkas(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "kafkas/delete", func(c *Client) {
+	Record(t, "kafkas/delete", func(c *Client) {
 		err = c.DeleteKafka(&DeleteKafkaInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-kafka",
 		})
@@ -240,14 +240,14 @@ func TestClient_Kafkas(t *testing.T) {
 
 func TestClient_ListKafkas_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListKafkas(&ListKafkasInput{
+	_, err = TestClient.ListKafkas(&ListKafkasInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListKafkas(&ListKafkasInput{
+	_, err = TestClient.ListKafkas(&ListKafkasInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -258,14 +258,14 @@ func TestClient_ListKafkas_validation(t *testing.T) {
 
 func TestClient_CreateKafka_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateKafka(&CreateKafkaInput{
+	_, err = TestClient.CreateKafka(&CreateKafkaInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateKafka(&CreateKafkaInput{
+	_, err = TestClient.CreateKafka(&CreateKafkaInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -277,7 +277,7 @@ func TestClient_CreateKafka_validation(t *testing.T) {
 func TestClient_GetKafka_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetKafka(&GetKafkaInput{
+	_, err = TestClient.GetKafka(&GetKafkaInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -285,7 +285,7 @@ func TestClient_GetKafka_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetKafka(&GetKafkaInput{
+	_, err = TestClient.GetKafka(&GetKafkaInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -293,7 +293,7 @@ func TestClient_GetKafka_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetKafka(&GetKafkaInput{
+	_, err = TestClient.GetKafka(&GetKafkaInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -305,7 +305,7 @@ func TestClient_GetKafka_validation(t *testing.T) {
 func TestClient_UpdateKafka_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateKafka(&UpdateKafkaInput{
+	_, err = TestClient.UpdateKafka(&UpdateKafkaInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -313,7 +313,7 @@ func TestClient_UpdateKafka_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateKafka(&UpdateKafkaInput{
+	_, err = TestClient.UpdateKafka(&UpdateKafkaInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -321,7 +321,7 @@ func TestClient_UpdateKafka_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateKafka(&UpdateKafkaInput{
+	_, err = TestClient.UpdateKafka(&UpdateKafkaInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -333,7 +333,7 @@ func TestClient_UpdateKafka_validation(t *testing.T) {
 func TestClient_DeleteKafka_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteKafka(&DeleteKafkaInput{
+	err = TestClient.DeleteKafka(&DeleteKafkaInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -341,7 +341,7 @@ func TestClient_DeleteKafka_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteKafka(&DeleteKafkaInput{
+	err = TestClient.DeleteKafka(&DeleteKafkaInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -349,7 +349,7 @@ func TestClient_DeleteKafka_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteKafka(&DeleteKafkaInput{
+	err = TestClient.DeleteKafka(&DeleteKafkaInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_kinesis.go
+++ b/fastly/logging_kinesis.go
@@ -49,7 +49,7 @@ func (c *Client) ListKinesis(i *ListKinesisInput) ([]*Kinesis, error) {
 	defer resp.Body.Close()
 
 	var kineses []*Kinesis
-	if err := decodeBodyMap(resp.Body, &kineses); err != nil {
+	if err := DecodeBodyMap(resp.Body, &kineses); err != nil {
 		return nil, err
 	}
 	return kineses, nil
@@ -100,7 +100,7 @@ func (c *Client) CreateKinesis(i *CreateKinesisInput) (*Kinesis, error) {
 	defer resp.Body.Close()
 
 	var kinesis *Kinesis
-	if err := decodeBodyMap(resp.Body, &kinesis); err != nil {
+	if err := DecodeBodyMap(resp.Body, &kinesis); err != nil {
 		return nil, err
 	}
 	return kinesis, nil
@@ -136,7 +136,7 @@ func (c *Client) GetKinesis(i *GetKinesisInput) (*Kinesis, error) {
 	defer resp.Body.Close()
 
 	var kinesis *Kinesis
-	if err := decodeBodyMap(resp.Body, &kinesis); err != nil {
+	if err := DecodeBodyMap(resp.Body, &kinesis); err != nil {
 		return nil, err
 	}
 	return kinesis, nil
@@ -192,7 +192,7 @@ func (c *Client) UpdateKinesis(i *UpdateKinesisInput) (*Kinesis, error) {
 	defer resp.Body.Close()
 
 	var kinesis *Kinesis
-	if err := decodeBodyMap(resp.Body, &kinesis); err != nil {
+	if err := DecodeBodyMap(resp.Body, &kinesis); err != nil {
 		return nil, err
 	}
 	return kinesis, nil
@@ -228,7 +228,7 @@ func (c *Client) DeleteKinesis(i *DeleteKinesisInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_kinesis_test.go
+++ b/fastly/logging_kinesis_test.go
@@ -9,7 +9,7 @@ func TestClient_Kinesis(t *testing.T) {
 
 	var err error
 	var v *Version
-	record(t, "kinesis/version", func(c *Client) {
+	Record(t, "kinesis/version", func(c *Client) {
 		v = testVersion(t, c)
 	})
 
@@ -17,9 +17,9 @@ func TestClient_Kinesis(t *testing.T) {
 	//
 	// NOTE: You can't send the API and empty ResponseCondition.
 	var kinesisCreateResp1, kinesisCreateResp2 *Kinesis
-	record(t, "kinesis/create", func(c *Client) {
+	Record(t, "kinesis/create", func(c *Client) {
 		kinesisCreateResp1, err = c.CreateKinesis(&CreateKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           ToPointer("test-kinesis"),
 			StreamName:     ToPointer("stream-name"),
@@ -35,9 +35,9 @@ func TestClient_Kinesis(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "kinesis/create2", func(c *Client) {
+	Record(t, "kinesis/create2", func(c *Client) {
 		kinesisCreateResp2, err = c.CreateKinesis(&CreateKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           ToPointer("test-kinesis-2"),
 			StreamName:     ToPointer("stream-name"),
@@ -53,9 +53,9 @@ func TestClient_Kinesis(t *testing.T) {
 	}
 
 	// This case is expected to fail
-	record(t, "kinesis/create3", func(c *Client) {
+	Record(t, "kinesis/create3", func(c *Client) {
 		_, err = c.CreateKinesis(&CreateKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           ToPointer("test-kinesis-3"),
 			StreamName:     ToPointer("stream-name"),
@@ -73,9 +73,9 @@ func TestClient_Kinesis(t *testing.T) {
 	}
 
 	// This case is expected to fail
-	record(t, "kinesis/create4", func(c *Client) {
+	Record(t, "kinesis/create4", func(c *Client) {
 		_, err = c.CreateKinesis(&CreateKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           ToPointer("test-kinesis-3"),
 			StreamName:     ToPointer("stream-name"),
@@ -92,21 +92,21 @@ func TestClient_Kinesis(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "kinesis/cleanup", func(c *Client) {
+		Record(t, "kinesis/cleanup", func(c *Client) {
 			_ = c.DeleteKinesis(&DeleteKinesisInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *v.Number,
 				Name:           "test-kinesis",
 			})
 
 			_ = c.DeleteKinesis(&DeleteKinesisInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *v.Number,
 				Name:           "test-kinesis-2",
 			})
 
 			_ = c.DeleteKinesis(&DeleteKinesisInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *v.Number,
 				Name:           "new-test-kinesis",
 			})
@@ -155,9 +155,9 @@ func TestClient_Kinesis(t *testing.T) {
 
 	// List
 	var kineses []*Kinesis
-	record(t, "kinesis/list", func(c *Client) {
+	Record(t, "kinesis/list", func(c *Client) {
 		kineses, err = c.ListKinesis(&ListKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 		})
 	})
@@ -170,9 +170,9 @@ func TestClient_Kinesis(t *testing.T) {
 
 	// Get
 	var kinesisGetResp, kinesisGetResp2 *Kinesis
-	record(t, "kinesis/get", func(c *Client) {
+	Record(t, "kinesis/get", func(c *Client) {
 		kinesisGetResp, err = c.GetKinesis(&GetKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           "test-kinesis",
 		})
@@ -181,9 +181,9 @@ func TestClient_Kinesis(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "kinesis/get2", func(c *Client) {
+	Record(t, "kinesis/get2", func(c *Client) {
 		kinesisGetResp2, err = c.GetKinesis(&GetKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           "test-kinesis-2",
 		})
@@ -240,9 +240,9 @@ func TestClient_Kinesis(t *testing.T) {
 
 	// Update
 	var kinesisUpdateResp1, kinesisUpdateResp2, kinesisUpdateResp3 *Kinesis
-	record(t, "kinesis/update", func(c *Client) {
+	Record(t, "kinesis/update", func(c *Client) {
 		kinesisUpdateResp1, err = c.UpdateKinesis(&UpdateKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           "test-kinesis",
 			NewName:        ToPointer("new-test-kinesis"),
@@ -254,9 +254,9 @@ func TestClient_Kinesis(t *testing.T) {
 
 	// Test that a configuration using an access key/secret key can be
 	// updated to use IAM role.
-	record(t, "kinesis/update2", func(c *Client) {
+	Record(t, "kinesis/update2", func(c *Client) {
 		kinesisUpdateResp2, err = c.UpdateKinesis(&UpdateKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           "new-test-kinesis",
 			AccessKey:      ToPointer(""),
@@ -270,9 +270,9 @@ func TestClient_Kinesis(t *testing.T) {
 
 	// Test that a configuration using an IAM role can be updated to use
 	// access key/secret key.
-	record(t, "kinesis/update3", func(c *Client) {
+	Record(t, "kinesis/update3", func(c *Client) {
 		kinesisUpdateResp3, err = c.UpdateKinesis(&UpdateKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           "test-kinesis-2",
 			AccessKey:      ToPointer("AKIAIOSFODNN7EXAMPLE"),
@@ -286,9 +286,9 @@ func TestClient_Kinesis(t *testing.T) {
 
 	// Test that an invalid IAM role ARN is rejected. This case is expected
 	// to fail.
-	record(t, "kinesis/update4", func(c *Client) {
+	Record(t, "kinesis/update4", func(c *Client) {
 		_, err = c.UpdateKinesis(&UpdateKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           "test-kinesis",
 			IAMRole:        ToPointer("badarn"),
@@ -321,9 +321,9 @@ func TestClient_Kinesis(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "kinesis/delete", func(c *Client) {
+	Record(t, "kinesis/delete", func(c *Client) {
 		err = c.DeleteKinesis(&DeleteKinesisInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Name:           "new-test-kinesis",
 		})
@@ -335,14 +335,14 @@ func TestClient_Kinesis(t *testing.T) {
 
 func TestClient_ListKinesis_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListKinesis(&ListKinesisInput{
+	_, err = TestClient.ListKinesis(&ListKinesisInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListKinesis(&ListKinesisInput{
+	_, err = TestClient.ListKinesis(&ListKinesisInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -353,14 +353,14 @@ func TestClient_ListKinesis_validation(t *testing.T) {
 
 func TestClient_CreateKinesis_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateKinesis(&CreateKinesisInput{
+	_, err = TestClient.CreateKinesis(&CreateKinesisInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateKinesis(&CreateKinesisInput{
+	_, err = TestClient.CreateKinesis(&CreateKinesisInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -372,7 +372,7 @@ func TestClient_CreateKinesis_validation(t *testing.T) {
 func TestClient_GetKinesis_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetKinesis(&GetKinesisInput{
+	_, err = TestClient.GetKinesis(&GetKinesisInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -380,7 +380,7 @@ func TestClient_GetKinesis_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetKinesis(&GetKinesisInput{
+	_, err = TestClient.GetKinesis(&GetKinesisInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -388,7 +388,7 @@ func TestClient_GetKinesis_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetKinesis(&GetKinesisInput{
+	_, err = TestClient.GetKinesis(&GetKinesisInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -400,7 +400,7 @@ func TestClient_GetKinesis_validation(t *testing.T) {
 func TestClient_UpdateKinesis_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateKinesis(&UpdateKinesisInput{
+	_, err = TestClient.UpdateKinesis(&UpdateKinesisInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -408,7 +408,7 @@ func TestClient_UpdateKinesis_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateKinesis(&UpdateKinesisInput{
+	_, err = TestClient.UpdateKinesis(&UpdateKinesisInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -416,7 +416,7 @@ func TestClient_UpdateKinesis_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateKinesis(&UpdateKinesisInput{
+	_, err = TestClient.UpdateKinesis(&UpdateKinesisInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -428,7 +428,7 @@ func TestClient_UpdateKinesis_validation(t *testing.T) {
 func TestClient_DeleteKinesis_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteKinesis(&DeleteKinesisInput{
+	err = TestClient.DeleteKinesis(&DeleteKinesisInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -436,7 +436,7 @@ func TestClient_DeleteKinesis_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteKinesis(&DeleteKinesisInput{
+	err = TestClient.DeleteKinesis(&DeleteKinesisInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -444,7 +444,7 @@ func TestClient_DeleteKinesis_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteKinesis(&DeleteKinesisInput{
+	err = TestClient.DeleteKinesis(&DeleteKinesisInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_logentries.go
+++ b/fastly/logging_logentries.go
@@ -48,7 +48,7 @@ func (c *Client) ListLogentries(i *ListLogentriesInput) ([]*Logentries, error) {
 	defer resp.Body.Close()
 
 	var ls []*Logentries
-	if err := decodeBodyMap(resp.Body, &ls); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ls); err != nil {
 		return nil, err
 	}
 	return ls, nil
@@ -97,7 +97,7 @@ func (c *Client) CreateLogentries(i *CreateLogentriesInput) (*Logentries, error)
 	defer resp.Body.Close()
 
 	var l *Logentries
-	if err := decodeBodyMap(resp.Body, &l); err != nil {
+	if err := DecodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -133,7 +133,7 @@ func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
 	defer resp.Body.Close()
 
 	var l *Logentries
-	if err := decodeBodyMap(resp.Body, &l); err != nil {
+	if err := DecodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -187,7 +187,7 @@ func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error)
 	defer resp.Body.Close()
 
 	var l *Logentries
-	if err := decodeBodyMap(resp.Body, &l); err != nil {
+	if err := DecodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -223,7 +223,7 @@ func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_logentries_test.go
+++ b/fastly/logging_logentries_test.go
@@ -9,15 +9,15 @@ func TestClient_Logentries(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "logentries/version", func(c *Client) {
+	Record(t, "logentries/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var le *Logentries
-	record(t, "logentries/create", func(c *Client) {
+	Record(t, "logentries/create", func(c *Client) {
 		le, err = c.CreateLogentries(&CreateLogentriesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-logentries"),
 			Port:           ToPointer(0),
@@ -34,15 +34,15 @@ func TestClient_Logentries(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "logentries/delete", func(c *Client) {
+		Record(t, "logentries/delete", func(c *Client) {
 			_ = c.DeleteLogentries(&DeleteLogentriesInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-logentries",
 			})
 
 			_ = c.DeleteLogentries(&DeleteLogentriesInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-logentries",
 			})
@@ -76,9 +76,9 @@ func TestClient_Logentries(t *testing.T) {
 
 	// List
 	var les []*Logentries
-	record(t, "logentries/list", func(c *Client) {
+	Record(t, "logentries/list", func(c *Client) {
 		les, err = c.ListLogentries(&ListLogentriesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -91,9 +91,9 @@ func TestClient_Logentries(t *testing.T) {
 
 	// Get
 	var nle *Logentries
-	record(t, "logentries/get", func(c *Client) {
+	Record(t, "logentries/get", func(c *Client) {
 		nle, err = c.GetLogentries(&GetLogentriesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-logentries",
 		})
@@ -125,9 +125,9 @@ func TestClient_Logentries(t *testing.T) {
 
 	// Update
 	var ule *Logentries
-	record(t, "logentries/update", func(c *Client) {
+	Record(t, "logentries/update", func(c *Client) {
 		ule, err = c.UpdateLogentries(&UpdateLogentriesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-logentries",
 			NewName:        ToPointer("new-test-logentries"),
@@ -149,9 +149,9 @@ func TestClient_Logentries(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "logentries/delete", func(c *Client) {
+	Record(t, "logentries/delete", func(c *Client) {
 		err = c.DeleteLogentries(&DeleteLogentriesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-logentries",
 		})
@@ -163,14 +163,14 @@ func TestClient_Logentries(t *testing.T) {
 
 func TestClient_ListLogentries_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListLogentries(&ListLogentriesInput{
+	_, err = TestClient.ListLogentries(&ListLogentriesInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListLogentries(&ListLogentriesInput{
+	_, err = TestClient.ListLogentries(&ListLogentriesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -181,14 +181,14 @@ func TestClient_ListLogentries_validation(t *testing.T) {
 
 func TestClient_CreateLogentries_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateLogentries(&CreateLogentriesInput{
+	_, err = TestClient.CreateLogentries(&CreateLogentriesInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateLogentries(&CreateLogentriesInput{
+	_, err = TestClient.CreateLogentries(&CreateLogentriesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -200,7 +200,7 @@ func TestClient_CreateLogentries_validation(t *testing.T) {
 func TestClient_GetLogentries_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetLogentries(&GetLogentriesInput{
+	_, err = TestClient.GetLogentries(&GetLogentriesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -208,7 +208,7 @@ func TestClient_GetLogentries_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetLogentries(&GetLogentriesInput{
+	_, err = TestClient.GetLogentries(&GetLogentriesInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -216,7 +216,7 @@ func TestClient_GetLogentries_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetLogentries(&GetLogentriesInput{
+	_, err = TestClient.GetLogentries(&GetLogentriesInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -228,7 +228,7 @@ func TestClient_GetLogentries_validation(t *testing.T) {
 func TestClient_UpdateLogentries_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateLogentries(&UpdateLogentriesInput{
+	_, err = TestClient.UpdateLogentries(&UpdateLogentriesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -236,7 +236,7 @@ func TestClient_UpdateLogentries_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateLogentries(&UpdateLogentriesInput{
+	_, err = TestClient.UpdateLogentries(&UpdateLogentriesInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -244,7 +244,7 @@ func TestClient_UpdateLogentries_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateLogentries(&UpdateLogentriesInput{
+	_, err = TestClient.UpdateLogentries(&UpdateLogentriesInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -256,7 +256,7 @@ func TestClient_UpdateLogentries_validation(t *testing.T) {
 func TestClient_DeleteLogentries_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteLogentries(&DeleteLogentriesInput{
+	err = TestClient.DeleteLogentries(&DeleteLogentriesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -264,7 +264,7 @@ func TestClient_DeleteLogentries_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteLogentries(&DeleteLogentriesInput{
+	err = TestClient.DeleteLogentries(&DeleteLogentriesInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -272,7 +272,7 @@ func TestClient_DeleteLogentries_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteLogentries(&DeleteLogentriesInput{
+	err = TestClient.DeleteLogentries(&DeleteLogentriesInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_loggly.go
+++ b/fastly/logging_loggly.go
@@ -45,7 +45,7 @@ func (c *Client) ListLoggly(i *ListLogglyInput) ([]*Loggly, error) {
 	defer resp.Body.Close()
 
 	var ls []*Loggly
-	if err := decodeBodyMap(resp.Body, &ls); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ls); err != nil {
 		return nil, err
 	}
 	return ls, nil
@@ -88,7 +88,7 @@ func (c *Client) CreateLoggly(i *CreateLogglyInput) (*Loggly, error) {
 	defer resp.Body.Close()
 
 	var l *Loggly
-	if err := decodeBodyMap(resp.Body, &l); err != nil {
+	if err := DecodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -124,7 +124,7 @@ func (c *Client) GetLoggly(i *GetLogglyInput) (*Loggly, error) {
 	defer resp.Body.Close()
 
 	var l *Loggly
-	if err := decodeBodyMap(resp.Body, &l); err != nil {
+	if err := DecodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -172,7 +172,7 @@ func (c *Client) UpdateLoggly(i *UpdateLogglyInput) (*Loggly, error) {
 	defer resp.Body.Close()
 
 	var l *Loggly
-	if err := decodeBodyMap(resp.Body, &l); err != nil {
+	if err := DecodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -208,7 +208,7 @@ func (c *Client) DeleteLoggly(i *DeleteLogglyInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_loggly_test.go
+++ b/fastly/logging_loggly_test.go
@@ -9,15 +9,15 @@ func TestClient_Loggly(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "loggly/version", func(c *Client) {
+	Record(t, "loggly/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var lg *Loggly
-	record(t, "loggly/create", func(c *Client) {
+	Record(t, "loggly/create", func(c *Client) {
 		lg, err = c.CreateLoggly(&CreateLogglyInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-loggly"),
 			Token:          ToPointer("abcd1234"),
@@ -31,15 +31,15 @@ func TestClient_Loggly(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "loggly/delete", func(c *Client) {
+		Record(t, "loggly/delete", func(c *Client) {
 			_ = c.DeleteLoggly(&DeleteLogglyInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-loggly",
 			})
 
 			_ = c.DeleteLoggly(&DeleteLogglyInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-loggly",
 			})
@@ -64,9 +64,9 @@ func TestClient_Loggly(t *testing.T) {
 
 	// List
 	var les []*Loggly
-	record(t, "loggly/list", func(c *Client) {
+	Record(t, "loggly/list", func(c *Client) {
 		les, err = c.ListLoggly(&ListLogglyInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -79,9 +79,9 @@ func TestClient_Loggly(t *testing.T) {
 
 	// Get
 	var nlg *Loggly
-	record(t, "loggly/get", func(c *Client) {
+	Record(t, "loggly/get", func(c *Client) {
 		nlg, err = c.GetLoggly(&GetLogglyInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-loggly",
 		})
@@ -107,9 +107,9 @@ func TestClient_Loggly(t *testing.T) {
 
 	// Update
 	var ulg *Loggly
-	record(t, "loggly/update", func(c *Client) {
+	Record(t, "loggly/update", func(c *Client) {
 		ulg, err = c.UpdateLoggly(&UpdateLogglyInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-loggly",
 			NewName:        ToPointer("new-test-loggly"),
@@ -127,9 +127,9 @@ func TestClient_Loggly(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "loggly/delete", func(c *Client) {
+	Record(t, "loggly/delete", func(c *Client) {
 		err = c.DeleteLoggly(&DeleteLogglyInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-loggly",
 		})
@@ -141,14 +141,14 @@ func TestClient_Loggly(t *testing.T) {
 
 func TestClient_ListLoggly_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListLoggly(&ListLogglyInput{
+	_, err = TestClient.ListLoggly(&ListLogglyInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListLoggly(&ListLogglyInput{
+	_, err = TestClient.ListLoggly(&ListLogglyInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -159,14 +159,14 @@ func TestClient_ListLoggly_validation(t *testing.T) {
 
 func TestClient_CreateLoggly_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateLoggly(&CreateLogglyInput{
+	_, err = TestClient.CreateLoggly(&CreateLogglyInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateLoggly(&CreateLogglyInput{
+	_, err = TestClient.CreateLoggly(&CreateLogglyInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -178,7 +178,7 @@ func TestClient_CreateLoggly_validation(t *testing.T) {
 func TestClient_GetLoggly_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetLoggly(&GetLogglyInput{
+	_, err = TestClient.GetLoggly(&GetLogglyInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -186,7 +186,7 @@ func TestClient_GetLoggly_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetLoggly(&GetLogglyInput{
+	_, err = TestClient.GetLoggly(&GetLogglyInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -194,7 +194,7 @@ func TestClient_GetLoggly_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetLoggly(&GetLogglyInput{
+	_, err = TestClient.GetLoggly(&GetLogglyInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -206,7 +206,7 @@ func TestClient_GetLoggly_validation(t *testing.T) {
 func TestClient_UpdateLoggly_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateLoggly(&UpdateLogglyInput{
+	_, err = TestClient.UpdateLoggly(&UpdateLogglyInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -214,7 +214,7 @@ func TestClient_UpdateLoggly_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateLoggly(&UpdateLogglyInput{
+	_, err = TestClient.UpdateLoggly(&UpdateLogglyInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -222,7 +222,7 @@ func TestClient_UpdateLoggly_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateLoggly(&UpdateLogglyInput{
+	_, err = TestClient.UpdateLoggly(&UpdateLogglyInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -234,7 +234,7 @@ func TestClient_UpdateLoggly_validation(t *testing.T) {
 func TestClient_DeleteLoggly_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteLoggly(&DeleteLogglyInput{
+	err = TestClient.DeleteLoggly(&DeleteLogglyInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -242,7 +242,7 @@ func TestClient_DeleteLoggly_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteLoggly(&DeleteLogglyInput{
+	err = TestClient.DeleteLoggly(&DeleteLogglyInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -250,7 +250,7 @@ func TestClient_DeleteLoggly_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteLoggly(&DeleteLogglyInput{
+	err = TestClient.DeleteLoggly(&DeleteLogglyInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_logshuttle.go
+++ b/fastly/logging_logshuttle.go
@@ -46,7 +46,7 @@ func (c *Client) ListLogshuttles(i *ListLogshuttlesInput) ([]*Logshuttle, error)
 	defer resp.Body.Close()
 
 	var ls []*Logshuttle
-	if err := decodeBodyMap(resp.Body, &ls); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ls); err != nil {
 		return nil, err
 	}
 	return ls, nil
@@ -91,7 +91,7 @@ func (c *Client) CreateLogshuttle(i *CreateLogshuttleInput) (*Logshuttle, error)
 	defer resp.Body.Close()
 
 	var l *Logshuttle
-	if err := decodeBodyMap(resp.Body, &l); err != nil {
+	if err := DecodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -127,7 +127,7 @@ func (c *Client) GetLogshuttle(i *GetLogshuttleInput) (*Logshuttle, error) {
 	defer resp.Body.Close()
 
 	var l *Logshuttle
-	if err := decodeBodyMap(resp.Body, &l); err != nil {
+	if err := DecodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -177,7 +177,7 @@ func (c *Client) UpdateLogshuttle(i *UpdateLogshuttleInput) (*Logshuttle, error)
 	defer resp.Body.Close()
 
 	var l *Logshuttle
-	if err := decodeBodyMap(resp.Body, &l); err != nil {
+	if err := DecodeBodyMap(resp.Body, &l); err != nil {
 		return nil, err
 	}
 	return l, nil
@@ -213,7 +213,7 @@ func (c *Client) DeleteLogshuttle(i *DeleteLogshuttleInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_logshuttle_test.go
+++ b/fastly/logging_logshuttle_test.go
@@ -9,15 +9,15 @@ func TestClient_Logshuttles(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "logshuttles/version", func(c *Client) {
+	Record(t, "logshuttles/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var l *Logshuttle
-	record(t, "logshuttles/create", func(c *Client) {
+	Record(t, "logshuttles/create", func(c *Client) {
 		l, err = c.CreateLogshuttle(&CreateLogshuttleInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-logshuttle"),
 			Format:         ToPointer("%h %l %u %t \"%r\" %>s %b"),
@@ -33,15 +33,15 @@ func TestClient_Logshuttles(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "logshuttles/cleanup", func(c *Client) {
+		Record(t, "logshuttles/cleanup", func(c *Client) {
 			_ = c.DeleteLogshuttle(&DeleteLogshuttleInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-logshuttle",
 			})
 
 			_ = c.DeleteLogshuttle(&DeleteLogshuttleInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-logshuttle",
 			})
@@ -69,9 +69,9 @@ func TestClient_Logshuttles(t *testing.T) {
 
 	// List
 	var ls []*Logshuttle
-	record(t, "logshuttles/list", func(c *Client) {
+	Record(t, "logshuttles/list", func(c *Client) {
 		ls, err = c.ListLogshuttles(&ListLogshuttlesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -84,9 +84,9 @@ func TestClient_Logshuttles(t *testing.T) {
 
 	// Get
 	var nl *Logshuttle
-	record(t, "logshuttles/get", func(c *Client) {
+	Record(t, "logshuttles/get", func(c *Client) {
 		nl, err = c.GetLogshuttle(&GetLogshuttleInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-logshuttle",
 		})
@@ -115,9 +115,9 @@ func TestClient_Logshuttles(t *testing.T) {
 
 	// Update
 	var ul *Logshuttle
-	record(t, "logshuttles/update", func(c *Client) {
+	Record(t, "logshuttles/update", func(c *Client) {
 		ul, err = c.UpdateLogshuttle(&UpdateLogshuttleInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-logshuttle",
 			NewName:        ToPointer("new-test-logshuttle"),
@@ -139,9 +139,9 @@ func TestClient_Logshuttles(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "logshuttles/delete", func(c *Client) {
+	Record(t, "logshuttles/delete", func(c *Client) {
 		err = c.DeleteLogshuttle(&DeleteLogshuttleInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-logshuttle",
 		})
@@ -154,14 +154,14 @@ func TestClient_Logshuttles(t *testing.T) {
 func TestClient_ListLogshuttles_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListLogshuttles(&ListLogshuttlesInput{
+	_, err = TestClient.ListLogshuttles(&ListLogshuttlesInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListLogshuttles(&ListLogshuttlesInput{
+	_, err = TestClient.ListLogshuttles(&ListLogshuttlesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -173,14 +173,14 @@ func TestClient_ListLogshuttles_validation(t *testing.T) {
 func TestClient_CreateLogshuttle_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateLogshuttle(&CreateLogshuttleInput{
+	_, err = TestClient.CreateLogshuttle(&CreateLogshuttleInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateLogshuttle(&CreateLogshuttleInput{
+	_, err = TestClient.CreateLogshuttle(&CreateLogshuttleInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -192,7 +192,7 @@ func TestClient_CreateLogshuttle_validation(t *testing.T) {
 func TestClient_GetLogshuttle_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetLogshuttle(&GetLogshuttleInput{
+	_, err = TestClient.GetLogshuttle(&GetLogshuttleInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -200,7 +200,7 @@ func TestClient_GetLogshuttle_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetLogshuttle(&GetLogshuttleInput{
+	_, err = TestClient.GetLogshuttle(&GetLogshuttleInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -208,7 +208,7 @@ func TestClient_GetLogshuttle_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetLogshuttle(&GetLogshuttleInput{
+	_, err = TestClient.GetLogshuttle(&GetLogshuttleInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -220,7 +220,7 @@ func TestClient_GetLogshuttle_validation(t *testing.T) {
 func TestClient_UpdateLogshuttle_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateLogshuttle(&UpdateLogshuttleInput{
+	_, err = TestClient.UpdateLogshuttle(&UpdateLogshuttleInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -228,7 +228,7 @@ func TestClient_UpdateLogshuttle_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateLogshuttle(&UpdateLogshuttleInput{
+	_, err = TestClient.UpdateLogshuttle(&UpdateLogshuttleInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -236,7 +236,7 @@ func TestClient_UpdateLogshuttle_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateLogshuttle(&UpdateLogshuttleInput{
+	_, err = TestClient.UpdateLogshuttle(&UpdateLogshuttleInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -248,7 +248,7 @@ func TestClient_UpdateLogshuttle_validation(t *testing.T) {
 func TestClient_DeleteLogshuttle_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteLogshuttle(&DeleteLogshuttleInput{
+	err = TestClient.DeleteLogshuttle(&DeleteLogshuttleInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -256,7 +256,7 @@ func TestClient_DeleteLogshuttle_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteLogshuttle(&DeleteLogshuttleInput{
+	err = TestClient.DeleteLogshuttle(&DeleteLogshuttleInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -264,7 +264,7 @@ func TestClient_DeleteLogshuttle_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteLogshuttle(&DeleteLogshuttleInput{
+	err = TestClient.DeleteLogshuttle(&DeleteLogshuttleInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_newrelic.go
+++ b/fastly/logging_newrelic.go
@@ -46,7 +46,7 @@ func (c *Client) ListNewRelic(i *ListNewRelicInput) ([]*NewRelic, error) {
 	defer resp.Body.Close()
 
 	var n []*NewRelic
-	if err := decodeBodyMap(resp.Body, &n); err != nil {
+	if err := DecodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
 	return n, nil
@@ -91,7 +91,7 @@ func (c *Client) CreateNewRelic(i *CreateNewRelicInput) (*NewRelic, error) {
 	defer resp.Body.Close()
 
 	var n *NewRelic
-	if err := decodeBodyMap(resp.Body, &n); err != nil {
+	if err := DecodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
 	return n, nil
@@ -127,7 +127,7 @@ func (c *Client) GetNewRelic(i *GetNewRelicInput) (*NewRelic, error) {
 	defer resp.Body.Close()
 
 	var n *NewRelic
-	if err := decodeBodyMap(resp.Body, &n); err != nil {
+	if err := DecodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
 	return n, nil
@@ -177,7 +177,7 @@ func (c *Client) UpdateNewRelic(i *UpdateNewRelicInput) (*NewRelic, error) {
 	defer resp.Body.Close()
 
 	var n *NewRelic
-	if err := decodeBodyMap(resp.Body, &n); err != nil {
+	if err := DecodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
 	return n, nil
@@ -213,7 +213,7 @@ func (c *Client) DeleteNewRelic(i *DeleteNewRelicInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_newrelic_test.go
+++ b/fastly/logging_newrelic_test.go
@@ -9,15 +9,15 @@ func TestClient_NewRelic(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "newrelic/version", func(c *Client) {
+	Record(t, "newrelic/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var newRelicResp1, newRelicResp2 *NewRelic
-	record(t, "newrelic/create", func(c *Client) {
+	Record(t, "newrelic/create", func(c *Client) {
 		newRelicResp1, err = c.CreateNewRelic(&CreateNewRelicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-newrelic"),
 			Token:          ToPointer("abcd1234"),
@@ -30,9 +30,9 @@ func TestClient_NewRelic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "newrelic/create2", func(c *Client) {
+	Record(t, "newrelic/create2", func(c *Client) {
 		newRelicResp2, err = c.CreateNewRelic(&CreateNewRelicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-newrelic-2"),
 			Token:          ToPointer("abcd1234"),
@@ -46,9 +46,9 @@ func TestClient_NewRelic(t *testing.T) {
 	}
 
 	// This case is expected to fail due to an invalid region
-	record(t, "newrelic/create3", func(c *Client) {
+	Record(t, "newrelic/create3", func(c *Client) {
 		_, err = c.CreateNewRelic(&CreateNewRelicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-newrelic-3"),
 			Token:          ToPointer("abcd1234"),
@@ -63,21 +63,21 @@ func TestClient_NewRelic(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "newrelic/delete", func(c *Client) {
+		Record(t, "newrelic/delete", func(c *Client) {
 			_ = c.DeleteNewRelic(&DeleteNewRelicInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-newrelic",
 			})
 
 			_ = c.DeleteNewRelic(&DeleteNewRelicInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-newrelic-2",
 			})
 
 			_ = c.DeleteNewRelic(&DeleteNewRelicInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-newrelic",
 			})
@@ -123,9 +123,9 @@ func TestClient_NewRelic(t *testing.T) {
 
 	// List
 	var ln []*NewRelic
-	record(t, "newrelic/list", func(c *Client) {
+	Record(t, "newrelic/list", func(c *Client) {
 		ln, err = c.ListNewRelic(&ListNewRelicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -138,9 +138,9 @@ func TestClient_NewRelic(t *testing.T) {
 
 	// Get
 	var newRelicGetResp, newRelicGetResp2 *NewRelic
-	record(t, "newrelic/get", func(c *Client) {
+	Record(t, "newrelic/get", func(c *Client) {
 		newRelicGetResp, err = c.GetNewRelic(&GetNewRelicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-newrelic",
 		})
@@ -149,9 +149,9 @@ func TestClient_NewRelic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "newrelic/get2", func(c *Client) {
+	Record(t, "newrelic/get2", func(c *Client) {
 		newRelicGetResp2, err = c.GetNewRelic(&GetNewRelicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-newrelic-2",
 		})
@@ -199,9 +199,9 @@ func TestClient_NewRelic(t *testing.T) {
 
 	// Update
 	var newRelicUpdateResp1 *NewRelic
-	record(t, "newrelic/update", func(c *Client) {
+	Record(t, "newrelic/update", func(c *Client) {
 		newRelicUpdateResp1, err = c.UpdateNewRelic(&UpdateNewRelicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-newrelic",
 			NewName:        ToPointer("new-test-newrelic"),
@@ -214,9 +214,9 @@ func TestClient_NewRelic(t *testing.T) {
 	}
 
 	// This case is expected to fail due to an invalid region.
-	record(t, "newrelic/update2", func(c *Client) {
+	Record(t, "newrelic/update2", func(c *Client) {
 		_, err = c.UpdateNewRelic(&UpdateNewRelicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-newrelic",
 			Region:         ToPointer("zz"),
@@ -237,9 +237,9 @@ func TestClient_NewRelic(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "newrelic/delete", func(c *Client) {
+	Record(t, "newrelic/delete", func(c *Client) {
 		err = c.DeleteNewRelic(&DeleteNewRelicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-newrelic",
 		})
@@ -252,14 +252,14 @@ func TestClient_NewRelic(t *testing.T) {
 func TestClient_ListNewRelic_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListNewRelic(&ListNewRelicInput{
+	_, err = TestClient.ListNewRelic(&ListNewRelicInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListNewRelic(&ListNewRelicInput{
+	_, err = TestClient.ListNewRelic(&ListNewRelicInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -271,14 +271,14 @@ func TestClient_ListNewRelic_validation(t *testing.T) {
 func TestClient_CreateNewRelic_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateNewRelic(&CreateNewRelicInput{
+	_, err = TestClient.CreateNewRelic(&CreateNewRelicInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateNewRelic(&CreateNewRelicInput{
+	_, err = TestClient.CreateNewRelic(&CreateNewRelicInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -290,7 +290,7 @@ func TestClient_CreateNewRelic_validation(t *testing.T) {
 func TestClient_GetNewRelic_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetNewRelic(&GetNewRelicInput{
+	_, err = TestClient.GetNewRelic(&GetNewRelicInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -298,7 +298,7 @@ func TestClient_GetNewRelic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetNewRelic(&GetNewRelicInput{
+	_, err = TestClient.GetNewRelic(&GetNewRelicInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -306,7 +306,7 @@ func TestClient_GetNewRelic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetNewRelic(&GetNewRelicInput{
+	_, err = TestClient.GetNewRelic(&GetNewRelicInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -318,7 +318,7 @@ func TestClient_GetNewRelic_validation(t *testing.T) {
 func TestClient_UpdateNewRelic_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateNewRelic(&UpdateNewRelicInput{
+	_, err = TestClient.UpdateNewRelic(&UpdateNewRelicInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -326,7 +326,7 @@ func TestClient_UpdateNewRelic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateNewRelic(&UpdateNewRelicInput{
+	_, err = TestClient.UpdateNewRelic(&UpdateNewRelicInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -334,7 +334,7 @@ func TestClient_UpdateNewRelic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateNewRelic(&UpdateNewRelicInput{
+	_, err = TestClient.UpdateNewRelic(&UpdateNewRelicInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -346,7 +346,7 @@ func TestClient_UpdateNewRelic_validation(t *testing.T) {
 func TestClient_DeleteNewRelic_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteNewRelic(&DeleteNewRelicInput{
+	err = TestClient.DeleteNewRelic(&DeleteNewRelicInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -354,7 +354,7 @@ func TestClient_DeleteNewRelic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteNewRelic(&DeleteNewRelicInput{
+	err = TestClient.DeleteNewRelic(&DeleteNewRelicInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -362,7 +362,7 @@ func TestClient_DeleteNewRelic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteNewRelic(&DeleteNewRelicInput{
+	err = TestClient.DeleteNewRelic(&DeleteNewRelicInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_newrelicotlp.go
+++ b/fastly/logging_newrelicotlp.go
@@ -49,7 +49,7 @@ func (c *Client) ListNewRelicOTLP(i *ListNewRelicOTLPInput) ([]*NewRelicOTLP, er
 	defer resp.Body.Close()
 
 	var n []*NewRelicOTLP
-	if err := decodeBodyMap(resp.Body, &n); err != nil {
+	if err := DecodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
 	return n, nil
@@ -97,7 +97,7 @@ func (c *Client) CreateNewRelicOTLP(i *CreateNewRelicOTLPInput) (*NewRelicOTLP, 
 	defer resp.Body.Close()
 
 	var n *NewRelicOTLP
-	if err := decodeBodyMap(resp.Body, &n); err != nil {
+	if err := DecodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
 	return n, nil
@@ -133,7 +133,7 @@ func (c *Client) GetNewRelicOTLP(i *GetNewRelicOTLPInput) (*NewRelicOTLP, error)
 	defer resp.Body.Close()
 
 	var n *NewRelicOTLP
-	if err := decodeBodyMap(resp.Body, &n); err != nil {
+	if err := DecodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
 	return n, nil
@@ -186,7 +186,7 @@ func (c *Client) UpdateNewRelicOTLP(i *UpdateNewRelicOTLPInput) (*NewRelicOTLP, 
 	defer resp.Body.Close()
 
 	var n *NewRelicOTLP
-	if err := decodeBodyMap(resp.Body, &n); err != nil {
+	if err := DecodeBodyMap(resp.Body, &n); err != nil {
 		return nil, err
 	}
 	return n, nil
@@ -222,7 +222,7 @@ func (c *Client) DeleteNewRelicOTLP(i *DeleteNewRelicOTLPInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_newrelicotlp_test.go
+++ b/fastly/logging_newrelicotlp_test.go
@@ -9,15 +9,15 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "newrelicotlp/version", func(c *Client) {
+	Record(t, "newrelicotlp/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var n *NewRelicOTLP
-	record(t, "newrelicotlp/create", func(c *Client) {
+	Record(t, "newrelicotlp/create", func(c *Client) {
 		n, err = c.CreateNewRelicOTLP(&CreateNewRelicOTLPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-newrelicotlp"),
 			Token:          ToPointer("abcd1234"),
@@ -32,15 +32,15 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "newrelicotlp/delete", func(c *Client) {
+		Record(t, "newrelicotlp/delete", func(c *Client) {
 			_ = c.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-newrelicotlp",
 			})
 
 			_ = c.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-newrelicotlp",
 			})
@@ -68,9 +68,9 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 
 	// List
 	var ln []*NewRelicOTLP
-	record(t, "newrelicotlp/list", func(c *Client) {
+	Record(t, "newrelicotlp/list", func(c *Client) {
 		ln, err = c.ListNewRelicOTLP(&ListNewRelicOTLPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -83,9 +83,9 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 
 	// Get
 	var nn *NewRelicOTLP
-	record(t, "newrelicotlp/get", func(c *Client) {
+	Record(t, "newrelicotlp/get", func(c *Client) {
 		nn, err = c.GetNewRelicOTLP(&GetNewRelicOTLPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-newrelicotlp",
 		})
@@ -114,9 +114,9 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 
 	// Update
 	var un *NewRelicOTLP
-	record(t, "newrelicotlp/update", func(c *Client) {
+	Record(t, "newrelicotlp/update", func(c *Client) {
 		un, err = c.UpdateNewRelicOTLP(&UpdateNewRelicOTLPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-newrelicotlp",
 			NewName:        ToPointer("new-test-newrelicotlp"),
@@ -134,9 +134,9 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "newrelicotlp/delete", func(c *Client) {
+	Record(t, "newrelicotlp/delete", func(c *Client) {
 		err = c.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-newrelicotlp",
 		})
@@ -148,14 +148,14 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 
 func TestClient_ListNewRelicOTLP_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListNewRelicOTLP(&ListNewRelicOTLPInput{
+	_, err = TestClient.ListNewRelicOTLP(&ListNewRelicOTLPInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListNewRelicOTLP(&ListNewRelicOTLPInput{
+	_, err = TestClient.ListNewRelicOTLP(&ListNewRelicOTLPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -166,14 +166,14 @@ func TestClient_ListNewRelicOTLP_validation(t *testing.T) {
 
 func TestClient_CreateNewRelicOTLP_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateNewRelicOTLP(&CreateNewRelicOTLPInput{
+	_, err = TestClient.CreateNewRelicOTLP(&CreateNewRelicOTLPInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateNewRelicOTLP(&CreateNewRelicOTLPInput{
+	_, err = TestClient.CreateNewRelicOTLP(&CreateNewRelicOTLPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -184,14 +184,14 @@ func TestClient_CreateNewRelicOTLP_validation(t *testing.T) {
 
 func TestClient_GetNewRelicOTLP_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetNewRelicOTLP(&GetNewRelicOTLPInput{
+	_, err = TestClient.GetNewRelicOTLP(&GetNewRelicOTLPInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetNewRelicOTLP(&GetNewRelicOTLPInput{
+	_, err = TestClient.GetNewRelicOTLP(&GetNewRelicOTLPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -199,7 +199,7 @@ func TestClient_GetNewRelicOTLP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetNewRelicOTLP(&GetNewRelicOTLPInput{
+	_, err = TestClient.GetNewRelicOTLP(&GetNewRelicOTLPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 		Name:           "",
@@ -211,14 +211,14 @@ func TestClient_GetNewRelicOTLP_validation(t *testing.T) {
 
 func TestClient_UpdateNewRelicOTLP_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateNewRelicOTLP(&UpdateNewRelicOTLPInput{
+	_, err = TestClient.UpdateNewRelicOTLP(&UpdateNewRelicOTLPInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateNewRelicOTLP(&UpdateNewRelicOTLPInput{
+	_, err = TestClient.UpdateNewRelicOTLP(&UpdateNewRelicOTLPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -226,7 +226,7 @@ func TestClient_UpdateNewRelicOTLP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateNewRelicOTLP(&UpdateNewRelicOTLPInput{
+	_, err = TestClient.UpdateNewRelicOTLP(&UpdateNewRelicOTLPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 		Name:           "",
@@ -238,14 +238,14 @@ func TestClient_UpdateNewRelicOTLP_validation(t *testing.T) {
 
 func TestClient_DeleteNewRelicOTLP_validation(t *testing.T) {
 	var err error
-	err = testClient.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
+	err = TestClient.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
+	err = TestClient.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -253,7 +253,7 @@ func TestClient_DeleteNewRelicOTLP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
+	err = TestClient.DeleteNewRelicOTLP(&DeleteNewRelicOTLPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 		Name:           "",

--- a/fastly/logging_openstack.go
+++ b/fastly/logging_openstack.go
@@ -55,7 +55,7 @@ func (c *Client) ListOpenstack(i *ListOpenstackInput) ([]*Openstack, error) {
 	defer resp.Body.Close()
 
 	var openstacks []*Openstack
-	if err := decodeBodyMap(resp.Body, &openstacks); err != nil {
+	if err := DecodeBodyMap(resp.Body, &openstacks); err != nil {
 		return nil, err
 	}
 	return openstacks, nil
@@ -118,7 +118,7 @@ func (c *Client) CreateOpenstack(i *CreateOpenstackInput) (*Openstack, error) {
 	defer resp.Body.Close()
 
 	var openstack *Openstack
-	if err := decodeBodyMap(resp.Body, &openstack); err != nil {
+	if err := DecodeBodyMap(resp.Body, &openstack); err != nil {
 		return nil, err
 	}
 	return openstack, nil
@@ -154,7 +154,7 @@ func (c *Client) GetOpenstack(i *GetOpenstackInput) (*Openstack, error) {
 	defer resp.Body.Close()
 
 	var openstack *Openstack
-	if err := decodeBodyMap(resp.Body, &openstack); err != nil {
+	if err := DecodeBodyMap(resp.Body, &openstack); err != nil {
 		return nil, err
 	}
 	return openstack, nil
@@ -222,7 +222,7 @@ func (c *Client) UpdateOpenstack(i *UpdateOpenstackInput) (*Openstack, error) {
 	defer resp.Body.Close()
 
 	var openstack *Openstack
-	if err := decodeBodyMap(resp.Body, &openstack); err != nil {
+	if err := DecodeBodyMap(resp.Body, &openstack); err != nil {
 		return nil, err
 	}
 	return openstack, nil
@@ -258,7 +258,7 @@ func (c *Client) DeleteOpenstack(i *DeleteOpenstackInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_openstack_test.go
+++ b/fastly/logging_openstack_test.go
@@ -9,15 +9,15 @@ func TestClient_Openstack(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "openstack/version", func(c *Client) {
+	Record(t, "openstack/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var osCreateResp1, osCreateResp2, osCreateResp3 *Openstack
-	record(t, "openstack/create", func(c *Client) {
+	Record(t, "openstack/create", func(c *Client) {
 		osCreateResp1, err = c.CreateOpenstack(&CreateOpenstackInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-openstack"),
 			User:             ToPointer("user"),
@@ -39,9 +39,9 @@ func TestClient_Openstack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "openstack/create2", func(c *Client) {
+	Record(t, "openstack/create2", func(c *Client) {
 		osCreateResp2, err = c.CreateOpenstack(&CreateOpenstackInput{
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-openstack-2"),
 			User:            ToPointer("user"),
@@ -63,9 +63,9 @@ func TestClient_Openstack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "openstack/create3", func(c *Client) {
+	Record(t, "openstack/create3", func(c *Client) {
 		osCreateResp3, err = c.CreateOpenstack(&CreateOpenstackInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-openstack-3"),
 			User:             ToPointer("user"),
@@ -89,9 +89,9 @@ func TestClient_Openstack(t *testing.T) {
 
 	// This case is expected to fail because both CompressionCodec and
 	// GzipLevel are present.
-	record(t, "openstack/create4", func(c *Client) {
+	Record(t, "openstack/create4", func(c *Client) {
 		_, err = c.CreateOpenstack(&CreateOpenstackInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-openstack-4"),
 			User:             ToPointer("user"),
@@ -116,27 +116,27 @@ func TestClient_Openstack(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "openstack/cleanup", func(c *Client) {
+		Record(t, "openstack/cleanup", func(c *Client) {
 			_ = c.DeleteOpenstack(&DeleteOpenstackInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-openstack",
 			})
 
 			_ = c.DeleteOpenstack(&DeleteOpenstackInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-openstack-2",
 			})
 
 			_ = c.DeleteOpenstack(&DeleteOpenstackInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-openstack-3",
 			})
 
 			_ = c.DeleteOpenstack(&DeleteOpenstackInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-openstack",
 			})
@@ -203,9 +203,9 @@ func TestClient_Openstack(t *testing.T) {
 
 	// List
 	var lc []*Openstack
-	record(t, "openstack/list", func(c *Client) {
+	Record(t, "openstack/list", func(c *Client) {
 		lc, err = c.ListOpenstack(&ListOpenstackInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -218,9 +218,9 @@ func TestClient_Openstack(t *testing.T) {
 
 	// Get
 	var osGetResp *Openstack
-	record(t, "openstack/get", func(c *Client) {
+	Record(t, "openstack/get", func(c *Client) {
 		osGetResp, err = c.GetOpenstack(&GetOpenstackInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-openstack",
 		})
@@ -276,9 +276,9 @@ func TestClient_Openstack(t *testing.T) {
 
 	// Update
 	var osUpdateResp1, osUpdateResp2, osUpdateResp3 *Openstack
-	record(t, "openstack/update", func(c *Client) {
+	Record(t, "openstack/update", func(c *Client) {
 		osUpdateResp1, err = c.UpdateOpenstack(&UpdateOpenstackInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-openstack",
 			User:             ToPointer("new-user"),
@@ -290,9 +290,9 @@ func TestClient_Openstack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "openstack/update2", func(c *Client) {
+	Record(t, "openstack/update2", func(c *Client) {
 		osUpdateResp2, err = c.UpdateOpenstack(&UpdateOpenstackInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-openstack-2",
 			CompressionCodec: ToPointer("zstd"),
@@ -302,9 +302,9 @@ func TestClient_Openstack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "openstack/update3", func(c *Client) {
+	Record(t, "openstack/update3", func(c *Client) {
 		osUpdateResp3, err = c.UpdateOpenstack(&UpdateOpenstackInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-openstack-3",
 			GzipLevel:      ToPointer(9),
@@ -340,9 +340,9 @@ func TestClient_Openstack(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "openstack/delete", func(c *Client) {
+	Record(t, "openstack/delete", func(c *Client) {
 		err = c.DeleteOpenstack(&DeleteOpenstackInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-openstack",
 		})
@@ -354,14 +354,14 @@ func TestClient_Openstack(t *testing.T) {
 
 func TestClient_ListOpenstack_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListOpenstack(&ListOpenstackInput{
+	_, err = TestClient.ListOpenstack(&ListOpenstackInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListOpenstack(&ListOpenstackInput{
+	_, err = TestClient.ListOpenstack(&ListOpenstackInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -372,14 +372,14 @@ func TestClient_ListOpenstack_validation(t *testing.T) {
 
 func TestClient_CreateOpenstack_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateOpenstack(&CreateOpenstackInput{
+	_, err = TestClient.CreateOpenstack(&CreateOpenstackInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateOpenstack(&CreateOpenstackInput{
+	_, err = TestClient.CreateOpenstack(&CreateOpenstackInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -391,7 +391,7 @@ func TestClient_CreateOpenstack_validation(t *testing.T) {
 func TestClient_GetOpenstack_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetOpenstack(&GetOpenstackInput{
+	_, err = TestClient.GetOpenstack(&GetOpenstackInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -399,7 +399,7 @@ func TestClient_GetOpenstack_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetOpenstack(&GetOpenstackInput{
+	_, err = TestClient.GetOpenstack(&GetOpenstackInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -407,7 +407,7 @@ func TestClient_GetOpenstack_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetOpenstack(&GetOpenstackInput{
+	_, err = TestClient.GetOpenstack(&GetOpenstackInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -419,7 +419,7 @@ func TestClient_GetOpenstack_validation(t *testing.T) {
 func TestClient_UpdateOpenstack_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateOpenstack(&UpdateOpenstackInput{
+	_, err = TestClient.UpdateOpenstack(&UpdateOpenstackInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -427,7 +427,7 @@ func TestClient_UpdateOpenstack_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateOpenstack(&UpdateOpenstackInput{
+	_, err = TestClient.UpdateOpenstack(&UpdateOpenstackInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -435,7 +435,7 @@ func TestClient_UpdateOpenstack_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateOpenstack(&UpdateOpenstackInput{
+	_, err = TestClient.UpdateOpenstack(&UpdateOpenstackInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -447,7 +447,7 @@ func TestClient_UpdateOpenstack_validation(t *testing.T) {
 func TestClient_DeleteOpenstack_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteOpenstack(&DeleteOpenstackInput{
+	err = TestClient.DeleteOpenstack(&DeleteOpenstackInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -455,7 +455,7 @@ func TestClient_DeleteOpenstack_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteOpenstack(&DeleteOpenstackInput{
+	err = TestClient.DeleteOpenstack(&DeleteOpenstackInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -463,7 +463,7 @@ func TestClient_DeleteOpenstack_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteOpenstack(&DeleteOpenstackInput{
+	err = TestClient.DeleteOpenstack(&DeleteOpenstackInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_papertrail.go
+++ b/fastly/logging_papertrail.go
@@ -46,7 +46,7 @@ func (c *Client) ListPapertrails(i *ListPapertrailsInput) ([]*Papertrail, error)
 	defer resp.Body.Close()
 
 	var ps []*Papertrail
-	if err := decodeBodyMap(resp.Body, &ps); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ps); err != nil {
 		return nil, err
 	}
 	return ps, nil
@@ -91,7 +91,7 @@ func (c *Client) CreatePapertrail(i *CreatePapertrailInput) (*Papertrail, error)
 	defer resp.Body.Close()
 
 	var p *Papertrail
-	if err := decodeBodyMap(resp.Body, &p); err != nil {
+	if err := DecodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -127,7 +127,7 @@ func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
 	defer resp.Body.Close()
 
 	var p *Papertrail
-	if err := decodeBodyMap(resp.Body, &p); err != nil {
+	if err := DecodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -177,7 +177,7 @@ func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error)
 	defer resp.Body.Close()
 
 	var p *Papertrail
-	if err := decodeBodyMap(resp.Body, &p); err != nil {
+	if err := DecodeBodyMap(resp.Body, &p); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -213,7 +213,7 @@ func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_papertrail_test.go
+++ b/fastly/logging_papertrail_test.go
@@ -9,15 +9,15 @@ func TestClient_Papertrails(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "papertrails/version", func(c *Client) {
+	Record(t, "papertrails/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var p *Papertrail
-	record(t, "papertrails/create", func(c *Client) {
+	Record(t, "papertrails/create", func(c *Client) {
 		p, err = c.CreatePapertrail(&CreatePapertrailInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-papertrail"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
@@ -33,15 +33,15 @@ func TestClient_Papertrails(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "papertrails/cleanup", func(c *Client) {
+		Record(t, "papertrails/cleanup", func(c *Client) {
 			_ = c.DeletePapertrail(&DeletePapertrailInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-papertrail",
 			})
 
 			_ = c.DeletePapertrail(&DeletePapertrailInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-papertrail",
 			})
@@ -69,9 +69,9 @@ func TestClient_Papertrails(t *testing.T) {
 
 	// List
 	var ps []*Papertrail
-	record(t, "papertrails/list", func(c *Client) {
+	Record(t, "papertrails/list", func(c *Client) {
 		ps, err = c.ListPapertrails(&ListPapertrailsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -84,9 +84,9 @@ func TestClient_Papertrails(t *testing.T) {
 
 	// Get
 	var np *Papertrail
-	record(t, "papertrails/get", func(c *Client) {
+	Record(t, "papertrails/get", func(c *Client) {
 		np, err = c.GetPapertrail(&GetPapertrailInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-papertrail",
 		})
@@ -115,9 +115,9 @@ func TestClient_Papertrails(t *testing.T) {
 
 	// Update
 	var up *Papertrail
-	record(t, "papertrails/update", func(c *Client) {
+	Record(t, "papertrails/update", func(c *Client) {
 		up, err = c.UpdatePapertrail(&UpdatePapertrailInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-papertrail",
 			NewName:        ToPointer("new-test-papertrail"),
@@ -131,9 +131,9 @@ func TestClient_Papertrails(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "papertrails/delete", func(c *Client) {
+	Record(t, "papertrails/delete", func(c *Client) {
 		err = c.DeletePapertrail(&DeletePapertrailInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-papertrail",
 		})
@@ -146,14 +146,14 @@ func TestClient_Papertrails(t *testing.T) {
 func TestClient_ListPapertrails_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListPapertrails(&ListPapertrailsInput{
+	_, err = TestClient.ListPapertrails(&ListPapertrailsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListPapertrails(&ListPapertrailsInput{
+	_, err = TestClient.ListPapertrails(&ListPapertrailsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -165,14 +165,14 @@ func TestClient_ListPapertrails_validation(t *testing.T) {
 func TestClient_CreatePapertrail_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreatePapertrail(&CreatePapertrailInput{
+	_, err = TestClient.CreatePapertrail(&CreatePapertrailInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreatePapertrail(&CreatePapertrailInput{
+	_, err = TestClient.CreatePapertrail(&CreatePapertrailInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -184,7 +184,7 @@ func TestClient_CreatePapertrail_validation(t *testing.T) {
 func TestClient_GetPapertrail_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetPapertrail(&GetPapertrailInput{
+	_, err = TestClient.GetPapertrail(&GetPapertrailInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -192,7 +192,7 @@ func TestClient_GetPapertrail_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetPapertrail(&GetPapertrailInput{
+	_, err = TestClient.GetPapertrail(&GetPapertrailInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -200,7 +200,7 @@ func TestClient_GetPapertrail_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetPapertrail(&GetPapertrailInput{
+	_, err = TestClient.GetPapertrail(&GetPapertrailInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -212,7 +212,7 @@ func TestClient_GetPapertrail_validation(t *testing.T) {
 func TestClient_UpdatePapertrail_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdatePapertrail(&UpdatePapertrailInput{
+	_, err = TestClient.UpdatePapertrail(&UpdatePapertrailInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -220,7 +220,7 @@ func TestClient_UpdatePapertrail_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdatePapertrail(&UpdatePapertrailInput{
+	_, err = TestClient.UpdatePapertrail(&UpdatePapertrailInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -228,7 +228,7 @@ func TestClient_UpdatePapertrail_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdatePapertrail(&UpdatePapertrailInput{
+	_, err = TestClient.UpdatePapertrail(&UpdatePapertrailInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -240,7 +240,7 @@ func TestClient_UpdatePapertrail_validation(t *testing.T) {
 func TestClient_DeletePapertrail_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeletePapertrail(&DeletePapertrailInput{
+	err = TestClient.DeletePapertrail(&DeletePapertrailInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -248,7 +248,7 @@ func TestClient_DeletePapertrail_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeletePapertrail(&DeletePapertrailInput{
+	err = TestClient.DeletePapertrail(&DeletePapertrailInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -256,7 +256,7 @@ func TestClient_DeletePapertrail_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeletePapertrail(&DeletePapertrailInput{
+	err = TestClient.DeletePapertrail(&DeletePapertrailInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_pubsub.go
+++ b/fastly/logging_pubsub.go
@@ -49,7 +49,7 @@ func (c *Client) ListPubsubs(i *ListPubsubsInput) ([]*Pubsub, error) {
 	defer resp.Body.Close()
 
 	var pubsubs []*Pubsub
-	if err := decodeBodyMap(resp.Body, &pubsubs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &pubsubs); err != nil {
 		return nil, err
 	}
 	return pubsubs, nil
@@ -100,7 +100,7 @@ func (c *Client) CreatePubsub(i *CreatePubsubInput) (*Pubsub, error) {
 	defer resp.Body.Close()
 
 	var pubsub *Pubsub
-	if err := decodeBodyMap(resp.Body, &pubsub); err != nil {
+	if err := DecodeBodyMap(resp.Body, &pubsub); err != nil {
 		return nil, err
 	}
 	return pubsub, nil
@@ -136,7 +136,7 @@ func (c *Client) GetPubsub(i *GetPubsubInput) (*Pubsub, error) {
 	defer resp.Body.Close()
 
 	var b *Pubsub
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -192,7 +192,7 @@ func (c *Client) UpdatePubsub(i *UpdatePubsubInput) (*Pubsub, error) {
 	defer resp.Body.Close()
 
 	var b *Pubsub
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -228,7 +228,7 @@ func (c *Client) DeletePubsub(i *DeletePubsubInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_pubsub_test.go
+++ b/fastly/logging_pubsub_test.go
@@ -10,15 +10,15 @@ func TestClient_Pubsubs(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "pubsubs/version", func(c *Client) {
+	Record(t, "pubsubs/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var pubsub *Pubsub
-	record(t, "pubsubs/create", func(c *Client) {
+	Record(t, "pubsubs/create", func(c *Client) {
 		pubsub, err = c.CreatePubsub(&CreatePubsubInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-pubsub"),
 			Topic:          ToPointer("topic"),
@@ -37,15 +37,15 @@ func TestClient_Pubsubs(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "pubsubs/cleanup", func(c *Client) {
+		Record(t, "pubsubs/cleanup", func(c *Client) {
 			_ = c.DeletePubsub(&DeletePubsubInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-pubsub",
 			})
 
 			_ = c.DeletePubsub(&DeletePubsubInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-pubsub",
 			})
@@ -109,9 +109,9 @@ bv1KwcKoQbNVXwauH79JKc0=
 
 	// List
 	var pubsubs []*Pubsub
-	record(t, "pubsubs/list", func(c *Client) {
+	Record(t, "pubsubs/list", func(c *Client) {
 		pubsubs, err = c.ListPubsubs(&ListPubsubsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -124,9 +124,9 @@ bv1KwcKoQbNVXwauH79JKc0=
 
 	// Get
 	var npubsub *Pubsub
-	record(t, "pubsubs/get", func(c *Client) {
+	Record(t, "pubsubs/get", func(c *Client) {
 		npubsub, err = c.GetPubsub(&GetPubsubInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-pubsub",
 		})
@@ -161,9 +161,9 @@ bv1KwcKoQbNVXwauH79JKc0=
 
 	// Update
 	var upubsub *Pubsub
-	record(t, "pubsubs/update", func(c *Client) {
+	Record(t, "pubsubs/update", func(c *Client) {
 		upubsub, err = c.UpdatePubsub(&UpdatePubsubInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-pubsub",
 			NewName:        ToPointer("new-test-pubsub"),
@@ -181,9 +181,9 @@ bv1KwcKoQbNVXwauH79JKc0=
 	}
 
 	// Delete
-	record(t, "pubsubs/delete", func(c *Client) {
+	Record(t, "pubsubs/delete", func(c *Client) {
 		err = c.DeletePubsub(&DeletePubsubInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-pubsub",
 		})
@@ -195,14 +195,14 @@ bv1KwcKoQbNVXwauH79JKc0=
 
 func TestClient_ListPubsubs_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListPubsubs(&ListPubsubsInput{
+	_, err = TestClient.ListPubsubs(&ListPubsubsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListPubsubs(&ListPubsubsInput{
+	_, err = TestClient.ListPubsubs(&ListPubsubsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -213,14 +213,14 @@ func TestClient_ListPubsubs_validation(t *testing.T) {
 
 func TestClient_CreatePubsub_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreatePubsub(&CreatePubsubInput{
+	_, err = TestClient.CreatePubsub(&CreatePubsubInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreatePubsub(&CreatePubsubInput{
+	_, err = TestClient.CreatePubsub(&CreatePubsubInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -232,7 +232,7 @@ func TestClient_CreatePubsub_validation(t *testing.T) {
 func TestClient_GetPubsub_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetPubsub(&GetPubsubInput{
+	_, err = TestClient.GetPubsub(&GetPubsubInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -240,7 +240,7 @@ func TestClient_GetPubsub_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetPubsub(&GetPubsubInput{
+	_, err = TestClient.GetPubsub(&GetPubsubInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -248,7 +248,7 @@ func TestClient_GetPubsub_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetPubsub(&GetPubsubInput{
+	_, err = TestClient.GetPubsub(&GetPubsubInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -260,7 +260,7 @@ func TestClient_GetPubsub_validation(t *testing.T) {
 func TestClient_UpdatePubsub_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdatePubsub(&UpdatePubsubInput{
+	_, err = TestClient.UpdatePubsub(&UpdatePubsubInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -268,7 +268,7 @@ func TestClient_UpdatePubsub_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdatePubsub(&UpdatePubsubInput{
+	_, err = TestClient.UpdatePubsub(&UpdatePubsubInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -276,7 +276,7 @@ func TestClient_UpdatePubsub_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdatePubsub(&UpdatePubsubInput{
+	_, err = TestClient.UpdatePubsub(&UpdatePubsubInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -288,7 +288,7 @@ func TestClient_UpdatePubsub_validation(t *testing.T) {
 func TestClient_DeletePubsub_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeletePubsub(&DeletePubsubInput{
+	err = TestClient.DeletePubsub(&DeletePubsubInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -296,7 +296,7 @@ func TestClient_DeletePubsub_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeletePubsub(&DeletePubsubInput{
+	err = TestClient.DeletePubsub(&DeletePubsubInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -304,7 +304,7 @@ func TestClient_DeletePubsub_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeletePubsub(&DeletePubsubInput{
+	err = TestClient.DeletePubsub(&DeletePubsubInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_s3.go
+++ b/fastly/logging_s3.go
@@ -109,7 +109,7 @@ func (c *Client) ListS3s(i *ListS3sInput) ([]*S3, error) {
 	defer resp.Body.Close()
 
 	var s3s []*S3
-	if err := decodeBodyMap(resp.Body, &s3s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s3s); err != nil {
 		return nil, err
 	}
 	return s3s, nil
@@ -190,7 +190,7 @@ func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
 	defer resp.Body.Close()
 
 	var s3 *S3
-	if err := decodeBodyMap(resp.Body, &s3); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s3); err != nil {
 		return nil, err
 	}
 	return s3, nil
@@ -226,7 +226,7 @@ func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
 	defer resp.Body.Close()
 
 	var s3 *S3
-	if err := decodeBodyMap(resp.Body, &s3); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s3); err != nil {
 		return nil, err
 	}
 	return s3, nil
@@ -312,7 +312,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 	defer resp.Body.Close()
 
 	var s3 *S3
-	if err := decodeBodyMap(resp.Body, &s3); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s3); err != nil {
 		return nil, err
 	}
 	return s3, nil
@@ -348,7 +348,7 @@ func (c *Client) DeleteS3(i *DeleteS3Input) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_s3_test.go
+++ b/fastly/logging_s3_test.go
@@ -9,7 +9,7 @@ func TestClient_S3s(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "s3s/version", func(c *Client) {
+	Record(t, "s3s/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -17,9 +17,9 @@ func TestClient_S3s(t *testing.T) {
 	//
 	// NOTE: You can't send the API and empty ResponseCondition.
 	var s3CreateResp1, s3CreateResp2, s3CreateResp3, s3CreateResp4 *S3
-	record(t, "s3s/create", func(c *Client) {
+	Record(t, "s3s/create", func(c *Client) {
 		s3CreateResp1, err = c.CreateS3(&CreateS3Input{
-			ServiceID:                    testDeliveryServiceID,
+			ServiceID:                    TestDeliveryServiceID,
 			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3"),
 			BucketName:                   ToPointer("bucket-name"),
@@ -46,9 +46,9 @@ func TestClient_S3s(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "s3s/create2", func(c *Client) {
+	Record(t, "s3s/create2", func(c *Client) {
 		s3CreateResp2, err = c.CreateS3(&CreateS3Input{
-			ServiceID:                    testDeliveryServiceID,
+			ServiceID:                    TestDeliveryServiceID,
 			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3-2"),
 			BucketName:                   ToPointer("bucket-name"),
@@ -74,9 +74,9 @@ func TestClient_S3s(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record(t, "s3s/create3", func(c *Client) {
+	Record(t, "s3s/create3", func(c *Client) {
 		s3CreateResp3, err = c.CreateS3(&CreateS3Input{
-			ServiceID:                    testDeliveryServiceID,
+			ServiceID:                    TestDeliveryServiceID,
 			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3-3"),
 			BucketName:                   ToPointer("bucket-name"),
@@ -102,9 +102,9 @@ func TestClient_S3s(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "s3s/create4", func(c *Client) {
+	Record(t, "s3s/create4", func(c *Client) {
 		s3CreateResp4, err = c.CreateS3(&CreateS3Input{
-			ServiceID:                    testDeliveryServiceID,
+			ServiceID:                    TestDeliveryServiceID,
 			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3-4"),
 			BucketName:                   ToPointer("bucket-name"),
@@ -130,9 +130,9 @@ func TestClient_S3s(t *testing.T) {
 	}
 
 	// This case is expected to fail
-	record(t, "s3s/create5", func(c *Client) {
+	Record(t, "s3s/create5", func(c *Client) {
 		_, err = c.CreateS3(&CreateS3Input{
-			ServiceID:                    testDeliveryServiceID,
+			ServiceID:                    TestDeliveryServiceID,
 			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3"),
 			BucketName:                   ToPointer("bucket-name"),
@@ -159,9 +159,9 @@ func TestClient_S3s(t *testing.T) {
 	}
 
 	// This case is expected to fail
-	record(t, "s3s/create6", func(c *Client) {
+	Record(t, "s3s/create6", func(c *Client) {
 		_, err = c.CreateS3(&CreateS3Input{
-			ServiceID:                    testDeliveryServiceID,
+			ServiceID:                    TestDeliveryServiceID,
 			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3"),
 			BucketName:                   ToPointer("bucket-name"),
@@ -187,9 +187,9 @@ func TestClient_S3s(t *testing.T) {
 
 	// This case is expected to fail because both CompressionCodec and
 	// GzipLevel are present.
-	record(t, "s3s/create7", func(c *Client) {
+	Record(t, "s3s/create7", func(c *Client) {
 		_, err = c.CreateS3(&CreateS3Input{
-			ServiceID:                    testDeliveryServiceID,
+			ServiceID:                    TestDeliveryServiceID,
 			ServiceVersion:               *tv.Number,
 			Name:                         ToPointer("test-s3-2"),
 			BucketName:                   ToPointer("bucket-name"),
@@ -217,27 +217,27 @@ func TestClient_S3s(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "s3s/cleanup", func(c *Client) {
+		Record(t, "s3s/cleanup", func(c *Client) {
 			_ = c.DeleteS3(&DeleteS3Input{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-s3",
 			})
 
 			_ = c.DeleteS3(&DeleteS3Input{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-s3-3",
 			})
 
 			_ = c.DeleteS3(&DeleteS3Input{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-s3-4",
 			})
 
 			_ = c.DeleteS3(&DeleteS3Input{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-s3",
 			})
@@ -349,9 +349,9 @@ func TestClient_S3s(t *testing.T) {
 
 	// List
 	var s3s []*S3
-	record(t, "s3s/list", func(c *Client) {
+	Record(t, "s3s/list", func(c *Client) {
 		s3s, err = c.ListS3s(&ListS3sInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -364,9 +364,9 @@ func TestClient_S3s(t *testing.T) {
 
 	// Get
 	var s3GetResp, s3GetResp2 *S3
-	record(t, "s3s/get", func(c *Client) {
+	Record(t, "s3s/get", func(c *Client) {
 		s3GetResp, err = c.GetS3(&GetS3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-s3",
 		})
@@ -376,9 +376,9 @@ func TestClient_S3s(t *testing.T) {
 	}
 
 	// Request the configuration using the IAM role
-	record(t, "s3s/get2", func(c *Client) {
+	Record(t, "s3s/get2", func(c *Client) {
 		s3GetResp2, err = c.GetS3(&GetS3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-s3-4",
 		})
@@ -465,9 +465,9 @@ func TestClient_S3s(t *testing.T) {
 
 	// Update
 	var s3UpdateResp1, s3UpdateResp2, s3UpdateResp3, s3UpdateResp4, s3UpdateResp5 *S3
-	record(t, "s3s/update", func(c *Client) {
+	Record(t, "s3s/update", func(c *Client) {
 		s3UpdateResp1, err = c.UpdateS3(&UpdateS3Input{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-s3",
 			NewName:          ToPointer("new-test-s3"),
@@ -482,9 +482,9 @@ func TestClient_S3s(t *testing.T) {
 
 	// Test that CompressionCodec can be set for a an endpoint where
 	// GzipLevel was specified at creation time.
-	record(t, "s3s/update2", func(c *Client) {
+	Record(t, "s3s/update2", func(c *Client) {
 		s3UpdateResp2, err = c.UpdateS3(&UpdateS3Input{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-s3-2",
 			CompressionCodec: ToPointer("zstd"),
@@ -496,9 +496,9 @@ func TestClient_S3s(t *testing.T) {
 
 	// Test that GzipLevel can be set for an endpoint where CompressionCodec
 	// was set at creation time.
-	record(t, "s3s/update3", func(c *Client) {
+	Record(t, "s3s/update3", func(c *Client) {
 		s3UpdateResp3, err = c.UpdateS3(&UpdateS3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-s3-3",
 			GzipLevel:      ToPointer(9),
@@ -510,9 +510,9 @@ func TestClient_S3s(t *testing.T) {
 
 	// Test that a configuration using an access key/secret key can be
 	// updated to use IAM role.
-	record(t, "s3s/update4", func(c *Client) {
+	Record(t, "s3s/update4", func(c *Client) {
 		s3UpdateResp4, err = c.UpdateS3(&UpdateS3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-s3",
 			AccessKey:      ToPointer(""),
@@ -526,9 +526,9 @@ func TestClient_S3s(t *testing.T) {
 
 	// Test that a configuration using an IAM role can be updated to use
 	// access key/secret key.
-	record(t, "s3s/update5", func(c *Client) {
+	Record(t, "s3s/update5", func(c *Client) {
 		s3UpdateResp5, err = c.UpdateS3(&UpdateS3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-s3-4",
 			AccessKey:      ToPointer("AKIAIOSFODNN7EXAMPLE"),
@@ -542,9 +542,9 @@ func TestClient_S3s(t *testing.T) {
 
 	// Test that an invalid IAM role ARN is rejected. This case is expected
 	// to fail.
-	record(t, "s3s/update6", func(c *Client) {
+	Record(t, "s3s/update6", func(c *Client) {
 		_, err = c.UpdateS3(&UpdateS3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-s3",
 			IAMRole:        ToPointer("badarn"),
@@ -601,9 +601,9 @@ func TestClient_S3s(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "s3s/delete", func(c *Client) {
+	Record(t, "s3s/delete", func(c *Client) {
 		err = c.DeleteS3(&DeleteS3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-s3",
 		})
@@ -616,14 +616,14 @@ func TestClient_S3s(t *testing.T) {
 func TestClient_ListS3s_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListS3s(&ListS3sInput{
+	_, err = TestClient.ListS3s(&ListS3sInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListS3s(&ListS3sInput{
+	_, err = TestClient.ListS3s(&ListS3sInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -635,7 +635,7 @@ func TestClient_ListS3s_validation(t *testing.T) {
 func TestClient_CreateS3_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateS3(&CreateS3Input{
+	_, err = TestClient.CreateS3(&CreateS3Input{
 		Name:                         ToPointer("test-service"),
 		ServerSideEncryption:         ToPointer(S3ServerSideEncryptionKMS),
 		ServerSideEncryptionKMSKeyID: ToPointer("1234"),
@@ -645,7 +645,7 @@ func TestClient_CreateS3_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateS3(&CreateS3Input{
+	_, err = TestClient.CreateS3(&CreateS3Input{
 		Name:                         ToPointer("test-service"),
 		ServerSideEncryption:         ToPointer(S3ServerSideEncryptionKMS),
 		ServerSideEncryptionKMSKeyID: ToPointer("1234"),
@@ -655,7 +655,7 @@ func TestClient_CreateS3_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateS3(&CreateS3Input{
+	_, err = TestClient.CreateS3(&CreateS3Input{
 		Name:                         ToPointer("test-service"),
 		ServerSideEncryption:         ToPointer(S3ServerSideEncryptionKMS),
 		ServerSideEncryptionKMSKeyID: ToPointer(""),
@@ -670,7 +670,7 @@ func TestClient_CreateS3_validation(t *testing.T) {
 func TestClient_GetS3_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetS3(&GetS3Input{
+	_, err = TestClient.GetS3(&GetS3Input{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -678,7 +678,7 @@ func TestClient_GetS3_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetS3(&GetS3Input{
+	_, err = TestClient.GetS3(&GetS3Input{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -686,7 +686,7 @@ func TestClient_GetS3_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetS3(&GetS3Input{
+	_, err = TestClient.GetS3(&GetS3Input{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -698,7 +698,7 @@ func TestClient_GetS3_validation(t *testing.T) {
 func TestClient_UpdateS3_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateS3(&UpdateS3Input{
+	_, err = TestClient.UpdateS3(&UpdateS3Input{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -706,7 +706,7 @@ func TestClient_UpdateS3_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateS3(&UpdateS3Input{
+	_, err = TestClient.UpdateS3(&UpdateS3Input{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -714,7 +714,7 @@ func TestClient_UpdateS3_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateS3(&UpdateS3Input{
+	_, err = TestClient.UpdateS3(&UpdateS3Input{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -722,7 +722,7 @@ func TestClient_UpdateS3_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateS3(&UpdateS3Input{
+	_, err = TestClient.UpdateS3(&UpdateS3Input{
 		Name:                         "test-service",
 		ServerSideEncryption:         ToPointer(S3ServerSideEncryptionKMS),
 		ServerSideEncryptionKMSKeyID: ToPointer(""),
@@ -737,7 +737,7 @@ func TestClient_UpdateS3_validation(t *testing.T) {
 func TestClient_DeleteS3_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteS3(&DeleteS3Input{
+	err = TestClient.DeleteS3(&DeleteS3Input{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -745,7 +745,7 @@ func TestClient_DeleteS3_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteS3(&DeleteS3Input{
+	err = TestClient.DeleteS3(&DeleteS3Input{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -753,7 +753,7 @@ func TestClient_DeleteS3_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteS3(&DeleteS3Input{
+	err = TestClient.DeleteS3(&DeleteS3Input{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_scalyr.go
+++ b/fastly/logging_scalyr.go
@@ -47,7 +47,7 @@ func (c *Client) ListScalyrs(i *ListScalyrsInput) ([]*Scalyr, error) {
 	defer resp.Body.Close()
 
 	var ss []*Scalyr
-	if err := decodeBodyMap(resp.Body, &ss); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 	return ss, nil
@@ -94,7 +94,7 @@ func (c *Client) CreateScalyr(i *CreateScalyrInput) (*Scalyr, error) {
 	defer resp.Body.Close()
 
 	var s *Scalyr
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -130,7 +130,7 @@ func (c *Client) GetScalyr(i *GetScalyrInput) (*Scalyr, error) {
 	defer resp.Body.Close()
 
 	var s *Scalyr
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -182,7 +182,7 @@ func (c *Client) UpdateScalyr(i *UpdateScalyrInput) (*Scalyr, error) {
 	defer resp.Body.Close()
 
 	var s *Scalyr
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -218,7 +218,7 @@ func (c *Client) DeleteScalyr(i *DeleteScalyrInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_scalyr_test.go
+++ b/fastly/logging_scalyr_test.go
@@ -9,15 +9,15 @@ func TestClient_Scalyrs(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "scalyrs/version", func(c *Client) {
+	Record(t, "scalyrs/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var s *Scalyr
-	record(t, "scalyrs/create", func(c *Client) {
+	Record(t, "scalyrs/create", func(c *Client) {
 		s, err = c.CreateScalyr(&CreateScalyrInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-scalyr"),
 			Format:         ToPointer("%h %l %u %t \"%r\" %>s %b"),
@@ -34,15 +34,15 @@ func TestClient_Scalyrs(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "scalyrs/cleanup", func(c *Client) {
+		Record(t, "scalyrs/cleanup", func(c *Client) {
 			_ = c.DeleteScalyr(&DeleteScalyrInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-scalyr",
 			})
 
 			_ = c.DeleteScalyr(&DeleteScalyrInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-scalyr",
 			})
@@ -73,9 +73,9 @@ func TestClient_Scalyrs(t *testing.T) {
 
 	// List
 	var ss []*Scalyr
-	record(t, "scalyrs/list", func(c *Client) {
+	Record(t, "scalyrs/list", func(c *Client) {
 		ss, err = c.ListScalyrs(&ListScalyrsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -88,9 +88,9 @@ func TestClient_Scalyrs(t *testing.T) {
 
 	// Get
 	var ns *Scalyr
-	record(t, "scalyrs/get", func(c *Client) {
+	Record(t, "scalyrs/get", func(c *Client) {
 		ns, err = c.GetScalyr(&GetScalyrInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-scalyr",
 		})
@@ -122,9 +122,9 @@ func TestClient_Scalyrs(t *testing.T) {
 
 	// Update
 	var us *Scalyr
-	record(t, "scalyrs/update", func(c *Client) {
+	Record(t, "scalyrs/update", func(c *Client) {
 		us, err = c.UpdateScalyr(&UpdateScalyrInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-scalyr",
 			NewName:        ToPointer("new-test-scalyr"),
@@ -150,9 +150,9 @@ func TestClient_Scalyrs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "scalyrs/delete", func(c *Client) {
+	Record(t, "scalyrs/delete", func(c *Client) {
 		err = c.DeleteScalyr(&DeleteScalyrInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-scalyr",
 		})
@@ -164,14 +164,14 @@ func TestClient_Scalyrs(t *testing.T) {
 
 func TestClient_ListScalyrs_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListScalyrs(&ListScalyrsInput{
+	_, err = TestClient.ListScalyrs(&ListScalyrsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListScalyrs(&ListScalyrsInput{
+	_, err = TestClient.ListScalyrs(&ListScalyrsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -182,14 +182,14 @@ func TestClient_ListScalyrs_validation(t *testing.T) {
 
 func TestClient_CreateScalyr_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateScalyr(&CreateScalyrInput{
+	_, err = TestClient.CreateScalyr(&CreateScalyrInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateScalyr(&CreateScalyrInput{
+	_, err = TestClient.CreateScalyr(&CreateScalyrInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -201,7 +201,7 @@ func TestClient_CreateScalyr_validation(t *testing.T) {
 func TestClient_GetScalyr_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetScalyr(&GetScalyrInput{
+	_, err = TestClient.GetScalyr(&GetScalyrInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -209,7 +209,7 @@ func TestClient_GetScalyr_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetScalyr(&GetScalyrInput{
+	_, err = TestClient.GetScalyr(&GetScalyrInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -217,7 +217,7 @@ func TestClient_GetScalyr_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetScalyr(&GetScalyrInput{
+	_, err = TestClient.GetScalyr(&GetScalyrInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -229,7 +229,7 @@ func TestClient_GetScalyr_validation(t *testing.T) {
 func TestClient_UpdateScalyr_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateScalyr(&UpdateScalyrInput{
+	_, err = TestClient.UpdateScalyr(&UpdateScalyrInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -237,7 +237,7 @@ func TestClient_UpdateScalyr_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateScalyr(&UpdateScalyrInput{
+	_, err = TestClient.UpdateScalyr(&UpdateScalyrInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -245,7 +245,7 @@ func TestClient_UpdateScalyr_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateScalyr(&UpdateScalyrInput{
+	_, err = TestClient.UpdateScalyr(&UpdateScalyrInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -257,7 +257,7 @@ func TestClient_UpdateScalyr_validation(t *testing.T) {
 func TestClient_DeleteScalyr_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteScalyr(&DeleteScalyrInput{
+	err = TestClient.DeleteScalyr(&DeleteScalyrInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -265,7 +265,7 @@ func TestClient_DeleteScalyr_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteScalyr(&DeleteScalyrInput{
+	err = TestClient.DeleteScalyr(&DeleteScalyrInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -273,7 +273,7 @@ func TestClient_DeleteScalyr_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteScalyr(&DeleteScalyrInput{
+	err = TestClient.DeleteScalyr(&DeleteScalyrInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_sftp.go
+++ b/fastly/logging_sftp.go
@@ -57,7 +57,7 @@ func (c *Client) ListSFTPs(i *ListSFTPsInput) ([]*SFTP, error) {
 	defer resp.Body.Close()
 
 	var sftps []*SFTP
-	if err := decodeBodyMap(resp.Body, &sftps); err != nil {
+	if err := DecodeBodyMap(resp.Body, &sftps); err != nil {
 		return nil, err
 	}
 	return sftps, nil
@@ -124,7 +124,7 @@ func (c *Client) CreateSFTP(i *CreateSFTPInput) (*SFTP, error) {
 	defer resp.Body.Close()
 
 	var ftp *SFTP
-	if err := decodeBodyMap(resp.Body, &ftp); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ftp); err != nil {
 		return nil, err
 	}
 	return ftp, nil
@@ -160,7 +160,7 @@ func (c *Client) GetSFTP(i *GetSFTPInput) (*SFTP, error) {
 	defer resp.Body.Close()
 
 	var b *SFTP
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -232,7 +232,7 @@ func (c *Client) UpdateSFTP(i *UpdateSFTPInput) (*SFTP, error) {
 	defer resp.Body.Close()
 
 	var b *SFTP
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -268,7 +268,7 @@ func (c *Client) DeleteSFTP(i *DeleteSFTPInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_sftp_test.go
+++ b/fastly/logging_sftp_test.go
@@ -10,16 +10,16 @@ func TestClient_SFTPs(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "sftps/version", func(c *Client) {
+	Record(t, "sftps/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 	knownHosts := "example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEmuNYPrqg9tjqfR14ye3Pvsm9sjIx6EJwm5tMXIMaN1"
 
 	// Create
 	var sftpCreateResp1, sftpCreateResp2, sftpCreateResp3 *SFTP
-	record(t, "sftps/create", func(c *Client) {
+	Record(t, "sftps/create", func(c *Client) {
 		sftpCreateResp1, err = c.CreateSFTP(&CreateSFTPInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-sftp"),
 			Address:          ToPointer("example.com"),
@@ -43,9 +43,9 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "sftps/create2", func(c *Client) {
+	Record(t, "sftps/create2", func(c *Client) {
 		sftpCreateResp2, err = c.CreateSFTP(&CreateSFTPInput{
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 			Name:            ToPointer("test-sftp-2"),
 			Address:         ToPointer("example.com"),
@@ -69,9 +69,9 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "sftps/create3", func(c *Client) {
+	Record(t, "sftps/create3", func(c *Client) {
 		sftpCreateResp3, err = c.CreateSFTP(&CreateSFTPInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-sftp-3"),
 			Address:          ToPointer("example.com"),
@@ -97,9 +97,9 @@ func TestClient_SFTPs(t *testing.T) {
 
 	// This case is expected to fail because both CompressionCodec and
 	// GzipLevel are present.
-	record(t, "sftps/create4", func(c *Client) {
+	Record(t, "sftps/create4", func(c *Client) {
 		_, err = c.CreateSFTP(&CreateSFTPInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             ToPointer("test-sftp-4"),
 			Address:          ToPointer("example.com"),
@@ -126,27 +126,27 @@ func TestClient_SFTPs(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "sftps/cleanup", func(c *Client) {
+		Record(t, "sftps/cleanup", func(c *Client) {
 			_ = c.DeleteSFTP(&DeleteSFTPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-sftp",
 			})
 
 			_ = c.DeleteSFTP(&DeleteSFTPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-sftp-2",
 			})
 
 			_ = c.DeleteSFTP(&DeleteSFTPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-sftp-3",
 			})
 
 			_ = c.DeleteSFTP(&DeleteSFTPInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-sftp",
 			})
@@ -219,9 +219,9 @@ func TestClient_SFTPs(t *testing.T) {
 
 	// List
 	var sftps []*SFTP
-	record(t, "sftps/list", func(c *Client) {
+	Record(t, "sftps/list", func(c *Client) {
 		sftps, err = c.ListSFTPs(&ListSFTPsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -234,9 +234,9 @@ func TestClient_SFTPs(t *testing.T) {
 
 	// Get
 	var sftpGetResp *SFTP
-	record(t, "sftps/get", func(c *Client) {
+	Record(t, "sftps/get", func(c *Client) {
 		sftpGetResp, err = c.GetSFTP(&GetSFTPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-sftp",
 		})
@@ -299,9 +299,9 @@ func TestClient_SFTPs(t *testing.T) {
 
 	// Update
 	var sftpUpdateResp1, sftpUpdateResp2, sftpUpdateResp3 *SFTP
-	record(t, "sftps/update", func(c *Client) {
+	Record(t, "sftps/update", func(c *Client) {
 		sftpUpdateResp1, err = c.UpdateSFTP(&UpdateSFTPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-sftp",
 			NewName:        ToPointer("new-test-sftp"),
@@ -313,9 +313,9 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "sftps/update2", func(c *Client) {
+	Record(t, "sftps/update2", func(c *Client) {
 		sftpUpdateResp2, err = c.UpdateSFTP(&UpdateSFTPInput{
-			ServiceID:        testDeliveryServiceID,
+			ServiceID:        TestDeliveryServiceID,
 			ServiceVersion:   *tv.Number,
 			Name:             "test-sftp-2",
 			CompressionCodec: ToPointer("zstd"),
@@ -325,9 +325,9 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "sftps/update3", func(c *Client) {
+	Record(t, "sftps/update3", func(c *Client) {
 		sftpUpdateResp3, err = c.UpdateSFTP(&UpdateSFTPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-sftp-3",
 			GzipLevel:      ToPointer(9),
@@ -363,9 +363,9 @@ func TestClient_SFTPs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "sftps/delete", func(c *Client) {
+	Record(t, "sftps/delete", func(c *Client) {
 		err = c.DeleteSFTP(&DeleteSFTPInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-sftp",
 		})
@@ -378,14 +378,14 @@ func TestClient_SFTPs(t *testing.T) {
 func TestClient_ListSFTPs_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListSFTPs(&ListSFTPsInput{
+	_, err = TestClient.ListSFTPs(&ListSFTPsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListSFTPs(&ListSFTPsInput{
+	_, err = TestClient.ListSFTPs(&ListSFTPsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -397,14 +397,14 @@ func TestClient_ListSFTPs_validation(t *testing.T) {
 func TestClient_CreateSFTP_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateSFTP(&CreateSFTPInput{
+	_, err = TestClient.CreateSFTP(&CreateSFTPInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateSFTP(&CreateSFTPInput{
+	_, err = TestClient.CreateSFTP(&CreateSFTPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -416,7 +416,7 @@ func TestClient_CreateSFTP_validation(t *testing.T) {
 func TestClient_GetSFTP_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetSFTP(&GetSFTPInput{
+	_, err = TestClient.GetSFTP(&GetSFTPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -424,7 +424,7 @@ func TestClient_GetSFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetSFTP(&GetSFTPInput{
+	_, err = TestClient.GetSFTP(&GetSFTPInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -432,7 +432,7 @@ func TestClient_GetSFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetSFTP(&GetSFTPInput{
+	_, err = TestClient.GetSFTP(&GetSFTPInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -444,7 +444,7 @@ func TestClient_GetSFTP_validation(t *testing.T) {
 func TestClient_UpdateSFTP_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateSFTP(&UpdateSFTPInput{
+	_, err = TestClient.UpdateSFTP(&UpdateSFTPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -452,7 +452,7 @@ func TestClient_UpdateSFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateSFTP(&UpdateSFTPInput{
+	_, err = TestClient.UpdateSFTP(&UpdateSFTPInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -460,7 +460,7 @@ func TestClient_UpdateSFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateSFTP(&UpdateSFTPInput{
+	_, err = TestClient.UpdateSFTP(&UpdateSFTPInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -472,7 +472,7 @@ func TestClient_UpdateSFTP_validation(t *testing.T) {
 func TestClient_DeleteSFTP_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteSFTP(&DeleteSFTPInput{
+	err = TestClient.DeleteSFTP(&DeleteSFTPInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -480,7 +480,7 @@ func TestClient_DeleteSFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteSFTP(&DeleteSFTPInput{
+	err = TestClient.DeleteSFTP(&DeleteSFTPInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -488,7 +488,7 @@ func TestClient_DeleteSFTP_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteSFTP(&DeleteSFTPInput{
+	err = TestClient.DeleteSFTP(&DeleteSFTPInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_splunk.go
+++ b/fastly/logging_splunk.go
@@ -53,7 +53,7 @@ func (c *Client) ListSplunks(i *ListSplunksInput) ([]*Splunk, error) {
 	defer resp.Body.Close()
 
 	var ss []*Splunk
-	if err := decodeBodyMap(resp.Body, &ss); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 	return ss, nil
@@ -112,7 +112,7 @@ func (c *Client) CreateSplunk(i *CreateSplunkInput) (*Splunk, error) {
 	defer resp.Body.Close()
 
 	var s *Splunk
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -148,7 +148,7 @@ func (c *Client) GetSplunk(i *GetSplunkInput) (*Splunk, error) {
 	defer resp.Body.Close()
 
 	var s *Splunk
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -212,7 +212,7 @@ func (c *Client) UpdateSplunk(i *UpdateSplunkInput) (*Splunk, error) {
 	defer resp.Body.Close()
 
 	var s *Splunk
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -248,7 +248,7 @@ func (c *Client) DeleteSplunk(i *DeleteSplunkInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_splunk_test.go
+++ b/fastly/logging_splunk_test.go
@@ -10,7 +10,7 @@ func TestClient_Splunks(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "splunks/version", func(c *Client) {
+	Record(t, "splunks/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -36,9 +36,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Create
 	var s *Splunk
-	record(t, "splunks/create", func(c *Client) {
+	Record(t, "splunks/create", func(c *Client) {
 		s, err = c.CreateSplunk(&CreateSplunkInput{
-			ServiceID:         testDeliveryServiceID,
+			ServiceID:         TestDeliveryServiceID,
 			ServiceVersion:    *tv.Number,
 			Name:              ToPointer("test-splunk"),
 			URL:               ToPointer("https://mysplunkendpoint.example.com/services/collector/event"),
@@ -61,15 +61,15 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Ensure deleted
 	defer func() {
-		record(t, "splunks/cleanup", func(c *Client) {
+		Record(t, "splunks/cleanup", func(c *Client) {
 			_ = c.DeleteSplunk(&DeleteSplunkInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-splunk",
 			})
 
 			_ = c.DeleteSplunk(&DeleteSplunkInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-splunk",
 			})
@@ -118,9 +118,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// List
 	var ss []*Splunk
-	record(t, "splunks/list", func(c *Client) {
+	Record(t, "splunks/list", func(c *Client) {
 		ss, err = c.ListSplunks(&ListSplunksInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -133,9 +133,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Get
 	var ns *Splunk
-	record(t, "splunks/get", func(c *Client) {
+	Record(t, "splunks/get", func(c *Client) {
 		ns, err = c.GetSplunk(&GetSplunkInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-splunk",
 		})
@@ -185,9 +185,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Update
 	var us *Splunk
-	record(t, "splunks/update", func(c *Client) {
+	Record(t, "splunks/update", func(c *Client) {
 		us, err = c.UpdateSplunk(&UpdateSplunkInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-splunk",
 			NewName:        ToPointer("new-test-splunk"),
@@ -201,9 +201,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	}
 
 	// Delete
-	record(t, "splunks/delete", func(c *Client) {
+	Record(t, "splunks/delete", func(c *Client) {
 		err = c.DeleteSplunk(&DeleteSplunkInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-splunk",
 		})
@@ -215,14 +215,14 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 func TestClient_ListSplunks_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListSplunks(&ListSplunksInput{
+	_, err = TestClient.ListSplunks(&ListSplunksInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListSplunks(&ListSplunksInput{
+	_, err = TestClient.ListSplunks(&ListSplunksInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -233,14 +233,14 @@ func TestClient_ListSplunks_validation(t *testing.T) {
 
 func TestClient_CreateSplunk_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateSplunk(&CreateSplunkInput{
+	_, err = TestClient.CreateSplunk(&CreateSplunkInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateSplunk(&CreateSplunkInput{
+	_, err = TestClient.CreateSplunk(&CreateSplunkInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -252,7 +252,7 @@ func TestClient_CreateSplunk_validation(t *testing.T) {
 func TestClient_GetSplunk_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetSplunk(&GetSplunkInput{
+	_, err = TestClient.GetSplunk(&GetSplunkInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -260,7 +260,7 @@ func TestClient_GetSplunk_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetSplunk(&GetSplunkInput{
+	_, err = TestClient.GetSplunk(&GetSplunkInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -268,7 +268,7 @@ func TestClient_GetSplunk_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetSplunk(&GetSplunkInput{
+	_, err = TestClient.GetSplunk(&GetSplunkInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -280,7 +280,7 @@ func TestClient_GetSplunk_validation(t *testing.T) {
 func TestClient_UpdateSplunk_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateSplunk(&UpdateSplunkInput{
+	_, err = TestClient.UpdateSplunk(&UpdateSplunkInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -288,7 +288,7 @@ func TestClient_UpdateSplunk_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateSplunk(&UpdateSplunkInput{
+	_, err = TestClient.UpdateSplunk(&UpdateSplunkInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -296,7 +296,7 @@ func TestClient_UpdateSplunk_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateSplunk(&UpdateSplunkInput{
+	_, err = TestClient.UpdateSplunk(&UpdateSplunkInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -308,7 +308,7 @@ func TestClient_UpdateSplunk_validation(t *testing.T) {
 func TestClient_DeleteSplunk_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteSplunk(&DeleteSplunkInput{
+	err = TestClient.DeleteSplunk(&DeleteSplunkInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -316,7 +316,7 @@ func TestClient_DeleteSplunk_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteSplunk(&DeleteSplunkInput{
+	err = TestClient.DeleteSplunk(&DeleteSplunkInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -324,7 +324,7 @@ func TestClient_DeleteSplunk_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteSplunk(&DeleteSplunkInput{
+	err = TestClient.DeleteSplunk(&DeleteSplunkInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_sumologic.go
+++ b/fastly/logging_sumologic.go
@@ -47,7 +47,7 @@ func (c *Client) ListSumologics(i *ListSumologicsInput) ([]*Sumologic, error) {
 	defer resp.Body.Close()
 
 	var ss []*Sumologic
-	if err := decodeBodyMap(resp.Body, &ss); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 	return ss, nil
@@ -92,7 +92,7 @@ func (c *Client) CreateSumologic(i *CreateSumologicInput) (*Sumologic, error) {
 	defer resp.Body.Close()
 
 	var s *Sumologic
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -128,7 +128,7 @@ func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
 	defer resp.Body.Close()
 
 	var s *Sumologic
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -179,7 +179,7 @@ func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
 	defer resp.Body.Close()
 
 	var s *Sumologic
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -215,7 +215,7 @@ func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_sumologic_test.go
+++ b/fastly/logging_sumologic_test.go
@@ -9,15 +9,15 @@ func TestClient_Sumologics(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "sumologics/version", func(c *Client) {
+	Record(t, "sumologics/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var s *Sumologic
-	record(t, "sumologics/create", func(c *Client) {
+	Record(t, "sumologics/create", func(c *Client) {
 		s, err = c.CreateSumologic(&CreateSumologicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-sumologic"),
 			URL:            ToPointer("https://foo.sumologic.com"),
@@ -33,15 +33,15 @@ func TestClient_Sumologics(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "sumologics/cleanup", func(c *Client) {
+		Record(t, "sumologics/cleanup", func(c *Client) {
 			_ = c.DeleteSumologic(&DeleteSumologicInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-sumologic",
 			})
 
 			_ = c.DeleteSumologic(&DeleteSumologicInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-sumologic",
 			})
@@ -69,9 +69,9 @@ func TestClient_Sumologics(t *testing.T) {
 
 	// List
 	var ss []*Sumologic
-	record(t, "sumologics/list", func(c *Client) {
+	Record(t, "sumologics/list", func(c *Client) {
 		ss, err = c.ListSumologics(&ListSumologicsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -84,9 +84,9 @@ func TestClient_Sumologics(t *testing.T) {
 
 	// Get
 	var ns *Sumologic
-	record(t, "sumologics/get", func(c *Client) {
+	Record(t, "sumologics/get", func(c *Client) {
 		ns, err = c.GetSumologic(&GetSumologicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-sumologic",
 		})
@@ -115,9 +115,9 @@ func TestClient_Sumologics(t *testing.T) {
 
 	// Update
 	var us *Sumologic
-	record(t, "sumologics/update", func(c *Client) {
+	Record(t, "sumologics/update", func(c *Client) {
 		us, err = c.UpdateSumologic(&UpdateSumologicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-sumologic",
 			NewName:        ToPointer("new-test-sumologic"),
@@ -131,9 +131,9 @@ func TestClient_Sumologics(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "sumologics/delete", func(c *Client) {
+	Record(t, "sumologics/delete", func(c *Client) {
 		err = c.DeleteSumologic(&DeleteSumologicInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-sumologic",
 		})
@@ -145,14 +145,14 @@ func TestClient_Sumologics(t *testing.T) {
 
 func TestClient_ListSumologics_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListSumologics(&ListSumologicsInput{
+	_, err = TestClient.ListSumologics(&ListSumologicsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListSumologics(&ListSumologicsInput{
+	_, err = TestClient.ListSumologics(&ListSumologicsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -163,14 +163,14 @@ func TestClient_ListSumologics_validation(t *testing.T) {
 
 func TestClient_CreateSumologic_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateSumologic(&CreateSumologicInput{
+	_, err = TestClient.CreateSumologic(&CreateSumologicInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateSumologic(&CreateSumologicInput{
+	_, err = TestClient.CreateSumologic(&CreateSumologicInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -182,7 +182,7 @@ func TestClient_CreateSumologic_validation(t *testing.T) {
 func TestClient_GetSumologic_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetSumologic(&GetSumologicInput{
+	_, err = TestClient.GetSumologic(&GetSumologicInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -190,7 +190,7 @@ func TestClient_GetSumologic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetSumologic(&GetSumologicInput{
+	_, err = TestClient.GetSumologic(&GetSumologicInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -198,7 +198,7 @@ func TestClient_GetSumologic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetSumologic(&GetSumologicInput{
+	_, err = TestClient.GetSumologic(&GetSumologicInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -210,7 +210,7 @@ func TestClient_GetSumologic_validation(t *testing.T) {
 func TestClient_UpdateSumologic_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateSumologic(&UpdateSumologicInput{
+	_, err = TestClient.UpdateSumologic(&UpdateSumologicInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -218,7 +218,7 @@ func TestClient_UpdateSumologic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateSumologic(&UpdateSumologicInput{
+	_, err = TestClient.UpdateSumologic(&UpdateSumologicInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -226,7 +226,7 @@ func TestClient_UpdateSumologic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateSumologic(&UpdateSumologicInput{
+	_, err = TestClient.UpdateSumologic(&UpdateSumologicInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -238,7 +238,7 @@ func TestClient_UpdateSumologic_validation(t *testing.T) {
 func TestClient_DeleteSumologic_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteSumologic(&DeleteSumologicInput{
+	err = TestClient.DeleteSumologic(&DeleteSumologicInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -246,7 +246,7 @@ func TestClient_DeleteSumologic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteSumologic(&DeleteSumologicInput{
+	err = TestClient.DeleteSumologic(&DeleteSumologicInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -254,7 +254,7 @@ func TestClient_DeleteSumologic_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteSumologic(&DeleteSumologicInput{
+	err = TestClient.DeleteSumologic(&DeleteSumologicInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/logging_syslog.go
+++ b/fastly/logging_syslog.go
@@ -55,7 +55,7 @@ func (c *Client) ListSyslogs(i *ListSyslogsInput) ([]*Syslog, error) {
 	defer resp.Body.Close()
 
 	var ss []*Syslog
-	if err := decodeBodyMap(resp.Body, &ss); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ss); err != nil {
 		return nil, err
 	}
 	return ss, nil
@@ -118,7 +118,7 @@ func (c *Client) CreateSyslog(i *CreateSyslogInput) (*Syslog, error) {
 	defer resp.Body.Close()
 
 	var s *Syslog
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -154,7 +154,7 @@ func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
 	defer resp.Body.Close()
 
 	var s *Syslog
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -222,7 +222,7 @@ func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
 	defer resp.Body.Close()
 
 	var s *Syslog
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -258,7 +258,7 @@ func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/logging_syslog_test.go
+++ b/fastly/logging_syslog_test.go
@@ -10,7 +10,7 @@ func TestClient_Syslogs(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "syslogs/version", func(c *Client) {
+	Record(t, "syslogs/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -36,9 +36,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Create
 	var s *Syslog
-	record(t, "syslogs/create", func(c *Client) {
+	Record(t, "syslogs/create", func(c *Client) {
 		s, err = c.CreateSyslog(&CreateSyslogInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-syslog"),
 			Address:        ToPointer("example.com"),
@@ -62,15 +62,15 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Ensure deleted
 	defer func() {
-		record(t, "syslogs/cleanup", func(c *Client) {
+		Record(t, "syslogs/cleanup", func(c *Client) {
 			_ = c.DeleteSyslog(&DeleteSyslogInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-syslog",
 			})
 
 			_ = c.DeleteSyslog(&DeleteSyslogInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-syslog",
 			})
@@ -122,9 +122,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// List
 	var ss []*Syslog
-	record(t, "syslogs/list", func(c *Client) {
+	Record(t, "syslogs/list", func(c *Client) {
 		ss, err = c.ListSyslogs(&ListSyslogsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -137,9 +137,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Get
 	var ns *Syslog
-	record(t, "syslogs/get", func(c *Client) {
+	Record(t, "syslogs/get", func(c *Client) {
 		ns, err = c.GetSyslog(&GetSyslogInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-syslog",
 		})
@@ -192,9 +192,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 	// Update
 	var us *Syslog
-	record(t, "syslogs/update", func(c *Client) {
+	Record(t, "syslogs/update", func(c *Client) {
 		us, err = c.UpdateSyslog(&UpdateSyslogInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-syslog",
 			NewName:        ToPointer("new-test-syslog"),
@@ -213,9 +213,9 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 	}
 
 	// Delete
-	record(t, "syslogs/delete", func(c *Client) {
+	Record(t, "syslogs/delete", func(c *Client) {
 		err = c.DeleteSyslog(&DeleteSyslogInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-syslog",
 		})
@@ -227,14 +227,14 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 
 func TestClient_ListSyslogs_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListSyslogs(&ListSyslogsInput{
+	_, err = TestClient.ListSyslogs(&ListSyslogsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListSyslogs(&ListSyslogsInput{
+	_, err = TestClient.ListSyslogs(&ListSyslogsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -245,14 +245,14 @@ func TestClient_ListSyslogs_validation(t *testing.T) {
 
 func TestClient_CreateSyslog_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateSyslog(&CreateSyslogInput{
+	_, err = TestClient.CreateSyslog(&CreateSyslogInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateSyslog(&CreateSyslogInput{
+	_, err = TestClient.CreateSyslog(&CreateSyslogInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -264,7 +264,7 @@ func TestClient_CreateSyslog_validation(t *testing.T) {
 func TestClient_GetSyslog_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetSyslog(&GetSyslogInput{
+	_, err = TestClient.GetSyslog(&GetSyslogInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -272,7 +272,7 @@ func TestClient_GetSyslog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetSyslog(&GetSyslogInput{
+	_, err = TestClient.GetSyslog(&GetSyslogInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -280,7 +280,7 @@ func TestClient_GetSyslog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetSyslog(&GetSyslogInput{
+	_, err = TestClient.GetSyslog(&GetSyslogInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -292,7 +292,7 @@ func TestClient_GetSyslog_validation(t *testing.T) {
 func TestClient_UpdateSyslog_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateSyslog(&UpdateSyslogInput{
+	_, err = TestClient.UpdateSyslog(&UpdateSyslogInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -300,7 +300,7 @@ func TestClient_UpdateSyslog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateSyslog(&UpdateSyslogInput{
+	_, err = TestClient.UpdateSyslog(&UpdateSyslogInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -308,7 +308,7 @@ func TestClient_UpdateSyslog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateSyslog(&UpdateSyslogInput{
+	_, err = TestClient.UpdateSyslog(&UpdateSyslogInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -320,7 +320,7 @@ func TestClient_UpdateSyslog_validation(t *testing.T) {
 func TestClient_DeleteSyslog_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteSyslog(&DeleteSyslogInput{
+	err = TestClient.DeleteSyslog(&DeleteSyslogInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -328,7 +328,7 @@ func TestClient_DeleteSyslog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteSyslog(&DeleteSyslogInput{
+	err = TestClient.DeleteSyslog(&DeleteSyslogInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -336,7 +336,7 @@ func TestClient_DeleteSyslog_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteSyslog(&DeleteSyslogInput{
+	err = TestClient.DeleteSyslog(&DeleteSyslogInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/managed_logging.go
+++ b/fastly/managed_logging.go
@@ -61,7 +61,7 @@ func (c *Client) CreateManagedLogging(i *CreateManagedLoggingInput) (*ManagedLog
 	defer resp.Body.Close()
 
 	var m *ManagedLogging
-	if err := decodeBodyMap(resp.Body, &m); err != nil {
+	if err := DecodeBodyMap(resp.Body, &m); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/fastly/managed_logging_test.go
+++ b/fastly/managed_logging_test.go
@@ -8,9 +8,9 @@ func TestClient_ManagedLogging(t *testing.T) {
 	var err error
 
 	// Create
-	record(t, "managed_logging/create", func(c *Client) {
+	Record(t, "managed_logging/create", func(c *Client) {
 		_, err = c.CreateManagedLogging(&CreateManagedLoggingInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			Kind:      ManagedLoggingInstanceOutput,
 		})
 	})
@@ -20,9 +20,9 @@ func TestClient_ManagedLogging(t *testing.T) {
 
 	// Test that enabling managed logging on a service with it already
 	// enabled results in a 409.
-	record(t, "managed_logging/recreate", func(c *Client) {
+	Record(t, "managed_logging/recreate", func(c *Client) {
 		_, err = c.CreateManagedLogging(&CreateManagedLoggingInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			Kind:      ManagedLoggingInstanceOutput,
 		})
 	})
@@ -31,9 +31,9 @@ func TestClient_ManagedLogging(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "managed_logging/delete", func(c *Client) {
+	Record(t, "managed_logging/delete", func(c *Client) {
 		err = c.DeleteManagedLogging(&DeleteManagedLoggingInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			Kind:      ManagedLoggingInstanceOutput,
 		})
 	})
@@ -43,7 +43,7 @@ func TestClient_ManagedLogging(t *testing.T) {
 }
 
 func TestClient_CreateManagedLogging_validation(t *testing.T) {
-	_, err := testClient.CreateManagedLogging(&CreateManagedLoggingInput{
+	_, err := TestClient.CreateManagedLogging(&CreateManagedLoggingInput{
 		ServiceID: "",
 		Kind:      ManagedLoggingInstanceOutput,
 	})
@@ -51,15 +51,15 @@ func TestClient_CreateManagedLogging_validation(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 
-	_, err = testClient.CreateManagedLogging(&CreateManagedLoggingInput{
-		ServiceID: testDeliveryServiceID,
+	_, err = TestClient.CreateManagedLogging(&CreateManagedLoggingInput{
+		ServiceID: TestDeliveryServiceID,
 	})
 	if err != ErrMissingKind {
 		t.Errorf("unexpected error: %s", err)
 	}
 
-	_, err = testClient.CreateManagedLogging(&CreateManagedLoggingInput{
-		ServiceID: testDeliveryServiceID,
+	_, err = TestClient.CreateManagedLogging(&CreateManagedLoggingInput{
+		ServiceID: TestDeliveryServiceID,
 		Kind:      999,
 	})
 	if err != ErrNotImplemented {
@@ -68,7 +68,7 @@ func TestClient_CreateManagedLogging_validation(t *testing.T) {
 }
 
 func TestClient_DeleteManagedLogging_validation(t *testing.T) {
-	err := testClient.DeleteManagedLogging(&DeleteManagedLoggingInput{
+	err := TestClient.DeleteManagedLogging(&DeleteManagedLoggingInput{
 		ServiceID: "",
 		Kind:      ManagedLoggingInstanceOutput,
 	})
@@ -76,15 +76,15 @@ func TestClient_DeleteManagedLogging_validation(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 
-	err = testClient.DeleteManagedLogging(&DeleteManagedLoggingInput{
-		ServiceID: testDeliveryServiceID,
+	err = TestClient.DeleteManagedLogging(&DeleteManagedLoggingInput{
+		ServiceID: TestDeliveryServiceID,
 	})
 	if err != ErrMissingKind {
 		t.Errorf("unexpected error: %s", err)
 	}
 
-	err = testClient.DeleteManagedLogging(&DeleteManagedLoggingInput{
-		ServiceID: testDeliveryServiceID,
+	err = TestClient.DeleteManagedLogging(&DeleteManagedLoggingInput{
+		ServiceID: TestDeliveryServiceID,
 		Kind:      999,
 	})
 	if err != ErrNotImplemented {

--- a/fastly/notifications_test.go
+++ b/fastly/notifications_test.go
@@ -10,7 +10,7 @@ func TestClient_Notifications(t *testing.T) {
 
 	// Get integration types
 	var its *[]IntegrationType
-	record(t, "notifications/get_integration_types", func(c *Client) {
+	Record(t, "notifications/get_integration_types", func(c *Client) {
 		its, err = c.GetIntegrationTypes()
 	})
 	if err != nil {
@@ -31,12 +31,12 @@ func TestClient_Notifications(t *testing.T) {
 
 	// Create integration
 	var cir *CreateIntegrationResponse
-	record(t, "notifications/create_integration", func(c *Client) {
+	Record(t, "notifications/create_integration", func(c *Client) {
 		cir, err = c.CreateIntegration(cii)
 	})
 	// Ensure integration deleted
 	defer func() {
-		record(t, "notifications/cleanup_integration", func(c *Client) {
+		Record(t, "notifications/cleanup_integration", func(c *Client) {
 			err = c.DeleteIntegration(&DeleteIntegrationInput{
 				ID: *cir.ID,
 			})
@@ -48,7 +48,7 @@ func TestClient_Notifications(t *testing.T) {
 
 	// Search integrations
 	var sir *SearchIntegrationsResponse
-	record(t, "notifications/search_integrations", func(c *Client) {
+	Record(t, "notifications/search_integrations", func(c *Client) {
 		sir, err = c.SearchIntegrations(&SearchIntegrationsInput{
 			Cursor: ToPointer(""),
 			Limit:  ToPointer(3),
@@ -77,7 +77,7 @@ func TestClient_Notifications(t *testing.T) {
 
 	// Get integration
 	var gi *Integration
-	record(t, "notifications/get_integration", func(c *Client) {
+	Record(t, "notifications/get_integration", func(c *Client) {
 		gi, err = c.GetIntegration(&GetIntegrationInput{
 			ID: *cir.ID,
 		})
@@ -105,7 +105,7 @@ func TestClient_Notifications(t *testing.T) {
 	}
 
 	// Create mailinglist integration confirmation
-	record(t, "notifications/create_mailinglist_confirmation", func(c *Client) {
+	Record(t, "notifications/create_mailinglist_confirmation", func(c *Client) {
 		err = c.CreateMailinglistConfirmation(&CreateMailinglistConfirmationInput{
 			Email: ToPointer("noreply@fastly.com"),
 		})
@@ -115,7 +115,7 @@ func TestClient_Notifications(t *testing.T) {
 	}
 
 	// Update integration
-	record(t, "notifications/update_integration", func(c *Client) {
+	Record(t, "notifications/update_integration", func(c *Client) {
 		err = c.UpdateIntegration(&UpdateIntegrationInput{
 			Config: map[string]string{
 				"url": "https://foo.com/bar",
@@ -132,7 +132,7 @@ func TestClient_Notifications(t *testing.T) {
 
 	// Rotate webhook integration signing key
 	var rwskr *WebhookSigningKeyResponse
-	record(t, "notifications/rotate_webhook_signing_key", func(c *Client) {
+	Record(t, "notifications/rotate_webhook_signing_key", func(c *Client) {
 		rwskr, err = c.RotateWebhookSigningKey(&RotateWebhookSigningKeyInput{
 			IntegrationID: *gi.ID,
 		})
@@ -146,7 +146,7 @@ func TestClient_Notifications(t *testing.T) {
 
 	// Get webhook integration signing key
 	var gwskr *WebhookSigningKeyResponse
-	record(t, "notifications/get_webhook_signing_key", func(c *Client) {
+	Record(t, "notifications/get_webhook_signing_key", func(c *Client) {
 		gwskr, err = c.GetWebhookSigningKey(&GetWebhookSigningKeyInput{
 			IntegrationID: *gi.ID,
 		})
@@ -159,7 +159,7 @@ func TestClient_Notifications(t *testing.T) {
 	}
 
 	// Delete integration
-	record(t, "notifications/delete_integration", func(c *Client) {
+	Record(t, "notifications/delete_integration", func(c *Client) {
 		err = c.DeleteIntegration(&DeleteIntegrationInput{
 			ID: *gi.ID,
 		})
@@ -170,35 +170,35 @@ func TestClient_Notifications(t *testing.T) {
 }
 
 func TestClient_GetIntegration_validation(t *testing.T) {
-	_, err := testClient.GetIntegration(&GetIntegrationInput{})
+	_, err := TestClient.GetIntegration(&GetIntegrationInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
 }
 
 func TestClient_UpdateIntegration_validation(t *testing.T) {
-	err := testClient.UpdateIntegration(&UpdateIntegrationInput{})
+	err := TestClient.UpdateIntegration(&UpdateIntegrationInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
 }
 
 func TestClient_DeleteIntegration_validation(t *testing.T) {
-	err := testClient.DeleteIntegration(&DeleteIntegrationInput{})
+	err := TestClient.DeleteIntegration(&DeleteIntegrationInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
 }
 
 func TestClient_GetWebhookSigningKey_validation(t *testing.T) {
-	_, err := testClient.GetWebhookSigningKey(&GetWebhookSigningKeyInput{})
+	_, err := TestClient.GetWebhookSigningKey(&GetWebhookSigningKeyInput{})
 	if err != ErrMissingIntegrationID {
 		t.Errorf("bad error: %s", err)
 	}
 }
 
 func TestClient_RotateWebhookSigningKey_validation(t *testing.T) {
-	_, err := testClient.RotateWebhookSigningKey(&RotateWebhookSigningKeyInput{})
+	_, err := TestClient.RotateWebhookSigningKey(&RotateWebhookSigningKeyInput{})
 	if err != ErrMissingIntegrationID {
 		t.Errorf("bad error: %s", err)
 	}

--- a/fastly/observability_custom_dashboard_test.go
+++ b/fastly/observability_custom_dashboard_test.go
@@ -34,7 +34,7 @@ func TestClient_ObservabilityCustomDashboards(t *testing.T) {
 
 	// Create
 	var ocd *ObservabilityCustomDashboard
-	record(t, "observability_custom_dashboards/create_custom_dashboard", func(c *Client) {
+	Record(t, "observability_custom_dashboards/create_custom_dashboard", func(c *Client) {
 		ocd, err = c.CreateObservabilityCustomDashboard(cocd)
 	})
 	if err != nil {
@@ -42,7 +42,7 @@ func TestClient_ObservabilityCustomDashboards(t *testing.T) {
 	}
 	// Ensure deleted
 	defer func() {
-		record(t, "observability_custom_dashboards/delete_custom_dashboard", func(c *Client) {
+		Record(t, "observability_custom_dashboards/delete_custom_dashboard", func(c *Client) {
 			err = c.DeleteObservabilityCustomDashboard(&DeleteObservabilityCustomDashboardInput{
 				ID: &ocd.ID,
 			})
@@ -63,7 +63,7 @@ func TestClient_ObservabilityCustomDashboards(t *testing.T) {
 
 	// List Dashboards
 	var ldr *ListDashboardsResponse
-	record(t, "observability_custom_dashboards/list_custom_dashboards", func(c *Client) {
+	Record(t, "observability_custom_dashboards/list_custom_dashboards", func(c *Client) {
 		ldr, err = c.ListObservabilityCustomDashboards(&ListObservabilityCustomDashboardsInput{})
 	})
 	if err != nil {
@@ -75,7 +75,7 @@ func TestClient_ObservabilityCustomDashboards(t *testing.T) {
 
 	// Get
 	var gocd *ObservabilityCustomDashboard
-	record(t, "observability_custom_dashboards/get_custom_dashboard", func(c *Client) {
+	Record(t, "observability_custom_dashboards/get_custom_dashboard", func(c *Client) {
 		gocd, err = c.GetObservabilityCustomDashboard(&GetObservabilityCustomDashboardInput{
 			ID: &ocd.ID,
 		})
@@ -109,7 +109,7 @@ func TestClient_ObservabilityCustomDashboards(t *testing.T) {
 			Type:   VisualizationTypeChart,
 		},
 	})
-	record(t, "observability_custom_dashboards/update_custom_dashboard", func(c *Client) {
+	Record(t, "observability_custom_dashboards/update_custom_dashboard", func(c *Client) {
 		ucd, err = c.UpdateObservabilityCustomDashboard(&UpdateObservabilityCustomDashboardInput{
 			Description: ToPointer("My dashboard just got even cooler."),
 			ID:          &ocd.ID,

--- a/fastly/paginator.go
+++ b/fastly/paginator.go
@@ -133,7 +133,7 @@ func (p *ListPaginator[T]) GetNext() ([]*T, error) {
 	p.consumed = true
 
 	var s []*T
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 

--- a/fastly/product_enablement.go
+++ b/fastly/product_enablement.go
@@ -76,7 +76,7 @@ func (c *Client) GetProduct(i *ProductEnablementInput) (*ProductEnablement, erro
 	defer resp.Body.Close()
 
 	var h *ProductEnablement
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 
@@ -101,7 +101,7 @@ func (c *Client) EnableProduct(i *ProductEnablementInput) (*ProductEnablement, e
 	defer resp.Body.Close()
 
 	var http3 *ProductEnablement
-	if err := decodeBodyMap(resp.Body, &http3); err != nil {
+	if err := DecodeBodyMap(resp.Body, &http3); err != nil {
 		return nil, err
 	}
 	return http3, nil

--- a/fastly/product_enablement_bot_management_test.go
+++ b/fastly/product_enablement_bot_management_test.go
@@ -11,10 +11,10 @@ func TestClient_ProductEnablement_bot_management(t *testing.T) {
 
 	// Enable Product - Bot Management
 	var pe *ProductEnablement
-	record(t, "product_enablement/enable_bot_management", func(c *Client) {
+	Record(t, "product_enablement/enable_bot_management", func(c *Client) {
 		pe, err = c.EnableProduct(&ProductEnablementInput{
 			ProductID: ProductBotManagement,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -27,10 +27,10 @@ func TestClient_ProductEnablement_bot_management(t *testing.T) {
 
 	// Get Product status
 	var gpe *ProductEnablement
-	record(t, "product_enablement/get_bot_management", func(c *Client) {
+	Record(t, "product_enablement/get_bot_management", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductBotManagement,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -42,10 +42,10 @@ func TestClient_ProductEnablement_bot_management(t *testing.T) {
 	}
 
 	// Disable Product
-	record(t, "product_enablement/disable_bot_management", func(c *Client) {
+	Record(t, "product_enablement/disable_bot_management", func(c *Client) {
 		err = c.DisableProduct(&ProductEnablementInput{
 			ProductID: ProductBotManagement,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -53,10 +53,10 @@ func TestClient_ProductEnablement_bot_management(t *testing.T) {
 	}
 
 	// Get Product status again to check disabled
-	record(t, "product_enablement/get-disabled_bot_management", func(c *Client) {
+	Record(t, "product_enablement/get-disabled_bot_management", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductBotManagement,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 
@@ -70,14 +70,14 @@ func TestClient_ProductEnablement_bot_management(t *testing.T) {
 func TestClient_GetProduct_validation_bot_management(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ProductID: ProductBotManagement,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -87,14 +87,14 @@ func TestClient_GetProduct_validation_bot_management(t *testing.T) {
 
 func TestClient_EnableProduct_validation_bot_management(t *testing.T) {
 	var err error
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ProductID: ProductBotManagement,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -105,14 +105,14 @@ func TestClient_EnableProduct_validation_bot_management(t *testing.T) {
 func TestClient_DisableProduct_validation_bot_management(t *testing.T) {
 	var err error
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ProductID: ProductBotManagement,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {

--- a/fastly/product_enablement_brotli_compression_test.go
+++ b/fastly/product_enablement_brotli_compression_test.go
@@ -11,10 +11,10 @@ func TestClient_ProductEnablement_brotli_compression(t *testing.T) {
 
 	// Enable Product
 	var pe *ProductEnablement
-	record(t, "product_enablement/enable_brotli_compression", func(c *Client) {
+	Record(t, "product_enablement/enable_brotli_compression", func(c *Client) {
 		pe, err = c.EnableProduct(&ProductEnablementInput{
 			ProductID: ProductBrotliCompression,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -27,10 +27,10 @@ func TestClient_ProductEnablement_brotli_compression(t *testing.T) {
 
 	// Get Product status
 	var gpe *ProductEnablement
-	record(t, "product_enablement/get_brotli_compression", func(c *Client) {
+	Record(t, "product_enablement/get_brotli_compression", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductBrotliCompression,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -42,10 +42,10 @@ func TestClient_ProductEnablement_brotli_compression(t *testing.T) {
 	}
 
 	// Disable Product
-	record(t, "product_enablement/disable_brotli_compression", func(c *Client) {
+	Record(t, "product_enablement/disable_brotli_compression", func(c *Client) {
 		err = c.DisableProduct(&ProductEnablementInput{
 			ProductID: ProductBrotliCompression,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -53,10 +53,10 @@ func TestClient_ProductEnablement_brotli_compression(t *testing.T) {
 	}
 
 	// Get Product status again to check disabled
-	record(t, "product_enablement/get-disabled_brotli_compression", func(c *Client) {
+	Record(t, "product_enablement/get-disabled_brotli_compression", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductBrotliCompression,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 
@@ -70,14 +70,14 @@ func TestClient_ProductEnablement_brotli_compression(t *testing.T) {
 func TestClient_GetProduct_validation_brotli_compression(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ProductID: ProductBrotliCompression,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -87,14 +87,14 @@ func TestClient_GetProduct_validation_brotli_compression(t *testing.T) {
 
 func TestClient_EnableProduct_validation_brotli_compression(t *testing.T) {
 	var err error
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ProductID: ProductBrotliCompression,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -105,14 +105,14 @@ func TestClient_EnableProduct_validation_brotli_compression(t *testing.T) {
 func TestClient_DisableProduct_validation_brotli_compression(t *testing.T) {
 	var err error
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ProductID: ProductBrotliCompression,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {

--- a/fastly/product_enablement_domain_inspector_test.go
+++ b/fastly/product_enablement_domain_inspector_test.go
@@ -11,10 +11,10 @@ func TestClient_ProductEnablement_domain_inspector(t *testing.T) {
 
 	// Enable Product - Bot Management
 	var pe *ProductEnablement
-	record(t, "product_enablement/enable_domain_inspector", func(c *Client) {
+	Record(t, "product_enablement/enable_domain_inspector", func(c *Client) {
 		pe, err = c.EnableProduct(&ProductEnablementInput{
 			ProductID: ProductDomainInspector,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -27,10 +27,10 @@ func TestClient_ProductEnablement_domain_inspector(t *testing.T) {
 
 	// Get Product status
 	var gpe *ProductEnablement
-	record(t, "product_enablement/get_domain_inspector", func(c *Client) {
+	Record(t, "product_enablement/get_domain_inspector", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductDomainInspector,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -42,10 +42,10 @@ func TestClient_ProductEnablement_domain_inspector(t *testing.T) {
 	}
 
 	// Disable Product
-	record(t, "product_enablement/disable_domain_inspector", func(c *Client) {
+	Record(t, "product_enablement/disable_domain_inspector", func(c *Client) {
 		err = c.DisableProduct(&ProductEnablementInput{
 			ProductID: ProductDomainInspector,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -53,10 +53,10 @@ func TestClient_ProductEnablement_domain_inspector(t *testing.T) {
 	}
 
 	// Get Product status again to check disabled
-	record(t, "product_enablement/get-disabled_domain_inspector", func(c *Client) {
+	Record(t, "product_enablement/get-disabled_domain_inspector", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductDomainInspector,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 
@@ -70,14 +70,14 @@ func TestClient_ProductEnablement_domain_inspector(t *testing.T) {
 func TestClient_GetProduct_validation_domain_inspector(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ProductID: ProductDomainInspector,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -87,14 +87,14 @@ func TestClient_GetProduct_validation_domain_inspector(t *testing.T) {
 
 func TestClient_EnableProduct_validation_domain_inspector(t *testing.T) {
 	var err error
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ProductID: ProductDomainInspector,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -105,14 +105,14 @@ func TestClient_EnableProduct_validation_domain_inspector(t *testing.T) {
 func TestClient_DisableProduct_validation_domain_inspector(t *testing.T) {
 	var err error
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ProductID: ProductDomainInspector,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {

--- a/fastly/product_enablement_fanout_test.go
+++ b/fastly/product_enablement_fanout_test.go
@@ -11,10 +11,10 @@ func TestClient_ProductEnablement_fanout(t *testing.T) {
 
 	// Enable Product - Bot Management
 	var pe *ProductEnablement
-	record(t, "product_enablement/enable_fanout", func(c *Client) {
+	Record(t, "product_enablement/enable_fanout", func(c *Client) {
 		pe, err = c.EnableProduct(&ProductEnablementInput{
 			ProductID: ProductFanout,
-			ServiceID: testComputeServiceID,
+			ServiceID: TestComputeServiceID,
 		})
 	})
 	if err != nil {
@@ -27,10 +27,10 @@ func TestClient_ProductEnablement_fanout(t *testing.T) {
 
 	// Get Product status
 	var gpe *ProductEnablement
-	record(t, "product_enablement/get_fanout", func(c *Client) {
+	Record(t, "product_enablement/get_fanout", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductFanout,
-			ServiceID: testComputeServiceID,
+			ServiceID: TestComputeServiceID,
 		})
 	})
 	if err != nil {
@@ -42,10 +42,10 @@ func TestClient_ProductEnablement_fanout(t *testing.T) {
 	}
 
 	// Disable Product
-	record(t, "product_enablement/disable_fanout", func(c *Client) {
+	Record(t, "product_enablement/disable_fanout", func(c *Client) {
 		err = c.DisableProduct(&ProductEnablementInput{
 			ProductID: ProductFanout,
-			ServiceID: testComputeServiceID,
+			ServiceID: TestComputeServiceID,
 		})
 	})
 	if err != nil {
@@ -53,10 +53,10 @@ func TestClient_ProductEnablement_fanout(t *testing.T) {
 	}
 
 	// Get Product status again to check disabled
-	record(t, "product_enablement/get-disabled_fanout", func(c *Client) {
+	Record(t, "product_enablement/get-disabled_fanout", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductFanout,
-			ServiceID: testComputeServiceID,
+			ServiceID: TestComputeServiceID,
 		})
 	})
 
@@ -70,14 +70,14 @@ func TestClient_ProductEnablement_fanout(t *testing.T) {
 func TestClient_GetProduct_validation_fanout(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ProductID: ProductFanout,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -87,14 +87,14 @@ func TestClient_GetProduct_validation_fanout(t *testing.T) {
 
 func TestClient_EnableProduct_validation_fanout(t *testing.T) {
 	var err error
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ProductID: ProductFanout,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -105,14 +105,14 @@ func TestClient_EnableProduct_validation_fanout(t *testing.T) {
 func TestClient_DisableProduct_validation_fanout(t *testing.T) {
 	var err error
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ProductID: ProductFanout,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {

--- a/fastly/product_enablement_image_optimizer_test.go
+++ b/fastly/product_enablement_image_optimizer_test.go
@@ -11,10 +11,10 @@ func TestClient_ProductEnablement_image_optimizer(t *testing.T) {
 
 	// Enable Product - Bot Management
 	var pe *ProductEnablement
-	record(t, "product_enablement/enable_image_optimizer", func(c *Client) {
+	Record(t, "product_enablement/enable_image_optimizer", func(c *Client) {
 		pe, err = c.EnableProduct(&ProductEnablementInput{
 			ProductID: ProductImageOptimizer,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -27,10 +27,10 @@ func TestClient_ProductEnablement_image_optimizer(t *testing.T) {
 
 	// Get Product status
 	var gpe *ProductEnablement
-	record(t, "product_enablement/get_image_optimizer", func(c *Client) {
+	Record(t, "product_enablement/get_image_optimizer", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductImageOptimizer,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -42,10 +42,10 @@ func TestClient_ProductEnablement_image_optimizer(t *testing.T) {
 	}
 
 	// Disable Product
-	record(t, "product_enablement/disable_image_optimizer", func(c *Client) {
+	Record(t, "product_enablement/disable_image_optimizer", func(c *Client) {
 		err = c.DisableProduct(&ProductEnablementInput{
 			ProductID: ProductImageOptimizer,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -53,10 +53,10 @@ func TestClient_ProductEnablement_image_optimizer(t *testing.T) {
 	}
 
 	// Get Product status again to check disabled
-	record(t, "product_enablement/get-disabled_image_optimizer", func(c *Client) {
+	Record(t, "product_enablement/get-disabled_image_optimizer", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductImageOptimizer,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 
@@ -70,14 +70,14 @@ func TestClient_ProductEnablement_image_optimizer(t *testing.T) {
 func TestClient_GetProduct_validation_image_optimizer(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ProductID: ProductImageOptimizer,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -87,14 +87,14 @@ func TestClient_GetProduct_validation_image_optimizer(t *testing.T) {
 
 func TestClient_EnableProduct_validation_image_optimizer(t *testing.T) {
 	var err error
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ProductID: ProductImageOptimizer,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -105,14 +105,14 @@ func TestClient_EnableProduct_validation_image_optimizer(t *testing.T) {
 func TestClient_DisableProduct_validation_image_optimizer(t *testing.T) {
 	var err error
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ProductID: ProductImageOptimizer,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {

--- a/fastly/product_enablement_log_explorer_insights_test.go
+++ b/fastly/product_enablement_log_explorer_insights_test.go
@@ -11,10 +11,10 @@ func TestClient_ProductEnablement_log_explorer_insights(t *testing.T) {
 
 	// Enable Product - Log Explorer & Insights
 	var pe *ProductEnablement
-	record(t, "product_enablement/enable_log_explorer_insights", func(c *Client) {
+	Record(t, "product_enablement/enable_log_explorer_insights", func(c *Client) {
 		pe, err = c.EnableProduct(&ProductEnablementInput{
 			ProductID: ProductLogExplorerInsights,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -27,10 +27,10 @@ func TestClient_ProductEnablement_log_explorer_insights(t *testing.T) {
 
 	// Get Product status
 	var gpe *ProductEnablement
-	record(t, "product_enablement/get_log_explorer_insights", func(c *Client) {
+	Record(t, "product_enablement/get_log_explorer_insights", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductLogExplorerInsights,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -42,10 +42,10 @@ func TestClient_ProductEnablement_log_explorer_insights(t *testing.T) {
 	}
 
 	// Disable Product
-	record(t, "product_enablement/disable_log_explorer_insights", func(c *Client) {
+	Record(t, "product_enablement/disable_log_explorer_insights", func(c *Client) {
 		err = c.DisableProduct(&ProductEnablementInput{
 			ProductID: ProductLogExplorerInsights,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -53,10 +53,10 @@ func TestClient_ProductEnablement_log_explorer_insights(t *testing.T) {
 	}
 
 	// Get Product status again to check disabled
-	record(t, "product_enablement/get-disabled_log_explorer_insights", func(c *Client) {
+	Record(t, "product_enablement/get-disabled_log_explorer_insights", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductLogExplorerInsights,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 
@@ -70,14 +70,14 @@ func TestClient_ProductEnablement_log_explorer_insights(t *testing.T) {
 func TestClient_GetProduct_validation_log_explorer_insights(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ProductID: ProductLogExplorerInsights,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -87,14 +87,14 @@ func TestClient_GetProduct_validation_log_explorer_insights(t *testing.T) {
 
 func TestClient_EnableProduct_validation_log_explorer_insights(t *testing.T) {
 	var err error
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ProductID: ProductLogExplorerInsights,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -105,14 +105,14 @@ func TestClient_EnableProduct_validation_log_explorer_insights(t *testing.T) {
 func TestClient_DisableProduct_validation_log_explorer_insights(t *testing.T) {
 	var err error
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ProductID: ProductLogExplorerInsights,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {

--- a/fastly/product_enablement_origin_inspector_test.go
+++ b/fastly/product_enablement_origin_inspector_test.go
@@ -11,10 +11,10 @@ func TestClient_ProductEnablement_origin_inspector(t *testing.T) {
 
 	// Enable Product - Bot Management
 	var pe *ProductEnablement
-	record(t, "product_enablement/enable_origin_inspector", func(c *Client) {
+	Record(t, "product_enablement/enable_origin_inspector", func(c *Client) {
 		pe, err = c.EnableProduct(&ProductEnablementInput{
 			ProductID: ProductOriginInspector,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -27,10 +27,10 @@ func TestClient_ProductEnablement_origin_inspector(t *testing.T) {
 
 	// Get Product status
 	var gpe *ProductEnablement
-	record(t, "product_enablement/get_origin_inspector", func(c *Client) {
+	Record(t, "product_enablement/get_origin_inspector", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductOriginInspector,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -42,10 +42,10 @@ func TestClient_ProductEnablement_origin_inspector(t *testing.T) {
 	}
 
 	// Disable Product
-	record(t, "product_enablement/disable_origin_inspector", func(c *Client) {
+	Record(t, "product_enablement/disable_origin_inspector", func(c *Client) {
 		err = c.DisableProduct(&ProductEnablementInput{
 			ProductID: ProductOriginInspector,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -53,10 +53,10 @@ func TestClient_ProductEnablement_origin_inspector(t *testing.T) {
 	}
 
 	// Get Product status again to check disabled
-	record(t, "product_enablement/get-disabled_origin_inspector", func(c *Client) {
+	Record(t, "product_enablement/get-disabled_origin_inspector", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductOriginInspector,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 
@@ -70,14 +70,14 @@ func TestClient_ProductEnablement_origin_inspector(t *testing.T) {
 func TestClient_GetProduct_validation_origin_inspector(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ProductID: ProductOriginInspector,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -87,14 +87,14 @@ func TestClient_GetProduct_validation_origin_inspector(t *testing.T) {
 
 func TestClient_EnableProduct_validation_origin_inspector(t *testing.T) {
 	var err error
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ProductID: ProductOriginInspector,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -105,14 +105,14 @@ func TestClient_EnableProduct_validation_origin_inspector(t *testing.T) {
 func TestClient_DisableProduct_validation_origin_inspector(t *testing.T) {
 	var err error
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ProductID: ProductOriginInspector,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {

--- a/fastly/product_enablement_websockets_test.go
+++ b/fastly/product_enablement_websockets_test.go
@@ -11,10 +11,10 @@ func TestClient_ProductEnablement_websockets(t *testing.T) {
 
 	// Enable Product - Bot Management
 	var pe *ProductEnablement
-	record(t, "product_enablement/enable_websockets", func(c *Client) {
+	Record(t, "product_enablement/enable_websockets", func(c *Client) {
 		pe, err = c.EnableProduct(&ProductEnablementInput{
 			ProductID: ProductWebSockets,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -27,10 +27,10 @@ func TestClient_ProductEnablement_websockets(t *testing.T) {
 
 	// Get Product status
 	var gpe *ProductEnablement
-	record(t, "product_enablement/get_websockets", func(c *Client) {
+	Record(t, "product_enablement/get_websockets", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductWebSockets,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -42,10 +42,10 @@ func TestClient_ProductEnablement_websockets(t *testing.T) {
 	}
 
 	// Disable Product
-	record(t, "product_enablement/disable_websockets", func(c *Client) {
+	Record(t, "product_enablement/disable_websockets", func(c *Client) {
 		err = c.DisableProduct(&ProductEnablementInput{
 			ProductID: ProductWebSockets,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -53,10 +53,10 @@ func TestClient_ProductEnablement_websockets(t *testing.T) {
 	}
 
 	// Get Product status again to check disabled
-	record(t, "product_enablement/get-disabled_websockets", func(c *Client) {
+	Record(t, "product_enablement/get-disabled_websockets", func(c *Client) {
 		gpe, err = c.GetProduct(&ProductEnablementInput{
 			ProductID: ProductWebSockets,
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 
@@ -70,14 +70,14 @@ func TestClient_ProductEnablement_websockets(t *testing.T) {
 func TestClient_GetProduct_validation_websockets(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ProductID: ProductWebSockets,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetProduct(&ProductEnablementInput{
+	_, err = TestClient.GetProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -87,14 +87,14 @@ func TestClient_GetProduct_validation_websockets(t *testing.T) {
 
 func TestClient_EnableProduct_validation_websockets(t *testing.T) {
 	var err error
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ProductID: ProductWebSockets,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.EnableProduct(&ProductEnablementInput{
+	_, err = TestClient.EnableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {
@@ -105,14 +105,14 @@ func TestClient_EnableProduct_validation_websockets(t *testing.T) {
 func TestClient_DisableProduct_validation_websockets(t *testing.T) {
 	var err error
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ProductID: ProductWebSockets,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DisableProduct(&ProductEnablementInput{
+	err = TestClient.DisableProduct(&ProductEnablementInput{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingProductID {

--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -50,7 +50,7 @@ func (c *Client) Purge(i *PurgeInput) (*Purge, error) {
 	defer resp.Body.Close()
 
 	var r *Purge
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -113,7 +113,7 @@ func (c *Client) PurgeKey(i *PurgeKeyInput) (*Purge, error) {
 	defer resp.Body.Close()
 
 	var r *Purge
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -160,7 +160,7 @@ func (c *Client) PurgeKeys(i *PurgeKeysInput) (map[string]string, error) {
 	defer resp.Body.Close()
 
 	var r map[string]string
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -192,7 +192,7 @@ func (c *Client) PurgeAll(i *PurgeAllInput) (*Purge, error) {
 	defer resp.Body.Close()
 
 	var r *Purge
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return nil, err
 	}
 	return r, nil

--- a/fastly/purge_test.go
+++ b/fastly/purge_test.go
@@ -71,9 +71,9 @@ func TestClient_PurgeKey(t *testing.T) {
 
 	var err error
 	var purge *Purge
-	record(t, "purges/purge_by_key", func(c *Client) {
+	Record(t, "purges/purge_by_key", func(c *Client) {
 		purge, err = c.PurgeKey(&PurgeKeyInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			Key:       "foo",
 		})
 	})
@@ -94,9 +94,9 @@ func TestClient_PurgeKeys(t *testing.T) {
 
 	var err error
 	var purges map[string]string
-	record(t, "purges/purge_by_keys", func(c *Client) {
+	Record(t, "purges/purge_by_keys", func(c *Client) {
 		purges, err = c.PurgeKeys(&PurgeKeysInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			Keys:      []string{"foo", "bar", "baz"},
 		})
 	})
@@ -114,9 +114,9 @@ func TestClient_PurgeAll(t *testing.T) {
 
 	var err error
 	var purge *Purge
-	record(t, "purges/purge_all", func(c *Client) {
+	Record(t, "purges/purge_all", func(c *Client) {
 		purge, err = c.PurgeAll(&PurgeAllInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {

--- a/fastly/resource.go
+++ b/fastly/resource.go
@@ -55,7 +55,7 @@ func (c *Client) ListResources(i *ListResourcesInput) ([]*Resource, error) {
 	defer resp.Body.Close()
 
 	var rs []*Resource
-	if err := decodeBodyMap(resp.Body, &rs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &rs); err != nil {
 		return nil, err
 	}
 	return rs, nil
@@ -95,7 +95,7 @@ func (c *Client) CreateResource(i *CreateResourceInput) (*Resource, error) {
 	defer resp.Body.Close()
 
 	var r *Resource
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -131,7 +131,7 @@ func (c *Client) GetResource(i *GetResourceInput) (*Resource, error) {
 	defer resp.Body.Close()
 
 	var r *Resource
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -169,7 +169,7 @@ func (c *Client) UpdateResource(i *UpdateResourceInput) (*Resource, error) {
 	defer resp.Body.Close()
 
 	var b *Resource
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -205,7 +205,7 @@ func (c *Client) DeleteResource(i *DeleteResourceInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/resource_test.go
+++ b/fastly/resource_test.go
@@ -12,13 +12,13 @@ func TestClient_Resources(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "resources/version", func(c *Client) {
+	Record(t, "resources/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create kv-store resource we want to link to via Resource API.
 	var o *KVStore
-	record(t, "resources/create-kv-store", func(c *Client) {
+	Record(t, "resources/create-kv-store", func(c *Client) {
 		o, err = c.CreateKVStore(&CreateKVStoreInput{
 			Name: "test-kv-store",
 		})
@@ -29,7 +29,7 @@ func TestClient_Resources(t *testing.T) {
 
 	// Ensure kv-store resource is deleted
 	defer func() {
-		record(t, "resources/cleanup-kv-store", func(c *Client) {
+		Record(t, "resources/cleanup-kv-store", func(c *Client) {
 			_ = c.DeleteKVStore(&DeleteKVStoreInput{
 				StoreID: o.StoreID,
 			})
@@ -43,9 +43,9 @@ func TestClient_Resources(t *testing.T) {
 
 	// Create
 	var r *Resource
-	record(t, "resources/create", func(c *Client) {
+	Record(t, "resources/create", func(c *Client) {
 		r, err = c.CreateResource(&CreateResourceInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer(kvStoreNameForServiceLinking),
 			ResourceID:     ToPointer(o.StoreID),
@@ -57,10 +57,10 @@ func TestClient_Resources(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "resources/cleanup", func(c *Client) {
+		Record(t, "resources/cleanup", func(c *Client) {
 			_ = c.DeleteResource(&DeleteResourceInput{
 				ResourceID:     *r.LinkID,
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 			})
 		})
@@ -72,9 +72,9 @@ func TestClient_Resources(t *testing.T) {
 
 	// List
 	var rs []*Resource
-	record(t, "resources/list", func(c *Client) {
+	Record(t, "resources/list", func(c *Client) {
 		rs, err = c.ListResources(&ListResourcesInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -87,10 +87,10 @@ func TestClient_Resources(t *testing.T) {
 
 	// Get
 	var gr *Resource
-	record(t, "resources/get", func(c *Client) {
+	Record(t, "resources/get", func(c *Client) {
 		gr, err = c.GetResource(&GetResourceInput{
 			ResourceID:     *r.LinkID,
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -103,10 +103,10 @@ func TestClient_Resources(t *testing.T) {
 
 	// Update
 	var ur *Resource
-	record(t, "resources/update", func(c *Client) {
+	Record(t, "resources/update", func(c *Client) {
 		ur, err = c.UpdateResource(&UpdateResourceInput{
 			ResourceID:     *r.LinkID,
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("new-kv-store-alias-for-my-service"),
 		})
@@ -119,10 +119,10 @@ func TestClient_Resources(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "resources/delete", func(c *Client) {
+	Record(t, "resources/delete", func(c *Client) {
 		err = c.DeleteResource(&DeleteResourceInput{
 			ResourceID:     *ur.LinkID,
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -133,14 +133,14 @@ func TestClient_Resources(t *testing.T) {
 
 func TestClient_ListResources_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListResources(&ListResourcesInput{
+	_, err = TestClient.ListResources(&ListResourcesInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListResources(&ListResourcesInput{
+	_, err = TestClient.ListResources(&ListResourcesInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -151,14 +151,14 @@ func TestClient_ListResources_validation(t *testing.T) {
 
 func TestClient_CreateResource_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateResource(&CreateResourceInput{
+	_, err = TestClient.CreateResource(&CreateResourceInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateResource(&CreateResourceInput{
+	_, err = TestClient.CreateResource(&CreateResourceInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -170,7 +170,7 @@ func TestClient_CreateResource_validation(t *testing.T) {
 func TestClient_GetResource_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetResource(&GetResourceInput{
+	_, err = TestClient.GetResource(&GetResourceInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -178,7 +178,7 @@ func TestClient_GetResource_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetResource(&GetResourceInput{
+	_, err = TestClient.GetResource(&GetResourceInput{
 		ResourceID:     "test",
 		ServiceVersion: 1,
 	})
@@ -186,7 +186,7 @@ func TestClient_GetResource_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetResource(&GetResourceInput{
+	_, err = TestClient.GetResource(&GetResourceInput{
 		ResourceID: "test",
 		ServiceID:  "foo",
 	})
@@ -198,7 +198,7 @@ func TestClient_GetResource_validation(t *testing.T) {
 func TestClient_UpdateResource_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateResource(&UpdateResourceInput{
+	_, err = TestClient.UpdateResource(&UpdateResourceInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -206,7 +206,7 @@ func TestClient_UpdateResource_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateResource(&UpdateResourceInput{
+	_, err = TestClient.UpdateResource(&UpdateResourceInput{
 		ResourceID:     "test",
 		ServiceVersion: 1,
 	})
@@ -214,7 +214,7 @@ func TestClient_UpdateResource_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateResource(&UpdateResourceInput{
+	_, err = TestClient.UpdateResource(&UpdateResourceInput{
 		ResourceID: "test",
 		ServiceID:  "foo",
 	})
@@ -226,7 +226,7 @@ func TestClient_UpdateResource_validation(t *testing.T) {
 func TestClient_DeleteResource_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteResource(&DeleteResourceInput{
+	err = TestClient.DeleteResource(&DeleteResourceInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -234,7 +234,7 @@ func TestClient_DeleteResource_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteResource(&DeleteResourceInput{
+	err = TestClient.DeleteResource(&DeleteResourceInput{
 		ResourceID:     "test",
 		ServiceVersion: 1,
 	})
@@ -242,7 +242,7 @@ func TestClient_DeleteResource_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteResource(&DeleteResourceInput{
+	err = TestClient.DeleteResource(&DeleteResourceInput{
 		ResourceID: "test",
 		ServiceID:  "foo",
 	})
@@ -279,7 +279,7 @@ func TestResourceJSONRoundtrip(t *testing.T) {
 	t.Logf("Encoded:\n%s", encoded)
 
 	var decoded Resource
-	if err := decodeBodyMap(&out, &decoded); err != nil {
+	if err := DecodeBodyMap(&out, &decoded); err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("Decoded:\n%#v", decoded)

--- a/fastly/secret_store_test.go
+++ b/fastly/secret_store_test.go
@@ -16,7 +16,7 @@ func TestClient_CreateSecretStore(t *testing.T) {
 		ss  *SecretStore
 		err error
 	)
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		ss, err = c.CreateSecretStore(&CreateSecretStoreInput{
 			Name: t.Name(),
 		})
@@ -27,7 +27,7 @@ func TestClient_CreateSecretStore(t *testing.T) {
 
 	// Ensure Secret Store is cleaned up.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("secret_store/%s/delete_store", t.Name()), func(c *Client) {
+		Record(t, fmt.Sprintf("secret_store/%s/delete_store", t.Name()), func(c *Client) {
 			err = c.DeleteSecretStore(&DeleteSecretStoreInput{
 				StoreID: ss.StoreID,
 			})
@@ -62,7 +62,7 @@ func TestClient_ListSecretStores(t *testing.T) {
 	})
 
 	var list *SecretStores
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		list, err = c.ListSecretStores(&ListSecretStoresInput{})
 	})
 	if err != nil {
@@ -92,7 +92,7 @@ func TestClient_ListSecretStores(t *testing.T) {
 		t.Errorf("Meta.NextCursor: got %q, want %q", got, want)
 	}
 
-	record(t, fmt.Sprintf("secret_store/%s/list-with-name", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s/list-with-name", t.Name()), func(c *Client) {
 		list, err = c.ListSecretStores(&ListSecretStoresInput{Name: stores[0].Name})
 	})
 
@@ -118,7 +118,7 @@ func TestClient_GetSecretStore(t *testing.T) {
 		store *SecretStore
 		err   error
 	)
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		store, err = c.GetSecretStore(&GetSecretStoreInput{
 			StoreID: ss.StoreID,
 		})
@@ -142,7 +142,7 @@ func TestClient_DeleteSecretStore(t *testing.T) {
 		ss  *SecretStore
 		err error
 	)
-	record(t, fmt.Sprintf("secret_store/%s/create_store", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s/create_store", t.Name()), func(c *Client) {
 		ss, err = c.CreateSecretStore(&CreateSecretStoreInput{
 			Name: t.Name(),
 		})
@@ -151,7 +151,7 @@ func TestClient_DeleteSecretStore(t *testing.T) {
 		t.Fatalf("error creating secret store: %v", err)
 	}
 
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		err = c.DeleteSecretStore(&DeleteSecretStoreInput{
 			StoreID: ss.StoreID,
 		})
@@ -170,7 +170,7 @@ func TestClient_CreateSecret(t *testing.T) {
 		s   *Secret
 		err error
 	)
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		s, err = c.CreateSecret(&CreateSecretInput{
 			StoreID: ss.StoreID,
 			Name:    t.Name(),
@@ -198,7 +198,7 @@ func TestClient_CreateOrRecreateSecret(t *testing.T) {
 		s   *Secret
 		err error
 	)
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		s, err = c.CreateSecret(&CreateSecretInput{
 			StoreID: ss.StoreID,
 			Name:    t.Name(),
@@ -230,7 +230,7 @@ func TestClient_RecreateSecret(t *testing.T) {
 		s   *Secret
 		err error
 	)
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		// There must be an existing secret already, otherwise
 		// the following PATCH request will fail.
 		s, err = c.CreateSecret(&CreateSecretInput{
@@ -274,7 +274,7 @@ func TestClient_CreateSecret_clientEncryption(t *testing.T) {
 		err error
 	)
 
-	record(t, fmt.Sprintf("secret_store/%s/create_client_key", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s/create_client_key", t.Name()), func(c *Client) {
 		ck, err = c.CreateClientKey()
 	})
 	if err != nil {
@@ -295,7 +295,7 @@ func TestClient_CreateSecret_clientEncryption(t *testing.T) {
 
 	var sk ed25519.PublicKey
 
-	record(t, fmt.Sprintf("secret_store/%s/get_signing_key", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s/get_signing_key", t.Name()), func(c *Client) {
 		sk, err = c.GetSigningKey()
 	})
 	if err != nil {
@@ -317,7 +317,7 @@ func TestClient_CreateSecret_clientEncryption(t *testing.T) {
 
 	var s *Secret
 
-	record(t, fmt.Sprintf("secret_store/%s/create_secret", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s/create_secret", t.Name()), func(c *Client) {
 		s, err = c.CreateSecret(&CreateSecretInput{
 			StoreID:   ss.StoreID,
 			Name:      t.Name(),
@@ -348,7 +348,7 @@ func TestClient_ListSecrets(t *testing.T) {
 		err     error
 	)
 	for i := 0; i < 5; i++ {
-		record(t, fmt.Sprintf("secret_store/%s/create_secret_%02d", t.Name(), i), func(c *Client) {
+		Record(t, fmt.Sprintf("secret_store/%s/create_secret_%02d", t.Name(), i), func(c *Client) {
 			s, err = c.CreateSecret(&CreateSecretInput{
 				StoreID: ss.StoreID,
 				Name:    fmt.Sprintf("%s-%02d", t.Name(), i),
@@ -362,7 +362,7 @@ func TestClient_ListSecrets(t *testing.T) {
 	}
 
 	var list *Secrets
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		list, err = c.ListSecrets(&ListSecretsInput{
 			StoreID: ss.StoreID,
 		})
@@ -404,7 +404,7 @@ func TestClient_GetSecret(t *testing.T) {
 		s   *Secret
 		err error
 	)
-	record(t, fmt.Sprintf("secret_store/%s/create_secret", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s/create_secret", t.Name()), func(c *Client) {
 		s, err = c.CreateSecret(&CreateSecretInput{
 			StoreID: ss.StoreID,
 			Name:    t.Name(),
@@ -416,7 +416,7 @@ func TestClient_GetSecret(t *testing.T) {
 	}
 
 	var secret *Secret
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		secret, err = c.GetSecret(&GetSecretInput{
 			StoreID: ss.StoreID,
 			Name:    s.Name,
@@ -443,7 +443,7 @@ func TestClient_DeleteSecret(t *testing.T) {
 		s   *Secret
 		err error
 	)
-	record(t, fmt.Sprintf("secret_store/%s/create_secret", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s/create_secret", t.Name()), func(c *Client) {
 		s, err = c.CreateSecret(&CreateSecretInput{
 			StoreID: ss.StoreID,
 			Name:    t.Name(),
@@ -454,7 +454,7 @@ func TestClient_DeleteSecret(t *testing.T) {
 		t.Fatalf("error creating secret: %v", err)
 	}
 
-	record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s", t.Name()), func(c *Client) {
 		err = c.DeleteSecret(&DeleteSecretInput{
 			StoreID: ss.StoreID,
 			Name:    s.Name,
@@ -470,28 +470,28 @@ func TestClient_SecretStore_validation(t *testing.T) {
 
 	var err error
 
-	_, err = testClient.CreateSecretStore(&CreateSecretStoreInput{
+	_, err = TestClient.CreateSecretStore(&CreateSecretStoreInput{
 		Name: "",
 	})
 	if want := ErrMissingName; err != want {
 		t.Errorf("CreateSecretStore: got error %v, want %v", err, want)
 	}
 
-	_, err = testClient.GetSecretStore(&GetSecretStoreInput{
+	_, err = TestClient.GetSecretStore(&GetSecretStoreInput{
 		StoreID: "",
 	})
 	if want := ErrMissingStoreID; err != want {
 		t.Errorf("GetSecretStore: got error %v, want %v", err, want)
 	}
 
-	err = testClient.DeleteSecretStore(&DeleteSecretStoreInput{
+	err = TestClient.DeleteSecretStore(&DeleteSecretStoreInput{
 		StoreID: "",
 	})
 	if want := ErrMissingStoreID; err != want {
 		t.Errorf("DeleteSecretStore: got error %v, want %v", err, want)
 	}
 
-	_, err = testClient.CreateSecret(&CreateSecretInput{
+	_, err = TestClient.CreateSecret(&CreateSecretInput{
 		StoreID: "",
 		Name:    "name",
 		Secret:  []byte("secret"),
@@ -499,7 +499,7 @@ func TestClient_SecretStore_validation(t *testing.T) {
 	if want := ErrMissingStoreID; err != want {
 		t.Errorf("CreateSecret: got error %v, want %v", err, want)
 	}
-	_, err = testClient.CreateSecret(&CreateSecretInput{
+	_, err = TestClient.CreateSecret(&CreateSecretInput{
 		StoreID: "123",
 		Name:    "",
 		Secret:  []byte("secret"),
@@ -507,7 +507,7 @@ func TestClient_SecretStore_validation(t *testing.T) {
 	if want := ErrMissingName; err != want {
 		t.Errorf("CreateSecret: got error %v, want %v", err, want)
 	}
-	_, err = testClient.CreateSecret(&CreateSecretInput{
+	_, err = TestClient.CreateSecret(&CreateSecretInput{
 		StoreID: "123",
 		Name:    "name",
 		Secret:  []byte(nil),
@@ -516,21 +516,21 @@ func TestClient_SecretStore_validation(t *testing.T) {
 		t.Errorf("CreateSecret: got error %v, want %v", err, want)
 	}
 
-	_, err = testClient.ListSecrets(&ListSecretsInput{
+	_, err = TestClient.ListSecrets(&ListSecretsInput{
 		StoreID: "",
 	})
 	if want := ErrMissingStoreID; err != want {
 		t.Errorf("ListSecrets: got error %v, want %v", err, want)
 	}
 
-	_, err = testClient.GetSecret(&GetSecretInput{
+	_, err = TestClient.GetSecret(&GetSecretInput{
 		StoreID: "",
 		Name:    "name",
 	})
 	if want := ErrMissingStoreID; err != want {
 		t.Errorf("GetSecret: got error %v, want %v", err, want)
 	}
-	_, err = testClient.GetSecret(&GetSecretInput{
+	_, err = TestClient.GetSecret(&GetSecretInput{
 		StoreID: "id",
 		Name:    "",
 	})
@@ -538,14 +538,14 @@ func TestClient_SecretStore_validation(t *testing.T) {
 		t.Errorf("GetSecret: got error %v, want %v", err, want)
 	}
 
-	err = testClient.DeleteSecret(&DeleteSecretInput{
+	err = TestClient.DeleteSecret(&DeleteSecretInput{
 		StoreID: "",
 		Name:    "name",
 	})
 	if want := ErrMissingStoreID; err != want {
 		t.Errorf("DeleteSecret: got error %v, want %v", err, want)
 	}
-	err = testClient.DeleteSecret(&DeleteSecretInput{
+	err = TestClient.DeleteSecret(&DeleteSecretInput{
 		StoreID: "id",
 		Name:    "",
 	})
@@ -561,7 +561,7 @@ func createSecretStoreHelper(t *testing.T, i int) *SecretStore {
 		ss  *SecretStore
 		err error
 	)
-	record(t, fmt.Sprintf("secret_store/%s/create_store_%02d", t.Name(), i), func(c *Client) {
+	Record(t, fmt.Sprintf("secret_store/%s/create_store_%02d", t.Name(), i), func(c *Client) {
 		ss, err = c.CreateSecretStore(&CreateSecretStoreInput{
 			Name: fmt.Sprintf("%s-%02d", t.Name(), i),
 		})
@@ -572,7 +572,7 @@ func createSecretStoreHelper(t *testing.T, i int) *SecretStore {
 
 	// Cleanup secret store.
 	t.Cleanup(func() {
-		record(t, fmt.Sprintf("secret_store/%s/delete_store_%02d", t.Name(), i), func(c *Client) {
+		Record(t, fmt.Sprintf("secret_store/%s/delete_store_%02d", t.Name(), i), func(c *Client) {
 			err = c.DeleteSecretStore(&DeleteSecretStoreInput{
 				StoreID: ss.StoreID,
 			})

--- a/fastly/service_authorization_test.go
+++ b/fastly/service_authorization_test.go
@@ -13,9 +13,9 @@ func TestClient_ServiceAuthorizations(t *testing.T) {
 	// Create
 	var err error
 	var sa *ServiceAuthorization
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		sa, err = c.CreateServiceAuthorization(&CreateServiceAuthorizationInput{
-			Service:    &SAService{ID: testDeliveryServiceID},
+			Service:    &SAService{ID: TestDeliveryServiceID},
 			User:       &SAUser{ID: "1pnpEMCscfjqgvH7Qofda6"},
 			Permission: "full",
 		})
@@ -26,7 +26,7 @@ func TestClient_ServiceAuthorizations(t *testing.T) {
 
 	// List
 	var sasResp *ServiceAuthorizations
-	record(t, fixtureBase+"/list", func(c *Client) {
+	Record(t, fixtureBase+"/list", func(c *Client) {
 		sasResp, err = c.ListServiceAuthorizations(&ListServiceAuthorizationsInput{
 			PageSize: 10,
 		})
@@ -40,14 +40,14 @@ func TestClient_ServiceAuthorizations(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"cleanup", func(c *Client) {
+		Record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteServiceAuthorization(&DeleteServiceAuthorizationInput{
 				ID: sa.ID,
 			})
 		})
 	}()
 
-	if sa.Service.ID != testDeliveryServiceID {
+	if sa.Service.ID != TestDeliveryServiceID {
 		t.Errorf("bad service id: %v", sa.Service.ID)
 	}
 
@@ -61,7 +61,7 @@ func TestClient_ServiceAuthorizations(t *testing.T) {
 
 	// Get
 	var nsa *ServiceAuthorization
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		nsa, err = c.GetServiceAuthorization(&GetServiceAuthorizationInput{
 			ID: sa.ID,
 		})
@@ -70,13 +70,13 @@ func TestClient_ServiceAuthorizations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if nsa.Service.ID != testDeliveryServiceID {
+	if nsa.Service.ID != TestDeliveryServiceID {
 		t.Errorf("bad service id: %v", nsa.Service)
 	}
 
 	// Update
 	var usa *ServiceAuthorization
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		usa, err = c.UpdateServiceAuthorization(&UpdateServiceAuthorizationInput{
 			ID:         sa.ID,
 			Permission: "purge_select",
@@ -86,7 +86,7 @@ func TestClient_ServiceAuthorizations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if usa.Service.ID != testDeliveryServiceID {
+	if usa.Service.ID != TestDeliveryServiceID {
 		t.Errorf("bad service id: %v", usa.Service)
 	}
 	if usa.Permission != "purge_select" {
@@ -94,7 +94,7 @@ func TestClient_ServiceAuthorizations(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteServiceAuthorization(&DeleteServiceAuthorizationInput{
 			ID: sa.ID,
 		})
@@ -106,7 +106,7 @@ func TestClient_ServiceAuthorizations(t *testing.T) {
 
 func TestClient_GetServiceAuthorization_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetServiceAuthorization(&GetServiceAuthorizationInput{
+	_, err = TestClient.GetServiceAuthorization(&GetServiceAuthorizationInput{
 		ID: "",
 	})
 	if err != ErrMissingID {
@@ -116,7 +116,7 @@ func TestClient_GetServiceAuthorization_validation(t *testing.T) {
 
 func TestClient_CreateServiceAuthorization_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateServiceAuthorization(&CreateServiceAuthorizationInput{
+	_, err = TestClient.CreateServiceAuthorization(&CreateServiceAuthorizationInput{
 		Service: &SAService{ID: ""},
 		User:    &SAUser{ID: ""},
 	})
@@ -124,7 +124,7 @@ func TestClient_CreateServiceAuthorization_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateServiceAuthorization(&CreateServiceAuthorizationInput{
+	_, err = TestClient.CreateServiceAuthorization(&CreateServiceAuthorizationInput{
 		Service: &SAService{ID: "my-service-id"},
 		User:    &SAUser{ID: ""},
 	})
@@ -135,7 +135,7 @@ func TestClient_CreateServiceAuthorization_validation(t *testing.T) {
 
 func TestClient_UpdateServiceAuthorization_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateServiceAuthorization(&UpdateServiceAuthorizationInput{
+	_, err = TestClient.UpdateServiceAuthorization(&UpdateServiceAuthorizationInput{
 		ID:         "",
 		Permission: "",
 	})
@@ -143,7 +143,7 @@ func TestClient_UpdateServiceAuthorization_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateServiceAuthorization(&UpdateServiceAuthorizationInput{
+	_, err = TestClient.UpdateServiceAuthorization(&UpdateServiceAuthorizationInput{
 		ID:         "my-service-authorization-id",
 		Permission: "",
 	})
@@ -153,7 +153,7 @@ func TestClient_UpdateServiceAuthorization_validation(t *testing.T) {
 }
 
 func TestClient_DeleteServiceAuthorization_validation(t *testing.T) {
-	err := testClient.DeleteServiceAuthorization(&DeleteServiceAuthorizationInput{
+	err := TestClient.DeleteServiceAuthorization(&DeleteServiceAuthorizationInput{
 		ID: "",
 	})
 	if err != ErrMissingID {

--- a/fastly/service_details.go
+++ b/fastly/service_details.go
@@ -125,7 +125,7 @@ func (c *Client) CreateService(i *CreateServiceInput) (*Service, error) {
 	defer resp.Body.Close()
 
 	var s *Service
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -154,7 +154,7 @@ func (c *Client) GetService(i *GetServiceInput) (*Service, error) {
 	defer resp.Body.Close()
 
 	var s *Service
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 
@@ -190,7 +190,7 @@ func (c *Client) GetServiceDetails(i *GetServiceInput) (*ServiceDetail, error) {
 	defer resp.Body.Close()
 
 	var s *ServiceDetail
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 
@@ -222,7 +222,7 @@ func (c *Client) UpdateService(i *UpdateServiceInput) (*Service, error) {
 	defer resp.Body.Close()
 
 	var s *Service
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -249,7 +249,7 @@ func (c *Client) DeleteService(i *DeleteServiceInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -283,7 +283,7 @@ func (c *Client) SearchService(i *SearchServiceInput) (*Service, error) {
 	defer resp.Body.Close()
 
 	var s *Service
-	if err := decodeBodyMap(resp.Body, &s); err != nil {
+	if err := DecodeBodyMap(resp.Body, &s); err != nil {
 		return nil, err
 	}
 
@@ -313,7 +313,7 @@ func (c *Client) ListServiceDomains(i *ListServiceDomainInput) (ServiceDomainsLi
 
 	var ds ServiceDomainsList
 
-	if err := decodeBodyMap(resp.Body, &ds); err != nil {
+	if err := DecodeBodyMap(resp.Body, &ds); err != nil {
 		return nil, err
 	}
 

--- a/fastly/service_details_test.go
+++ b/fastly/service_details_test.go
@@ -11,7 +11,7 @@ func TestClient_Services(t *testing.T) {
 
 	// Create
 	var s *Service
-	record(t, "services/create", func(c *Client) {
+	Record(t, "services/create", func(c *Client) {
 		s, err = c.CreateService(&CreateServiceInput{
 			Name:    ToPointer("test-service"),
 			Comment: ToPointer("comment"),
@@ -23,7 +23,7 @@ func TestClient_Services(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "services/cleanup", func(c *Client) {
+		Record(t, "services/cleanup", func(c *Client) {
 			_ = c.DeleteService(&DeleteServiceInput{
 				ServiceID: *s.ServiceID,
 			})
@@ -43,7 +43,7 @@ func TestClient_Services(t *testing.T) {
 
 	// List
 	var ss []*Service
-	record(t, "services/list", func(c *Client) {
+	Record(t, "services/list", func(c *Client) {
 		ss, err = c.ListServices(&ListServicesInput{
 			Direction: ToPointer("descend"),
 			Sort:      ToPointer("created"),
@@ -59,7 +59,7 @@ func TestClient_Services(t *testing.T) {
 	// List with paginator
 	var ss2 []*Service
 	var paginator *ListPaginator[Service]
-	record(t, "services/list_paginator", func(c *Client) {
+	Record(t, "services/list_paginator", func(c *Client) {
 		paginator = c.GetServices(&GetServicesInput{
 			Direction: ToPointer("descend"),
 			PerPage:   ToPointer(200),
@@ -84,7 +84,7 @@ func TestClient_Services(t *testing.T) {
 
 	// Get
 	var ns *Service
-	record(t, "services/get", func(c *Client) {
+	Record(t, "services/get", func(c *Client) {
 		ns, err = c.GetService(&GetServiceInput{
 			ServiceID: *s.ServiceID,
 		})
@@ -110,7 +110,7 @@ func TestClient_Services(t *testing.T) {
 
 	// Get Details
 	var nsd *ServiceDetail
-	record(t, "services/details", func(c *Client) {
+	Record(t, "services/details", func(c *Client) {
 		nsd, err = c.GetServiceDetails(&GetServiceInput{
 			ServiceID: *s.ServiceID,
 		})
@@ -131,7 +131,7 @@ func TestClient_Services(t *testing.T) {
 
 	// Search
 	var fs *Service
-	record(t, "services/search", func(c *Client) {
+	Record(t, "services/search", func(c *Client) {
 		fs, err = c.SearchService(&SearchServiceInput{
 			Name: "test-service",
 		})
@@ -148,7 +148,7 @@ func TestClient_Services(t *testing.T) {
 
 	// Update
 	var us *Service
-	record(t, "services/update", func(c *Client) {
+	Record(t, "services/update", func(c *Client) {
 		us, err = c.UpdateService(&UpdateServiceInput{
 			ServiceID: *s.ServiceID,
 			Name:      ToPointer("new-test-service"),
@@ -162,7 +162,7 @@ func TestClient_Services(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "services/delete", func(c *Client) {
+	Record(t, "services/delete", func(c *Client) {
 		err = c.DeleteService(&DeleteServiceInput{
 			ServiceID: *s.ServiceID,
 		})
@@ -173,7 +173,7 @@ func TestClient_Services(t *testing.T) {
 
 	//	List Domains
 	var ds ServiceDomainsList
-	record(t, "services/domain", func(c *Client) {
+	Record(t, "services/domain", func(c *Client) {
 		ds, err = c.ListServiceDomains(&ListServiceDomainInput{
 			ServiceID: *s.ServiceID,
 		})
@@ -187,21 +187,21 @@ func TestClient_Services(t *testing.T) {
 }
 
 func TestClient_GetService_validation(t *testing.T) {
-	_, err := testClient.GetService(&GetServiceInput{})
+	_, err := TestClient.GetService(&GetServiceInput{})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 }
 
 func TestClient_UpdateService_validation(t *testing.T) {
-	_, err := testClient.UpdateService(&UpdateServiceInput{})
+	_, err := TestClient.UpdateService(&UpdateServiceInput{})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 }
 
 func TestClient_DeleteService_validation(t *testing.T) {
-	err := testClient.DeleteService(&DeleteServiceInput{})
+	err := TestClient.DeleteService(&DeleteServiceInput{})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}

--- a/fastly/service_version.go
+++ b/fastly/service_version.go
@@ -49,7 +49,7 @@ func (c *Client) ListVersions(i *ListVersionsInput) ([]*Version, error) {
 	defer resp.Body.Close()
 
 	var e []*Version
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 
@@ -108,7 +108,7 @@ func (c *Client) CreateVersion(i *CreateVersionInput) (*Version, error) {
 	defer resp.Body.Close()
 
 	var e *Version
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -139,7 +139,7 @@ func (c *Client) GetVersion(i *GetVersionInput) (*Version, error) {
 	defer resp.Body.Close()
 
 	var e *Version
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -172,7 +172,7 @@ func (c *Client) UpdateVersion(i *UpdateVersionInput) (*Version, error) {
 	defer resp.Body.Close()
 
 	var e *Version
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -211,7 +211,7 @@ func (c *Client) ActivateVersion(i *ActivateVersionInput) (*Version, error) {
 	defer resp.Body.Close()
 
 	var e *Version
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -250,7 +250,7 @@ func (c *Client) DeactivateVersion(i *DeactivateVersionInput) (*Version, error) 
 	defer resp.Body.Close()
 
 	var e *Version
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -284,7 +284,7 @@ func (c *Client) CloneVersion(i *CloneVersionInput) (*Version, error) {
 	defer resp.Body.Close()
 
 	var e *Version
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil
@@ -317,7 +317,7 @@ func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, string, error) 
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return false, msg, err
 	}
 
@@ -350,7 +350,7 @@ func (c *Client) LockVersion(i *LockVersionInput) (*Version, error) {
 	defer resp.Body.Close()
 
 	var e *Version
-	if err := decodeBodyMap(resp.Body, &e); err != nil {
+	if err := DecodeBodyMap(resp.Body, &e); err != nil {
 		return nil, err
 	}
 	return e, nil

--- a/fastly/service_version_test.go
+++ b/fastly/service_version_test.go
@@ -14,9 +14,9 @@ func TestClient_Versions(t *testing.T) {
 
 	// Create
 	var v *Version
-	record(t, "versions/create", func(c *Client) {
+	Record(t, "versions/create", func(c *Client) {
 		v, err = c.CreateVersion(&CreateVersionInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			Comment:   ToPointer("test comment"),
 		})
 	})
@@ -35,9 +35,9 @@ func TestClient_Versions(t *testing.T) {
 
 	// List
 	var vs []*Version
-	record(t, "versions/list", func(c *Client) {
+	Record(t, "versions/list", func(c *Client) {
 		vs, err = c.ListVersions(&ListVersionsInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 		})
 	})
 	if err != nil {
@@ -49,9 +49,9 @@ func TestClient_Versions(t *testing.T) {
 
 	// Get
 	var nv *Version
-	record(t, "versions/get", func(c *Client) {
+	Record(t, "versions/get", func(c *Client) {
 		nv, err = c.GetVersion(&GetVersionInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 		})
 	})
@@ -67,9 +67,9 @@ func TestClient_Versions(t *testing.T) {
 
 	// Update
 	var uv *Version
-	record(t, "versions/update", func(c *Client) {
+	Record(t, "versions/update", func(c *Client) {
 		uv, err = c.UpdateVersion(&UpdateVersionInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 			Comment:        ToPointer("new comment"),
 		})
@@ -83,9 +83,9 @@ func TestClient_Versions(t *testing.T) {
 
 	// Lock
 	var vl *Version
-	record(t, "versions/lock", func(c *Client) {
+	Record(t, "versions/lock", func(c *Client) {
 		vl, err = c.LockVersion(&LockVersionInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 		})
 	})
@@ -98,9 +98,9 @@ func TestClient_Versions(t *testing.T) {
 
 	// Clone
 	var cv *Version
-	record(t, "versions/clone", func(c *Client) {
+	Record(t, "versions/clone", func(c *Client) {
 		cv, err = c.CloneVersion(&CloneVersionInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *v.Number,
 		})
 	})
@@ -117,7 +117,7 @@ func TestClient_Versions(t *testing.T) {
 
 func TestClient_ListVersions_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListVersions(&ListVersionsInput{
+	_, err = TestClient.ListVersions(&ListVersionsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
@@ -127,7 +127,7 @@ func TestClient_ListVersions_validation(t *testing.T) {
 
 func TestClient_CreateVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateVersion(&CreateVersionInput{
+	_, err = TestClient.CreateVersion(&CreateVersionInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
@@ -137,14 +137,14 @@ func TestClient_CreateVersion_validation(t *testing.T) {
 
 func TestClient_GetVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetVersion(&GetVersionInput{
+	_, err = TestClient.GetVersion(&GetVersionInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetVersion(&GetVersionInput{
+	_, err = TestClient.GetVersion(&GetVersionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -155,14 +155,14 @@ func TestClient_GetVersion_validation(t *testing.T) {
 
 func TestClient_UpdateVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateVersion(&UpdateVersionInput{
+	_, err = TestClient.UpdateVersion(&UpdateVersionInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateVersion(&UpdateVersionInput{
+	_, err = TestClient.UpdateVersion(&UpdateVersionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -173,14 +173,14 @@ func TestClient_UpdateVersion_validation(t *testing.T) {
 
 func TestClient_ActivateVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ActivateVersion(&ActivateVersionInput{
+	_, err = TestClient.ActivateVersion(&ActivateVersionInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ActivateVersion(&ActivateVersionInput{
+	_, err = TestClient.ActivateVersion(&ActivateVersionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -191,14 +191,14 @@ func TestClient_ActivateVersion_validation(t *testing.T) {
 
 func TestClient_DeactivateVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.DeactivateVersion(&DeactivateVersionInput{
+	_, err = TestClient.DeactivateVersion(&DeactivateVersionInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.DeactivateVersion(&DeactivateVersionInput{
+	_, err = TestClient.DeactivateVersion(&DeactivateVersionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -209,14 +209,14 @@ func TestClient_DeactivateVersion_validation(t *testing.T) {
 
 func TestClient_CloneVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CloneVersion(&CloneVersionInput{
+	_, err = TestClient.CloneVersion(&CloneVersionInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CloneVersion(&CloneVersionInput{
+	_, err = TestClient.CloneVersion(&CloneVersionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -227,14 +227,14 @@ func TestClient_CloneVersion_validation(t *testing.T) {
 
 func TestClient_ValidateVersion_validation(t *testing.T) {
 	var err error
-	_, _, err = testClient.ValidateVersion(&ValidateVersionInput{
+	_, _, err = TestClient.ValidateVersion(&ValidateVersionInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, _, err = testClient.ValidateVersion(&ValidateVersionInput{
+	_, _, err = TestClient.ValidateVersion(&ValidateVersionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -245,14 +245,14 @@ func TestClient_ValidateVersion_validation(t *testing.T) {
 
 func TestClient_LockVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.LockVersion(&LockVersionInput{
+	_, err = TestClient.LockVersion(&LockVersionInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.LockVersion(&LockVersionInput{
+	_, err = TestClient.LockVersion(&LockVersionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})

--- a/fastly/stats_domain_inspector_test.go
+++ b/fastly/stats_domain_inspector_test.go
@@ -14,9 +14,9 @@ func TestClient_GetDomainMetricsForService(t *testing.T) {
 	end := time.Date(2023, 11, 7, 0, 0, 0, 0, time.UTC)
 	start := end.Add(-8 * time.Hour)
 	var err error
-	record(t, "domain_inspector/metrics_for_service", func(c *Client) {
+	Record(t, "domain_inspector/metrics_for_service", func(c *Client) {
 		_, err = c.GetDomainMetricsForService(&GetDomainMetricsInput{
-			ServiceID:   testDeliveryServiceID,
+			ServiceID:   TestDeliveryServiceID,
 			Start:       &start,
 			End:         &end,
 			Domains:     []string{"domain_1.com", "domain_2.com"},

--- a/fastly/stats_historical.go
+++ b/fastly/stats_historical.go
@@ -262,7 +262,7 @@ func (c *Client) GetUsage(i *GetUsageInput) (*UsageResponse, error) {
 	defer resp.Body.Close()
 
 	var sr *UsageResponse
-	if err := decodeBodyMap(resp.Body, &sr); err != nil {
+	if err := DecodeBodyMap(resp.Body, &sr); err != nil {
 		return nil, err
 	}
 
@@ -309,7 +309,7 @@ func (c *Client) GetUsageByService(i *GetUsageInput) (*UsageByServiceResponse, e
 	defer resp.Body.Close()
 
 	var sr *UsageByServiceResponse
-	if err := decodeBodyMap(resp.Body, &sr); err != nil {
+	if err := DecodeBodyMap(resp.Body, &sr); err != nil {
 		return nil, err
 	}
 
@@ -352,7 +352,7 @@ func (c *Client) GetAggregateJSON(i *GetAggregateInput, dst any) error {
 		return err
 	}
 
-	if err = decodeBodyMap(resp.Body, &dst); err != nil {
+	if err = DecodeBodyMap(resp.Body, &dst); err != nil {
 		return err
 	}
 
@@ -376,7 +376,7 @@ func (c *Client) GetRegions() (*RegionsResponse, error) {
 	defer resp.Body.Close()
 
 	var rr *RegionsResponse
-	if err := decodeBodyMap(resp.Body, &rr); err != nil {
+	if err := DecodeBodyMap(resp.Body, &rr); err != nil {
 		return nil, err
 	}
 

--- a/fastly/stats_historical_test.go
+++ b/fastly/stats_historical_test.go
@@ -8,9 +8,9 @@ func TestClient_GetStats(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "stats/service_stats", func(c *Client) {
+	Record(t, "stats/service_stats", func(c *Client) {
 		_, err = c.GetStats(&GetStatsInput{
-			Service: ToPointer(testDeliveryServiceID),
+			Service: ToPointer(TestDeliveryServiceID),
 			From:    ToPointer("10 days ago"),
 			To:      ToPointer("now"),
 			By:      ToPointer("minute"),
@@ -26,7 +26,7 @@ func TestClient_GetStats_ByField(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "stats/service_stats_by_field", func(c *Client) {
+	Record(t, "stats/service_stats_by_field", func(c *Client) {
 		_, err = c.GetStatsField(&GetStatsInput{
 			Field:  ToPointer("bandwidth"),
 			From:   ToPointer("1 hour ago"),
@@ -44,9 +44,9 @@ func TestClient_GetStats_ByFieldAndService(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "stats/service_stats_by_field_and_service", func(c *Client) {
+	Record(t, "stats/service_stats_by_field_and_service", func(c *Client) {
 		_, err = c.GetStats(&GetStatsInput{
-			Service: ToPointer(testDeliveryServiceID),
+			Service: ToPointer(TestDeliveryServiceID),
 			Field:   ToPointer("bandwidth"),
 			From:    ToPointer("10 days ago"),
 			To:      ToPointer("now"),
@@ -67,9 +67,9 @@ func TestClient_GetStatsJSON(t *testing.T) {
 	}
 
 	var err error
-	record(t, "stats/service_stats", func(c *Client) {
+	Record(t, "stats/service_stats", func(c *Client) {
 		err = c.GetStatsJSON(&GetStatsInput{
-			Service: ToPointer(testDeliveryServiceID),
+			Service: ToPointer(TestDeliveryServiceID),
 			From:    ToPointer("10 days ago"),
 			To:      ToPointer("now"),
 			By:      ToPointer("minute"),
@@ -93,7 +93,7 @@ func TestClient_GetAggregateJSON(t *testing.T) {
 	}
 
 	var err error
-	record(t, "stats/aggregate", func(c *Client) {
+	Record(t, "stats/aggregate", func(c *Client) {
 		err = c.GetAggregateJSON(&GetAggregateInput{
 			From:   ToPointer("15 minutes ago"),
 			To:     ToPointer("now"),
@@ -114,7 +114,7 @@ func TestClient_GetRegions(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "stats/regions", func(c *Client) {
+	Record(t, "stats/regions", func(c *Client) {
 		_, err = c.GetRegions()
 	})
 	if err != nil {
@@ -126,7 +126,7 @@ func TestClient_GetRegionsUsage(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "stats/regions_usage", func(c *Client) {
+	Record(t, "stats/regions_usage", func(c *Client) {
 		_, err = c.GetUsage(&GetUsageInput{
 			From:   ToPointer("10 days ago"),
 			To:     ToPointer("now"),
@@ -143,7 +143,7 @@ func TestClient_GetServicesByRegionsUsage(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "stats/services_usage", func(c *Client) {
+	Record(t, "stats/services_usage", func(c *Client) {
 		_, err = c.GetUsageByService(&GetUsageInput{
 			From:   ToPointer("10 days ago"),
 			To:     ToPointer("now"),

--- a/fastly/stats_origin_inspector_test.go
+++ b/fastly/stats_origin_inspector_test.go
@@ -15,7 +15,7 @@ func TestClient_GetOriginMetricsForService(t *testing.T) {
 	start := end.Add(-2 * 24 * time.Hour)
 	limit := 150
 	var err error
-	record(t, "origin_inspector/metrics_for_service", func(c *Client) {
+	Record(t, "origin_inspector/metrics_for_service", func(c *Client) {
 		_, err = c.GetOriginMetricsForService(&GetOriginMetricsInput{
 			Cursor:      ToPointer(""),
 			Datacenters: []string{"LHR", "JFK"},
@@ -25,7 +25,7 @@ func TestClient_GetOriginMetricsForService(t *testing.T) {
 			Hosts:       []string{"host01"},
 			Metrics:     []string{"responses", "status_2xx"},
 			Regions:     []string{"europe", "usa"},
-			ServiceID:   testDeliveryServiceID,
+			ServiceID:   TestDeliveryServiceID,
 			Start:       &start,
 			Limit:       &limit,
 		})

--- a/fastly/stats_realtime_test.go
+++ b/fastly/stats_realtime_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestClient_GetRealtimeStats_validation(t *testing.T) {
 	var err error
-	_, err = testStatsClient.GetRealtimeStats(&GetRealtimeStatsInput{
+	_, err = TestStatsClient.GetRealtimeStats(&GetRealtimeStatsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
@@ -20,9 +20,9 @@ func TestStatsClient_GetRealtimeStats(t *testing.T) {
 	var err error
 
 	// Get
-	recordRealtimeStats(t, "realtime_stats/get", func(c *RTSClient) {
+	RecordRealtimeStats(t, "realtime_stats/get", func(c *RTSClient) {
 		_, err = c.GetRealtimeStats(&GetRealtimeStatsInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			Timestamp: 0,
 			Limit:     ToPointer(uint32(3)),
 		})
@@ -40,9 +40,9 @@ func TestStatsClient_GetRealtimeStatsJSON(t *testing.T) {
 	}
 
 	var err error
-	recordRealtimeStats(t, "realtime_stats/get", func(c *RTSClient) {
+	RecordRealtimeStats(t, "realtime_stats/get", func(c *RTSClient) {
 		err = c.GetRealtimeStatsJSON(&GetRealtimeStatsInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			Timestamp: 0,
 			Limit:     ToPointer(uint32(3)),
 		}, &ret)

--- a/fastly/tls_custom_activation_test.go
+++ b/fastly/tls_custom_activation_test.go
@@ -12,7 +12,7 @@ func TestClient_TLSActivation(t *testing.T) {
 	// Create
 	var err error
 	var ta *TLSActivation
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		ta, err = c.CreateTLSActivation(&CreateTLSActivationInput{
 			Certificate:   &CustomTLSCertificate{ID: "CERTIFICATE_ID"},
 			Configuration: &TLSConfiguration{ID: "CONFIGURATION_ID"},
@@ -25,7 +25,7 @@ func TestClient_TLSActivation(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"cleanup", func(c *Client) {
+		Record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteTLSActivation(&DeleteTLSActivationInput{
 				ID: ta.ID,
 			})
@@ -34,7 +34,7 @@ func TestClient_TLSActivation(t *testing.T) {
 
 	// List
 	var lta []*TLSActivation
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		lta, err = c.ListTLSActivations(&ListTLSActivationsInput{})
 	})
 	if err != nil {
@@ -64,7 +64,7 @@ func TestClient_TLSActivation(t *testing.T) {
 
 	// Get
 	var gta *TLSActivation
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		gta, err = c.GetTLSActivation(&GetTLSActivationInput{
 			ID: ta.ID,
 		})
@@ -78,7 +78,7 @@ func TestClient_TLSActivation(t *testing.T) {
 
 	// Update
 	var uta *TLSActivation
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		uta, err = c.UpdateTLSActivation(&UpdateTLSActivationInput{
 			ID:          "ACTIVATION_ID",
 			Certificate: &CustomTLSCertificate{},
@@ -92,7 +92,7 @@ func TestClient_TLSActivation(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteTLSActivation(&DeleteTLSActivationInput{
 			ID: ta.ID,
 		})
@@ -106,7 +106,7 @@ func TestClient_CreateTLSActivation_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "custom_tls_activation/create", func(c *Client) {
+	Record(t, "custom_tls_activation/create", func(c *Client) {
 		_, err = c.CreateTLSActivation(&CreateTLSActivationInput{
 			Certificate:   &CustomTLSCertificate{ID: "CERTIFICATE_ID"},
 			Configuration: &TLSConfiguration{ID: "CONFIGURATION_ID"},
@@ -117,7 +117,7 @@ func TestClient_CreateTLSActivation_validation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = testClient.CreateTLSActivation(&CreateTLSActivationInput{
+	_, err = TestClient.CreateTLSActivation(&CreateTLSActivationInput{
 		Configuration: &TLSConfiguration{ID: "CONFIGURATION_ID"},
 		Domain:        &TLSDomain{ID: "DOMAIN_NAME"},
 	})
@@ -125,7 +125,7 @@ func TestClient_CreateTLSActivation_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateTLSActivation(&CreateTLSActivationInput{
+	_, err = TestClient.CreateTLSActivation(&CreateTLSActivationInput{
 		Certificate:   &CustomTLSCertificate{ID: "CERTIFICATE_ID"},
 		Configuration: &TLSConfiguration{ID: "CONFIGURATION_ID"},
 	})
@@ -138,7 +138,7 @@ func TestClient_DeleteTLSActivation_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "custom_tls_activation/delete", func(c *Client) {
+	Record(t, "custom_tls_activation/delete", func(c *Client) {
 		err = c.DeleteTLSActivation(&DeleteTLSActivationInput{
 			ID: "ACTIVATION_ID",
 		})
@@ -147,7 +147,7 @@ func TestClient_DeleteTLSActivation_validation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testClient.DeleteTLSActivation(&DeleteTLSActivationInput{})
+	err = TestClient.DeleteTLSActivation(&DeleteTLSActivationInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
@@ -157,7 +157,7 @@ func TestClient_ListTLSActivations_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "custom_tls_activation/list", func(c *Client) {
+	Record(t, "custom_tls_activation/list", func(c *Client) {
 		_, err = c.ListTLSActivations(&ListTLSActivationsInput{})
 	})
 	if err != nil {
@@ -169,7 +169,7 @@ func TestClient_GetTLSActivation_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "custom_tls_activation/get", func(c *Client) {
+	Record(t, "custom_tls_activation/get", func(c *Client) {
 		_, err = c.GetTLSActivation(&GetTLSActivationInput{
 			ID: "ACTIVATION_ID",
 		})
@@ -178,7 +178,7 @@ func TestClient_GetTLSActivation_validation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = testClient.GetTLSActivation(&GetTLSActivationInput{})
+	_, err = TestClient.GetTLSActivation(&GetTLSActivationInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
@@ -188,7 +188,7 @@ func TestClient_UpdateTLSActivation_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "custom_tls_activation/update", func(c *Client) {
+	Record(t, "custom_tls_activation/update", func(c *Client) {
 		_, err = c.UpdateTLSActivation(&UpdateTLSActivationInput{
 			ID:          "ACTIVATION_ID",
 			Certificate: &CustomTLSCertificate{ID: "CERTIFICATE_ID"},
@@ -198,14 +198,14 @@ func TestClient_UpdateTLSActivation_validation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = testClient.UpdateTLSActivation(&UpdateTLSActivationInput{
+	_, err = TestClient.UpdateTLSActivation(&UpdateTLSActivationInput{
 		ID: "ACTIVATION_ID",
 	})
 	if err != ErrMissingCertificateMTLS {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateTLSActivation(&UpdateTLSActivationInput{
+	_, err = TestClient.UpdateTLSActivation(&UpdateTLSActivationInput{
 		Certificate: &CustomTLSCertificate{ID: "CERTIFICATE_ID"},
 	})
 	if err != ErrMissingID {

--- a/fastly/tls_custom_certificate_test.go
+++ b/fastly/tls_custom_certificate_test.go
@@ -22,7 +22,7 @@ func TestClient_CustomTLSCertificate(t *testing.T) {
 
 	// Create
 	var pk *PrivateKey
-	record(t, fixtureBase+"create-key", func(c *Client) {
+	Record(t, fixtureBase+"create-key", func(c *Client) {
 		pk, err = c.CreatePrivateKey(&CreatePrivateKeyInput{
 			Key:  key,
 			Name: "My private key",
@@ -34,7 +34,7 @@ func TestClient_CustomTLSCertificate(t *testing.T) {
 
 	// Create
 	var cc *CustomTLSCertificate
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		cc, err = c.CreateCustomTLSCertificate(&CreateCustomTLSCertificateInput{
 			CertBlob: cert,
 			Name:     "My certificate",
@@ -46,17 +46,17 @@ func TestClient_CustomTLSCertificate(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		_ = testClient.DeleteCustomTLSCertificate(&DeleteCustomTLSCertificateInput{
+		_ = TestClient.DeleteCustomTLSCertificate(&DeleteCustomTLSCertificateInput{
 			ID: cc.ID,
 		})
-		_ = testClient.DeletePrivateKey(&DeletePrivateKeyInput{
+		_ = TestClient.DeletePrivateKey(&DeletePrivateKeyInput{
 			ID: pk.ID,
 		})
 	}()
 
 	// List
 	var lcc []*CustomTLSCertificate
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		lcc, err = c.ListCustomTLSCertificates(&ListCustomTLSCertificatesInput{
 			// NOTE: We set to an explicit false to avoid a test error.
 			// This is because we don't activate a real TLS certificate in the test.
@@ -73,7 +73,7 @@ func TestClient_CustomTLSCertificate(t *testing.T) {
 
 	// Get
 	var gcc *CustomTLSCertificate
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		gcc, err = c.GetCustomTLSCertificate(&GetCustomTLSCertificateInput{
 			ID: cc.ID,
 		})
@@ -102,7 +102,7 @@ func TestClient_CustomTLSCertificate(t *testing.T) {
 
 	// Update
 	var ucc *CustomTLSCertificate
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		ucc, err = c.UpdateCustomTLSCertificate(&UpdateCustomTLSCertificateInput{
 			ID:       cc.ID,
 			CertBlob: cert,
@@ -117,7 +117,7 @@ func TestClient_CustomTLSCertificate(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete-cert", func(c *Client) {
+	Record(t, fixtureBase+"delete-cert", func(c *Client) {
 		err = c.DeleteCustomTLSCertificate(&DeleteCustomTLSCertificateInput{
 			ID: cc.ID,
 		})
@@ -125,7 +125,7 @@ func TestClient_CustomTLSCertificate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record(t, fixtureBase+"delete-key", func(c *Client) {
+	Record(t, fixtureBase+"delete-key", func(c *Client) {
 		err = c.DeletePrivateKey(&DeletePrivateKeyInput{
 			ID: pk.ID,
 		})
@@ -139,7 +139,7 @@ func TestClient_CreateCustomTLSCertificate_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	_, err = testClient.CreateCustomTLSCertificate(&CreateCustomTLSCertificateInput{
+	_, err = TestClient.CreateCustomTLSCertificate(&CreateCustomTLSCertificateInput{
 		Name: "My certificate",
 	})
 	if err != ErrMissingCertBlob {
@@ -150,7 +150,7 @@ func TestClient_CreateCustomTLSCertificate_validation(t *testing.T) {
 func TestClient_DeleteCustomTLSCertificate_validation(t *testing.T) {
 	t.Parallel()
 
-	err := testClient.DeleteCustomTLSCertificate(&DeleteCustomTLSCertificateInput{})
+	err := TestClient.DeleteCustomTLSCertificate(&DeleteCustomTLSCertificateInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
@@ -160,7 +160,7 @@ func TestClient_ListCustomTLSCertificates_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "custom_tls/list", func(c *Client) {
+	Record(t, "custom_tls/list", func(c *Client) {
 		_, err = c.ListCustomTLSCertificates(&ListCustomTLSCertificatesInput{
 			FilterInUse: ToPointer(false),
 		})
@@ -174,7 +174,7 @@ func TestClient_GetCustomTLSCertificate_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	_, err = testClient.GetCustomTLSCertificate(&GetCustomTLSCertificateInput{})
+	_, err = TestClient.GetCustomTLSCertificate(&GetCustomTLSCertificateInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
@@ -184,7 +184,7 @@ func TestClient_UpdateCustomTLSCertificate_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	_, err = testClient.UpdateCustomTLSCertificate(&UpdateCustomTLSCertificateInput{
+	_, err = TestClient.UpdateCustomTLSCertificate(&UpdateCustomTLSCertificateInput{
 		CertBlob: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
 		Name:     "My certificate",
 	})
@@ -192,7 +192,7 @@ func TestClient_UpdateCustomTLSCertificate_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateCustomTLSCertificate(&UpdateCustomTLSCertificateInput{
+	_, err = TestClient.UpdateCustomTLSCertificate(&UpdateCustomTLSCertificateInput{
 		ID:   "CERTIFICATE_ID",
 		Name: "My certificate",
 	})

--- a/fastly/tls_custom_configuration_test.go
+++ b/fastly/tls_custom_configuration_test.go
@@ -14,7 +14,7 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 
 	// Get
 	var gcon *CustomTLSConfiguration
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		gcon, err = c.GetCustomTLSConfiguration(&GetCustomTLSConfigurationInput{
 			ID: conID,
 		})
@@ -28,7 +28,7 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 
 	// List
 	var lcon []*CustomTLSConfiguration
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		lcon, err = c.ListCustomTLSConfigurations(&ListCustomTLSConfigurationsInput{})
 	})
 	if err != nil {
@@ -41,7 +41,7 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 	// Update
 	var ucon *CustomTLSConfiguration
 	newName := "My configuration v2"
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		ucon, err = c.UpdateCustomTLSConfiguration(&UpdateCustomTLSConfigurationInput{
 			ID:   "TLS_CONFIGURATION_ID",
 			Name: newName,
@@ -62,7 +62,7 @@ func TestClient_ListCustomTLSConfigurations_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "custom_tls_configuration/list", func(c *Client) {
+	Record(t, "custom_tls_configuration/list", func(c *Client) {
 		_, err = c.ListCustomTLSConfigurations(&ListCustomTLSConfigurationsInput{})
 	})
 	if err != nil {
@@ -74,7 +74,7 @@ func TestClient_GetCustomTLSConfiguration_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "custom_tls_configuration/get", func(c *Client) {
+	Record(t, "custom_tls_configuration/get", func(c *Client) {
 		_, err = c.GetCustomTLSConfiguration(&GetCustomTLSConfigurationInput{
 			ID: "TLS_CONFIGURATION_ID",
 		})
@@ -83,7 +83,7 @@ func TestClient_GetCustomTLSConfiguration_validation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = testClient.GetCustomTLSConfiguration(&GetCustomTLSConfigurationInput{})
+	_, err = TestClient.GetCustomTLSConfiguration(&GetCustomTLSConfigurationInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
@@ -93,7 +93,7 @@ func TestClient_UpdateCustomTLSConfiguration_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "custom_tls_configuration/update", func(c *Client) {
+	Record(t, "custom_tls_configuration/update", func(c *Client) {
 		_, err = c.UpdateCustomTLSConfiguration(&UpdateCustomTLSConfigurationInput{
 			ID:   "TLS_CONFIGURATION_ID",
 			Name: "My configuration v2",
@@ -103,14 +103,14 @@ func TestClient_UpdateCustomTLSConfiguration_validation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = testClient.UpdateCustomTLSConfiguration(&UpdateCustomTLSConfigurationInput{
+	_, err = TestClient.UpdateCustomTLSConfiguration(&UpdateCustomTLSConfigurationInput{
 		Name: "My configuration v2",
 	})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateCustomTLSConfiguration(&UpdateCustomTLSConfigurationInput{
+	_, err = TestClient.UpdateCustomTLSConfiguration(&UpdateCustomTLSConfigurationInput{
 		ID: "CONFIGURATION_ID",
 	})
 	if err != ErrMissingName {

--- a/fastly/tls_custom_domain_test.go
+++ b/fastly/tls_custom_domain_test.go
@@ -13,7 +13,7 @@ func TestClient_ListTLSDomains(t *testing.T) {
 
 	// List
 	var ldom []*TLSDomain
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		ldom, err = c.ListTLSDomains(&ListTLSDomainsInput{
 			PageSize: 10,
 		})
@@ -35,7 +35,7 @@ func TestClient_ListTLSDomainsFilterCertificates(t *testing.T) {
 
 	// List
 	var ldom []*TLSDomain
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		ldom, err = c.ListTLSDomains(&ListTLSDomainsInput{
 			FilterTLSCertificateID: "6RltCYkOfFfzPVitOyLCnV",
 		})

--- a/fastly/tls_mutual_authentication_test.go
+++ b/fastly/tls_mutual_authentication_test.go
@@ -21,7 +21,7 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 
 	// Create private key required to generate a custom certificate.
 	var pk *PrivateKey
-	record(t, fixtureBase+"create-key", func(c *Client) {
+	Record(t, fixtureBase+"create-key", func(c *Client) {
 		pk, err = c.CreatePrivateKey(&CreatePrivateKeyInput{
 			Key:  key,
 			Name: "My private key",
@@ -33,7 +33,7 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 
 	// Create a customer TLS certificate to pass to the mutual authentication endpoint.
 	var cc *CustomTLSCertificate
-	record(t, fixtureBase+"create-cert", func(c *Client) {
+	Record(t, fixtureBase+"create-cert", func(c *Client) {
 		cc, err = c.CreateCustomTLSCertificate(&CreateCustomTLSCertificateInput{
 			CertBlob: cert,
 			Name:     "My custom certificate",
@@ -45,17 +45,17 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		_ = testClient.DeleteCustomTLSCertificate(&DeleteCustomTLSCertificateInput{
+		_ = TestClient.DeleteCustomTLSCertificate(&DeleteCustomTLSCertificateInput{
 			ID: cc.ID,
 		})
-		_ = testClient.DeletePrivateKey(&DeletePrivateKeyInput{
+		_ = TestClient.DeletePrivateKey(&DeletePrivateKeyInput{
 			ID: pk.ID,
 		})
 	}()
 
 	// Create mutual authentication using the custom TLS certificate above.
 	var tma *TLSMutualAuthentication
-	record(t, fixtureBase+"create-tma", func(c *Client) {
+	Record(t, fixtureBase+"create-tma", func(c *Client) {
 		tma, err = c.CreateTLSMutualAuthentication(&CreateTLSMutualAuthenticationInput{
 			CertBundle: cert,
 			Enforced:   false,
@@ -68,7 +68,7 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		_ = testClient.DeleteTLSMutualAuthentication(&DeleteTLSMutualAuthenticationInput{
+		_ = TestClient.DeleteTLSMutualAuthentication(&DeleteTLSMutualAuthenticationInput{
 			ID: tma.ID,
 		})
 	}()
@@ -79,7 +79,7 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 
 	// List
 	var tmas []*TLSMutualAuthentication
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		tmas, err = c.ListTLSMutualAuthentication(&ListTLSMutualAuthenticationsInput{})
 	})
 	if err != nil {
@@ -91,7 +91,7 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 
 	// Get
 	var gtma *TLSMutualAuthentication
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		gtma, err = c.GetTLSMutualAuthentication(&GetTLSMutualAuthenticationInput{
 			ID: tma.ID,
 		})
@@ -105,7 +105,7 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 
 	// Update
 	var utma *TLSMutualAuthentication
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		utma, err = c.UpdateTLSMutualAuthentication(&UpdateTLSMutualAuthenticationInput{
 			CertBundle: cert,
 			Enforced:   true,
@@ -121,7 +121,7 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete-tma", func(c *Client) {
+	Record(t, fixtureBase+"delete-tma", func(c *Client) {
 		err = c.DeleteTLSMutualAuthentication(&DeleteTLSMutualAuthenticationInput{
 			ID: tma.ID,
 		})
@@ -129,7 +129,7 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record(t, fixtureBase+"delete-cert", func(c *Client) {
+	Record(t, fixtureBase+"delete-cert", func(c *Client) {
 		err = c.DeleteCustomTLSCertificate(&DeleteCustomTLSCertificateInput{
 			ID: cc.ID,
 		})
@@ -137,7 +137,7 @@ func TestClient_TLSMutualAuthentication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	record(t, fixtureBase+"delete-key", func(c *Client) {
+	Record(t, fixtureBase+"delete-key", func(c *Client) {
 		err = c.DeletePrivateKey(&DeletePrivateKeyInput{
 			ID: pk.ID,
 		})
@@ -151,7 +151,7 @@ func TestClient_CreateTLSMutualAuthentication_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	_, err = testClient.CreateTLSMutualAuthentication(&CreateTLSMutualAuthenticationInput{
+	_, err = TestClient.CreateTLSMutualAuthentication(&CreateTLSMutualAuthenticationInput{
 		Name: "My certificate",
 	})
 	if err != ErrMissingCertBundle {
@@ -162,7 +162,7 @@ func TestClient_CreateTLSMutualAuthentication_validation(t *testing.T) {
 func TestClient_DeleteTLSMutualAuthentication_validation(t *testing.T) {
 	t.Parallel()
 
-	err := testClient.DeleteTLSMutualAuthentication(&DeleteTLSMutualAuthenticationInput{})
+	err := TestClient.DeleteTLSMutualAuthentication(&DeleteTLSMutualAuthenticationInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
@@ -172,7 +172,7 @@ func TestClient_ListTLSMutualAuthentication_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "mutual_authentication/list", func(c *Client) {
+	Record(t, "mutual_authentication/list", func(c *Client) {
 		_, err = c.ListTLSMutualAuthentication(&ListTLSMutualAuthenticationsInput{})
 	})
 	if err != nil {
@@ -184,7 +184,7 @@ func TestClient_GetTLSMutualAuthentication_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	_, err = testClient.GetCustomTLSCertificate(&GetCustomTLSCertificateInput{})
+	_, err = TestClient.GetCustomTLSCertificate(&GetCustomTLSCertificateInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
@@ -194,7 +194,7 @@ func TestClient_UpdateTLSMutualAuthentication_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	_, err = testClient.UpdateTLSMutualAuthentication(&UpdateTLSMutualAuthenticationInput{
+	_, err = TestClient.UpdateTLSMutualAuthentication(&UpdateTLSMutualAuthenticationInput{
 		ID:   "example",
 		Name: "My certificate",
 	})
@@ -202,7 +202,7 @@ func TestClient_UpdateTLSMutualAuthentication_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateTLSMutualAuthentication(&UpdateTLSMutualAuthenticationInput{
+	_, err = TestClient.UpdateTLSMutualAuthentication(&UpdateTLSMutualAuthenticationInput{
 		CertBundle: "example",
 		Name:       "My certificate",
 	})

--- a/fastly/tls_platform_test.go
+++ b/fastly/tls_platform_test.go
@@ -12,7 +12,7 @@ func TestClient_BulkCertificate(t *testing.T) {
 	// Create
 	var err error
 	var bc *BulkCertificate
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		bc, err = c.CreateBulkCertificate(&CreateBulkCertificateInput{
 			CertBlob:          "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
 			IntermediatesBlob: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
@@ -29,7 +29,7 @@ func TestClient_BulkCertificate(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"cleanup", func(c *Client) {
+		Record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteBulkCertificate(&DeleteBulkCertificateInput{
 				ID: bc.ID,
 			})
@@ -38,7 +38,7 @@ func TestClient_BulkCertificate(t *testing.T) {
 
 	// List
 	var lbc []*BulkCertificate
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		lbc, err = c.ListBulkCertificates(&ListBulkCertificatesInput{})
 	})
 	if err != nil {
@@ -50,7 +50,7 @@ func TestClient_BulkCertificate(t *testing.T) {
 
 	// Get
 	var gbc *BulkCertificate
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		gbc, err = c.GetBulkCertificate(&GetBulkCertificateInput{
 			ID: bc.ID,
 		})
@@ -64,7 +64,7 @@ func TestClient_BulkCertificate(t *testing.T) {
 
 	// Update
 	var ubc *BulkCertificate
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		ubc, err = c.UpdateBulkCertificate(&UpdateBulkCertificateInput{
 			ID:                "CERTIFICATE_ID",
 			CertBlob:          "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
@@ -79,7 +79,7 @@ func TestClient_BulkCertificate(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteBulkCertificate(&DeleteBulkCertificateInput{
 			ID: bc.ID,
 		})
@@ -93,7 +93,7 @@ func TestClient_CreateBulkCertificate_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "platform_tls/create", func(c *Client) {
+	Record(t, "platform_tls/create", func(c *Client) {
 		_, err = c.CreateBulkCertificate(&CreateBulkCertificateInput{
 			CertBlob:          "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
 			IntermediatesBlob: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
@@ -113,7 +113,7 @@ func TestClient_DeleteBulkCertificate_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "platform_tls/delete", func(c *Client) {
+	Record(t, "platform_tls/delete", func(c *Client) {
 		err = c.DeleteBulkCertificate(&DeleteBulkCertificateInput{
 			ID: "CERTIFICATE_ID",
 		})
@@ -127,7 +127,7 @@ func TestClient_ListBulkCertificates_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "platform_tls/list", func(c *Client) {
+	Record(t, "platform_tls/list", func(c *Client) {
 		_, err = c.ListBulkCertificates(&ListBulkCertificatesInput{})
 	})
 	if err != nil {
@@ -139,7 +139,7 @@ func TestClient_GetBulkCertificate_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "platform_tls/get", func(c *Client) {
+	Record(t, "platform_tls/get", func(c *Client) {
 		_, err = c.GetBulkCertificate(&GetBulkCertificateInput{
 			ID: "CERTIFICATE_ID",
 		})
@@ -153,7 +153,7 @@ func TestClient_UpdateBulkCertificate_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "platform_tls/update", func(c *Client) {
+	Record(t, "platform_tls/update", func(c *Client) {
 		_, err = c.UpdateBulkCertificate(&UpdateBulkCertificateInput{
 			ID:                "CERTIFICATE_ID",
 			CertBlob:          "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",

--- a/fastly/tls_private_keys_test.go
+++ b/fastly/tls_private_keys_test.go
@@ -26,7 +26,7 @@ func TestClient_PrivateKey(t *testing.T) {
 
 	// Create
 	var pk *PrivateKey
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		pk, err = c.CreatePrivateKey(&CreatePrivateKeyInput{
 			Key:  key,
 			Name: "My private key",
@@ -38,14 +38,14 @@ func TestClient_PrivateKey(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		_ = testClient.DeletePrivateKey(&DeletePrivateKeyInput{
+		_ = TestClient.DeletePrivateKey(&DeletePrivateKeyInput{
 			ID: pk.ID,
 		})
 	}()
 
 	// List
 	var lpk []*PrivateKey
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		lpk, err = c.ListPrivateKeys(&ListPrivateKeysInput{})
 	})
 	if err != nil {
@@ -57,7 +57,7 @@ func TestClient_PrivateKey(t *testing.T) {
 
 	// Get
 	var gpk *PrivateKey
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		gpk, err = c.GetPrivateKey(&GetPrivateKeyInput{
 			ID: pk.ID,
 		})
@@ -70,7 +70,7 @@ func TestClient_PrivateKey(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeletePrivateKey(&DeletePrivateKeyInput{
 			ID: pk.ID,
 		})

--- a/fastly/tls_subscription_test.go
+++ b/fastly/tls_subscription_test.go
@@ -14,15 +14,15 @@ func TestClient_TLSSubscription(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, fixtureBase+"version", func(c *Client) {
+	Record(t, fixtureBase+"version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Ensure service (and all domains within it) are deleted
 	defer func() {
-		record(t, fixtureBase+"version", func(c *Client) {
+		Record(t, fixtureBase+"version", func(c *Client) {
 			_ = c.DeleteService(&DeleteServiceInput{
-				ServiceID: testDeliveryServiceID,
+				ServiceID: TestDeliveryServiceID,
 			})
 		})
 	}()
@@ -36,9 +36,9 @@ func TestClient_TLSSubscription(t *testing.T) {
 	domain1 := "integ-test1.go-fastly-1.com"
 	domain2 := "integ-test2.go-fastly-2.com"
 
-	record(t, fixtureBase+"domains/create", func(c *Client) {
+	Record(t, fixtureBase+"domains/create", func(c *Client) {
 		_, err = c.CreateDomain(&CreateDomainInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer(domain1),
 			Comment:        ToPointer("comment"),
@@ -48,9 +48,9 @@ func TestClient_TLSSubscription(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, fixtureBase+"domains/create2", func(c *Client) {
+	Record(t, fixtureBase+"domains/create2", func(c *Client) {
 		_, err = c.CreateDomain(&CreateDomainInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer(domain2),
 			Comment:        ToPointer("comment"),
@@ -63,9 +63,9 @@ func TestClient_TLSSubscription(t *testing.T) {
 	// Activate service version otherwise TLS Subscription won't be able to locate
 	// the specified domains and the API will return an error.
 
-	record(t, fixtureBase+"activate_version", func(c *Client) {
+	Record(t, fixtureBase+"activate_version", func(c *Client) {
 		_, err = c.ActivateVersion(&ActivateVersionInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -75,7 +75,7 @@ func TestClient_TLSSubscription(t *testing.T) {
 
 	// Create
 	var subscription *TLSSubscription
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		subscription, err = c.CreateTLSSubscription(&CreateTLSSubscriptionInput{
 			Domains: []*TLSDomain{
 				{ID: domain1},
@@ -88,7 +88,7 @@ func TestClient_TLSSubscription(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"cleanup", func(c *Client) {
+		Record(t, fixtureBase+"cleanup", func(c *Client) {
 			// NOTE: We would expect this API call to produce a 404 rather than a 204
 			// because the "delete" step at the end of the test function is
 			// effectively deleting the subscription, and then this defer function is
@@ -104,7 +104,7 @@ func TestClient_TLSSubscription(t *testing.T) {
 
 	// List
 	var listSubscriptions []*TLSSubscription
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		listSubscriptions, err = c.ListTLSSubscriptions(&ListTLSSubscriptionsInput{
 			// NOTE: Added this filter so I could manually verify that the filter is
 			// only added to the API request query parameters when set to `true`. See
@@ -133,7 +133,7 @@ func TestClient_TLSSubscription(t *testing.T) {
 	}
 
 	var retrievedSubscription *TLSSubscription
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		retrievedSubscription, err = c.GetTLSSubscription(&GetTLSSubscriptionInput{
 			ID: subscription.ID,
 		})
@@ -146,7 +146,7 @@ func TestClient_TLSSubscription(t *testing.T) {
 	}
 
 	var updatedSubscription *TLSSubscription
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		updatedSubscription, err = c.UpdateTLSSubscription(&UpdateTLSSubscriptionInput{
 			ID: subscription.ID,
 			Domains: []*TLSDomain{
@@ -164,7 +164,7 @@ func TestClient_TLSSubscription(t *testing.T) {
 		t.Errorf("bad CommonName %s (%s)", updatedSubscription.CommonName.ID, domain2)
 	}
 
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteTLSSubscription(&DeleteTLSSubscriptionInput{
 			ID: subscription.ID,
 		})
@@ -179,7 +179,7 @@ func TestClient_ListTLSSubscriptions_validation(t *testing.T) {
 
 	var tlsSubscriptions []*TLSSubscription
 	var err error
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		tlsSubscriptions, err = c.ListTLSSubscriptions(&ListTLSSubscriptionsInput{})
 	})
 	if err != nil {
@@ -194,7 +194,7 @@ func TestClient_CreateTLSSubscription_validation(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		_, err = c.CreateTLSSubscription(&CreateTLSSubscriptionInput{
 			Domains: []*TLSDomain{
 				{ID: "DOMAIN_NAME"},
@@ -206,12 +206,12 @@ func TestClient_CreateTLSSubscription_validation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = testClient.CreateTLSSubscription(&CreateTLSSubscriptionInput{})
+	_, err = TestClient.CreateTLSSubscription(&CreateTLSSubscriptionInput{})
 	if err != ErrMissingTLSDomain {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateTLSSubscription(&CreateTLSSubscriptionInput{
+	_, err = TestClient.CreateTLSSubscription(&CreateTLSSubscriptionInput{
 		Domains: []*TLSDomain{
 			{ID: "DN1"},
 			{ID: "DN2"},
@@ -226,7 +226,7 @@ func TestClient_CreateTLSSubscription_validation(t *testing.T) {
 func TestClient_GetTLSSubscription_validation(t *testing.T) {
 	t.Parallel()
 
-	_, err := testClient.GetTLSSubscription(&GetTLSSubscriptionInput{})
+	_, err := TestClient.GetTLSSubscription(&GetTLSSubscriptionInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
@@ -235,7 +235,7 @@ func TestClient_GetTLSSubscription_validation(t *testing.T) {
 func TestClient_UpdateTLSSubscription_validation(t *testing.T) {
 	t.Parallel()
 
-	_, err := testClient.UpdateTLSSubscription(&UpdateTLSSubscriptionInput{})
+	_, err := TestClient.UpdateTLSSubscription(&UpdateTLSSubscriptionInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
@@ -244,7 +244,7 @@ func TestClient_UpdateTLSSubscription_validation(t *testing.T) {
 func TestClient_DeleteTLSSubscription_validation(t *testing.T) {
 	t.Parallel()
 
-	err := testClient.DeleteTLSSubscription(&DeleteTLSSubscriptionInput{})
+	err := TestClient.DeleteTLSSubscription(&DeleteTLSSubscriptionInput{})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}

--- a/fastly/token.go
+++ b/fastly/token.go
@@ -48,7 +48,7 @@ func (c *Client) ListTokens(_ *ListTokensInput) ([]*Token, error) {
 	defer resp.Body.Close()
 
 	var t []*Token
-	if err := decodeBodyMap(resp.Body, &t); err != nil {
+	if err := DecodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 	return t, nil
@@ -75,7 +75,7 @@ func (c *Client) ListCustomerTokens(i *ListCustomerTokensInput) ([]*Token, error
 	defer resp.Body.Close()
 
 	var t []*Token
-	if err := decodeBodyMap(resp.Body, &t); err != nil {
+	if err := DecodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 	return t, nil
@@ -93,7 +93,7 @@ func (c *Client) GetTokenSelf() (*Token, error) {
 	defer resp.Body.Close()
 
 	var t *Token
-	if err := decodeBodyMap(resp.Body, &t); err != nil {
+	if err := DecodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 
@@ -130,7 +130,7 @@ func (c *Client) CreateToken(i *CreateTokenInput) (*Token, error) {
 	defer resp.Body.Close()
 
 	var t *Token
-	if err := decodeBodyMap(resp.Body, &t); err != nil {
+	if err := DecodeBodyMap(resp.Body, &t); err != nil {
 		return nil, err
 	}
 	return t, nil

--- a/fastly/token_test.go
+++ b/fastly/token_test.go
@@ -9,7 +9,7 @@ func TestClient_ListTokens(t *testing.T) {
 
 	var tokens []*Token
 	var err error
-	record(t, "tokens/list", func(c *Client) {
+	Record(t, "tokens/list", func(c *Client) {
 		tokens, err = c.ListTokens(&ListTokensInput{})
 	})
 	if err != nil {
@@ -25,7 +25,7 @@ func TestClient_ListCustomerTokens(t *testing.T) {
 
 	var tokens []*Token
 	var err error
-	record(t, "tokens/list_customer", func(c *Client) {
+	Record(t, "tokens/list_customer", func(c *Client) {
 		tokens, err = c.ListCustomerTokens(&ListCustomerTokensInput{
 			CustomerID: "XXXXXXXXXXXXXXXXXXXXXX",
 		})
@@ -43,7 +43,7 @@ func TestClient_GetTokenSelf(t *testing.T) {
 
 	var token *Token
 	var err error
-	record(t, "tokens/get_self", func(c *Client) {
+	Record(t, "tokens/get_self", func(c *Client) {
 		token, err = c.GetTokenSelf()
 	})
 	if err != nil {
@@ -64,7 +64,7 @@ func TestClient_CreateToken(t *testing.T) {
 
 	var token *Token
 	var err error
-	record(t, "tokens/create", func(c *Client) {
+	Record(t, "tokens/create", func(c *Client) {
 		token, err = c.CreateToken(input)
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func TestClient_DeleteToken(t *testing.T) {
 	}
 
 	var err error
-	record(t, "tokens/delete", func(c *Client) {
+	Record(t, "tokens/delete", func(c *Client) {
 		err = c.DeleteToken(input)
 	})
 	if err != nil {
@@ -99,7 +99,7 @@ func TestClient_DeleteTokenSelf(t *testing.T) {
 	t.Parallel()
 
 	var err error
-	record(t, "tokens/delete_self", func(c *Client) {
+	Record(t, "tokens/delete_self", func(c *Client) {
 		err = c.DeleteTokenSelf()
 	})
 	if err != nil {
@@ -112,7 +112,7 @@ func TestClient_CreateAndBulkDeleteTokens(t *testing.T) {
 
 	var deleteErr error
 
-	record(t, "tokens/create_and_bulk_delete", func(c *Client) {
+	Record(t, "tokens/create_and_bulk_delete", func(c *Client) {
 		token1, err := c.CreateToken(&CreateTokenInput{
 			Name:     ToPointer("my-test-token-1"),
 			Scope:    ToPointer(GlobalScope),

--- a/fastly/user.go
+++ b/fastly/user.go
@@ -44,7 +44,7 @@ func (c *Client) ListCustomerUsers(i *ListCustomerUsersInput) ([]*User, error) {
 	defer resp.Body.Close()
 
 	var u []*User
-	if err := decodeBodyMap(resp.Body, &u); err != nil {
+	if err := DecodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 	return u, nil
@@ -59,7 +59,7 @@ func (c *Client) GetCurrentUser() (*User, error) {
 	defer resp.Body.Close()
 
 	var u *User
-	if err := decodeBodyMap(resp.Body, &u); err != nil {
+	if err := DecodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 
@@ -89,7 +89,7 @@ func (c *Client) GetUser(i *GetUserInput) (*User, error) {
 	defer resp.Body.Close()
 
 	var u *User
-	if err := decodeBodyMap(resp.Body, &u); err != nil {
+	if err := DecodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 
@@ -115,7 +115,7 @@ func (c *Client) CreateUser(i *CreateUserInput) (*User, error) {
 	defer resp.Body.Close()
 
 	var u *User
-	if err := decodeBodyMap(resp.Body, &u); err != nil {
+	if err := DecodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 	return u, nil
@@ -146,7 +146,7 @@ func (c *Client) UpdateUser(i *UpdateUserInput) (*User, error) {
 	defer resp.Body.Close()
 
 	var u *User
-	if err := decodeBodyMap(resp.Body, &u); err != nil {
+	if err := DecodeBodyMap(resp.Body, &u); err != nil {
 		return nil, err
 	}
 	return u, nil
@@ -173,7 +173,7 @@ func (c *Client) DeleteUser(i *DeleteUserInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -203,7 +203,7 @@ func (c *Client) ResetUserPassword(i *ResetUserPasswordInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/user_test.go
+++ b/fastly/user_test.go
@@ -9,7 +9,7 @@ func TestClient_UsersCurrent(t *testing.T) {
 
 	var err error
 	var u *User
-	record(t, "users/get_current_user", func(c *Client) {
+	Record(t, "users/get_current_user", func(c *Client) {
 		u, err = c.GetCurrentUser()
 	})
 	if err != nil {
@@ -29,7 +29,7 @@ func TestClient_Users(t *testing.T) {
 	// NOTE: When recreating the fixtures, update the login.
 	var err error
 	var u *User
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		u, err = c.CreateUser(&CreateUserInput{
 			Login: ToPointer(login),
 			Name:  ToPointer("test user"),
@@ -42,7 +42,7 @@ func TestClient_Users(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"cleanup", func(c *Client) {
+		Record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteUser(&DeleteUserInput{
 				UserID: *u.UserID,
 			})
@@ -63,7 +63,7 @@ func TestClient_Users(t *testing.T) {
 
 	// List
 	var us []*User
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		us, err = c.ListCustomerUsers(&ListCustomerUsersInput{
 			CustomerID: *u.CustomerID,
 		})
@@ -77,7 +77,7 @@ func TestClient_Users(t *testing.T) {
 
 	// Get
 	var nu *User
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		nu, err = c.GetUser(&GetUserInput{
 			UserID: *u.UserID,
 		})
@@ -91,7 +91,7 @@ func TestClient_Users(t *testing.T) {
 
 	// Update
 	var uu *User
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		uu, err = c.UpdateUser(&UpdateUserInput{
 			UserID: *u.UserID,
 			Name:   ToPointer("updated user"),
@@ -112,7 +112,7 @@ func TestClient_Users(t *testing.T) {
 	//
 	// NOTE: This integration test can fail due to reCAPTCHA.
 	// Which means you might have to manually correct the fixtures 😬
-	record(t, fixtureBase+"reset_password", func(c *Client) {
+	Record(t, fixtureBase+"reset_password", func(c *Client) {
 		err = c.ResetUserPassword(&ResetUserPasswordInput{
 			Login: *uu.Login,
 		})
@@ -122,7 +122,7 @@ func TestClient_Users(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteUser(&DeleteUserInput{
 			UserID: *u.UserID,
 		})
@@ -134,7 +134,7 @@ func TestClient_Users(t *testing.T) {
 
 func TestClient_ListCustomerUsers_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListCustomerUsers(&ListCustomerUsersInput{
+	_, err = TestClient.ListCustomerUsers(&ListCustomerUsersInput{
 		CustomerID: "",
 	})
 	if err != ErrMissingCustomerID {
@@ -144,7 +144,7 @@ func TestClient_ListCustomerUsers_validation(t *testing.T) {
 
 func TestClient_GetUser_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetUser(&GetUserInput{
+	_, err = TestClient.GetUser(&GetUserInput{
 		UserID: "",
 	})
 	if err != ErrMissingUserID {
@@ -154,7 +154,7 @@ func TestClient_GetUser_validation(t *testing.T) {
 
 func TestClient_UpdateUser_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateUser(&UpdateUserInput{
+	_, err = TestClient.UpdateUser(&UpdateUserInput{
 		UserID: "",
 	})
 	if err != ErrMissingUserID {
@@ -163,7 +163,7 @@ func TestClient_UpdateUser_validation(t *testing.T) {
 }
 
 func TestClient_DeleteUser_validation(t *testing.T) {
-	err := testClient.DeleteUser(&DeleteUserInput{
+	err := TestClient.DeleteUser(&DeleteUserInput{
 		UserID: "",
 	})
 	if err != ErrMissingUserID {
@@ -172,7 +172,7 @@ func TestClient_DeleteUser_validation(t *testing.T) {
 }
 
 func TestClient_ResetUser_validation(t *testing.T) {
-	err := testClient.ResetUserPassword(&ResetUserPasswordInput{
+	err := TestClient.ResetUserPassword(&ResetUserPasswordInput{
 		Login: "",
 	})
 	if err != ErrMissingLogin {

--- a/fastly/vcl_cache_setting.go
+++ b/fastly/vcl_cache_setting.go
@@ -58,7 +58,7 @@ func (c *Client) ListCacheSettings(i *ListCacheSettingsInput) ([]*CacheSetting, 
 	defer resp.Body.Close()
 
 	var cs []*CacheSetting
-	if err := decodeBodyMap(resp.Body, &cs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -99,7 +99,7 @@ func (c *Client) CreateCacheSetting(i *CreateCacheSettingInput) (*CacheSetting, 
 	defer resp.Body.Close()
 
 	var cs *CacheSetting
-	if err := decodeBodyMap(resp.Body, &cs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -135,7 +135,7 @@ func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error)
 	defer resp.Body.Close()
 
 	var cs *CacheSetting
-	if err := decodeBodyMap(resp.Body, &cs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -181,7 +181,7 @@ func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, 
 	defer resp.Body.Close()
 
 	var cs *CacheSetting
-	if err := decodeBodyMap(resp.Body, &cs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -217,7 +217,7 @@ func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl_cache_setting_test.go
+++ b/fastly/vcl_cache_setting_test.go
@@ -9,15 +9,15 @@ func TestClient_CacheSettings(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "cache_settings/version", func(c *Client) {
+	Record(t, "cache_settings/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var cacheSetting *CacheSetting
-	record(t, "cache_settings/create", func(c *Client) {
+	Record(t, "cache_settings/create", func(c *Client) {
 		cacheSetting, err = c.CreateCacheSetting(&CreateCacheSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-cache-setting"),
 			Action:         ToPointer(CacheSettingActionCache),
@@ -31,15 +31,15 @@ func TestClient_CacheSettings(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "cache_settings/cleanup", func(c *Client) {
+		Record(t, "cache_settings/cleanup", func(c *Client) {
 			_ = c.DeleteCacheSetting(&DeleteCacheSettingInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-cache-setting",
 			})
 
 			_ = c.DeleteCacheSetting(&DeleteCacheSettingInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-cache-setting",
 			})
@@ -61,9 +61,9 @@ func TestClient_CacheSettings(t *testing.T) {
 
 	// List
 	var cacheSettings []*CacheSetting
-	record(t, "cache_settings/list", func(c *Client) {
+	Record(t, "cache_settings/list", func(c *Client) {
 		cacheSettings, err = c.ListCacheSettings(&ListCacheSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -76,9 +76,9 @@ func TestClient_CacheSettings(t *testing.T) {
 
 	// Get
 	var newCacheSetting *CacheSetting
-	record(t, "cache_settings/get", func(c *Client) {
+	Record(t, "cache_settings/get", func(c *Client) {
 		newCacheSetting, err = c.GetCacheSetting(&GetCacheSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-cache-setting",
 		})
@@ -101,9 +101,9 @@ func TestClient_CacheSettings(t *testing.T) {
 
 	// Update
 	var updatedCacheSetting *CacheSetting
-	record(t, "cache_settings/update", func(c *Client) {
+	Record(t, "cache_settings/update", func(c *Client) {
 		updatedCacheSetting, err = c.UpdateCacheSetting(&UpdateCacheSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-cache-setting",
 			NewName:        ToPointer("new-test-cache-setting"),
@@ -117,9 +117,9 @@ func TestClient_CacheSettings(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "cache_settings/delete", func(c *Client) {
+	Record(t, "cache_settings/delete", func(c *Client) {
 		err = c.DeleteCacheSetting(&DeleteCacheSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-cache-setting",
 		})
@@ -131,14 +131,14 @@ func TestClient_CacheSettings(t *testing.T) {
 
 func TestClient_ListCacheSettings_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListCacheSettings(&ListCacheSettingsInput{
+	_, err = TestClient.ListCacheSettings(&ListCacheSettingsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListCacheSettings(&ListCacheSettingsInput{
+	_, err = TestClient.ListCacheSettings(&ListCacheSettingsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -149,14 +149,14 @@ func TestClient_ListCacheSettings_validation(t *testing.T) {
 
 func TestClient_CreateCacheSetting_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateCacheSetting(&CreateCacheSettingInput{
+	_, err = TestClient.CreateCacheSetting(&CreateCacheSettingInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateCacheSetting(&CreateCacheSettingInput{
+	_, err = TestClient.CreateCacheSetting(&CreateCacheSettingInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -168,7 +168,7 @@ func TestClient_CreateCacheSetting_validation(t *testing.T) {
 func TestClient_GetCacheSetting_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetCacheSetting(&GetCacheSettingInput{
+	_, err = TestClient.GetCacheSetting(&GetCacheSettingInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -176,7 +176,7 @@ func TestClient_GetCacheSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetCacheSetting(&GetCacheSettingInput{
+	_, err = TestClient.GetCacheSetting(&GetCacheSettingInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -184,7 +184,7 @@ func TestClient_GetCacheSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetCacheSetting(&GetCacheSettingInput{
+	_, err = TestClient.GetCacheSetting(&GetCacheSettingInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -196,7 +196,7 @@ func TestClient_GetCacheSetting_validation(t *testing.T) {
 func TestClient_UpdateCacheSetting_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateCacheSetting(&UpdateCacheSettingInput{
+	_, err = TestClient.UpdateCacheSetting(&UpdateCacheSettingInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -204,7 +204,7 @@ func TestClient_UpdateCacheSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateCacheSetting(&UpdateCacheSettingInput{
+	_, err = TestClient.UpdateCacheSetting(&UpdateCacheSettingInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -212,7 +212,7 @@ func TestClient_UpdateCacheSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateCacheSetting(&UpdateCacheSettingInput{
+	_, err = TestClient.UpdateCacheSetting(&UpdateCacheSettingInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -224,7 +224,7 @@ func TestClient_UpdateCacheSetting_validation(t *testing.T) {
 func TestClient_DeleteCacheSetting_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteCacheSetting(&DeleteCacheSettingInput{
+	err = TestClient.DeleteCacheSetting(&DeleteCacheSettingInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -232,7 +232,7 @@ func TestClient_DeleteCacheSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteCacheSetting(&DeleteCacheSettingInput{
+	err = TestClient.DeleteCacheSetting(&DeleteCacheSettingInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -240,7 +240,7 @@ func TestClient_DeleteCacheSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteCacheSetting(&DeleteCacheSettingInput{
+	err = TestClient.DeleteCacheSetting(&DeleteCacheSettingInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/vcl_condition.go
+++ b/fastly/vcl_condition.go
@@ -44,7 +44,7 @@ func (c *Client) ListConditions(i *ListConditionsInput) ([]*Condition, error) {
 	defer resp.Body.Close()
 
 	var cs []*Condition
-	if err := decodeBodyMap(resp.Body, &cs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &cs); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -83,7 +83,7 @@ func (c *Client) CreateCondition(i *CreateConditionInput) (*Condition, error) {
 	defer resp.Body.Close()
 
 	var co *Condition
-	if err := decodeBodyMap(resp.Body, &co); err != nil {
+	if err := DecodeBodyMap(resp.Body, &co); err != nil {
 		return nil, err
 	}
 	return co, nil
@@ -119,7 +119,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 	defer resp.Body.Close()
 
 	var co *Condition
-	if err := decodeBodyMap(resp.Body, &co); err != nil {
+	if err := DecodeBodyMap(resp.Body, &co); err != nil {
 		return nil, err
 	}
 	return co, nil
@@ -163,7 +163,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 	defer resp.Body.Close()
 
 	var co *Condition
-	if err := decodeBodyMap(resp.Body, &co); err != nil {
+	if err := DecodeBodyMap(resp.Body, &co); err != nil {
 		return nil, err
 	}
 	return co, nil
@@ -199,7 +199,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl_condition_test.go
+++ b/fastly/vcl_condition_test.go
@@ -9,15 +9,15 @@ func TestClient_Conditions(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "conditions/version", func(c *Client) {
+	Record(t, "conditions/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var condition *Condition
-	record(t, "conditions/create", func(c *Client) {
+	Record(t, "conditions/create", func(c *Client) {
 		condition, err = c.CreateCondition(&CreateConditionInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test/condition"),
 			Statement:      ToPointer("req.url~+\"index.html\""),
@@ -31,9 +31,9 @@ func TestClient_Conditions(t *testing.T) {
 
 	// // Ensure deleted
 	defer func() {
-		record(t, "conditions/cleanup", func(c *Client) {
+		Record(t, "conditions/cleanup", func(c *Client) {
 			_ = c.DeleteCondition(&DeleteConditionInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test/condition",
 			})
@@ -55,9 +55,9 @@ func TestClient_Conditions(t *testing.T) {
 
 	// List
 	var conditions []*Condition
-	record(t, "conditions/list", func(c *Client) {
+	Record(t, "conditions/list", func(c *Client) {
 		conditions, err = c.ListConditions(&ListConditionsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -70,9 +70,9 @@ func TestClient_Conditions(t *testing.T) {
 
 	// Get
 	var newCondition *Condition
-	record(t, "conditions/get", func(c *Client) {
+	Record(t, "conditions/get", func(c *Client) {
 		newCondition, err = c.GetCondition(&GetConditionInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test/condition",
 		})
@@ -95,9 +95,9 @@ func TestClient_Conditions(t *testing.T) {
 
 	// Update
 	var updatedCondition *Condition
-	record(t, "conditions/update", func(c *Client) {
+	Record(t, "conditions/update", func(c *Client) {
 		updatedCondition, err = c.UpdateCondition(&UpdateConditionInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test/condition",
 			Statement:      ToPointer("req.url~+\"updated.html\""),
@@ -111,9 +111,9 @@ func TestClient_Conditions(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "conditions/delete", func(c *Client) {
+	Record(t, "conditions/delete", func(c *Client) {
 		err = c.DeleteCondition(&DeleteConditionInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test/condition",
 		})
@@ -125,14 +125,14 @@ func TestClient_Conditions(t *testing.T) {
 
 func TestClient_ListConditions_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListConditions(&ListConditionsInput{
+	_, err = TestClient.ListConditions(&ListConditionsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListConditions(&ListConditionsInput{
+	_, err = TestClient.ListConditions(&ListConditionsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -143,14 +143,14 @@ func TestClient_ListConditions_validation(t *testing.T) {
 
 func TestClient_CreateCondition_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateCondition(&CreateConditionInput{
+	_, err = TestClient.CreateCondition(&CreateConditionInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateCondition(&CreateConditionInput{
+	_, err = TestClient.CreateCondition(&CreateConditionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -162,7 +162,7 @@ func TestClient_CreateCondition_validation(t *testing.T) {
 func TestClient_GetCondition_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetCondition(&GetConditionInput{
+	_, err = TestClient.GetCondition(&GetConditionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -170,7 +170,7 @@ func TestClient_GetCondition_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetCondition(&GetConditionInput{
+	_, err = TestClient.GetCondition(&GetConditionInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -178,7 +178,7 @@ func TestClient_GetCondition_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetCondition(&GetConditionInput{
+	_, err = TestClient.GetCondition(&GetConditionInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -190,7 +190,7 @@ func TestClient_GetCondition_validation(t *testing.T) {
 func TestClient_UpdateCondition_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateCondition(&UpdateConditionInput{
+	_, err = TestClient.UpdateCondition(&UpdateConditionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -198,7 +198,7 @@ func TestClient_UpdateCondition_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateCondition(&UpdateConditionInput{
+	_, err = TestClient.UpdateCondition(&UpdateConditionInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -206,7 +206,7 @@ func TestClient_UpdateCondition_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateCondition(&UpdateConditionInput{
+	_, err = TestClient.UpdateCondition(&UpdateConditionInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -218,7 +218,7 @@ func TestClient_UpdateCondition_validation(t *testing.T) {
 func TestClient_DeleteCondition_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteCondition(&DeleteConditionInput{
+	err = TestClient.DeleteCondition(&DeleteConditionInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -226,7 +226,7 @@ func TestClient_DeleteCondition_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteCondition(&DeleteConditionInput{
+	err = TestClient.DeleteCondition(&DeleteConditionInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -234,7 +234,7 @@ func TestClient_DeleteCondition_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteCondition(&DeleteConditionInput{
+	err = TestClient.DeleteCondition(&DeleteConditionInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/vcl_custom.go
+++ b/fastly/vcl_custom.go
@@ -42,7 +42,7 @@ func (c *Client) ListVCLs(i *ListVCLsInput) ([]*VCL, error) {
 	defer resp.Body.Close()
 
 	var vcls []*VCL
-	if err := decodeBodyMap(resp.Body, &vcls); err != nil {
+	if err := DecodeBodyMap(resp.Body, &vcls); err != nil {
 		return nil, err
 	}
 	return vcls, nil
@@ -78,7 +78,7 @@ func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
 	defer resp.Body.Close()
 
 	var vcl *VCL
-	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
+	if err := DecodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -109,7 +109,7 @@ func (c *Client) GetGeneratedVCL(i *GetGeneratedVCLInput) (*VCL, error) {
 	defer resp.Body.Close()
 
 	var vcl *VCL
-	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
+	if err := DecodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -146,7 +146,7 @@ func (c *Client) CreateVCL(i *CreateVCLInput) (*VCL, error) {
 	defer resp.Body.Close()
 
 	var vcl *VCL
-	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
+	if err := DecodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -186,7 +186,7 @@ func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
 	defer resp.Body.Close()
 
 	var vcl *VCL
-	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
+	if err := DecodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -222,7 +222,7 @@ func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
 	defer resp.Body.Close()
 
 	var vcl *VCL
-	if err := decodeBodyMap(resp.Body, &vcl); err != nil {
+	if err := DecodeBodyMap(resp.Body, &vcl); err != nil {
 		return nil, err
 	}
 	return vcl, nil
@@ -258,7 +258,7 @@ func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl_custom_test.go
+++ b/fastly/vcl_custom_test.go
@@ -9,7 +9,7 @@ func TestClient_VCLs(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "vcls/version", func(c *Client) {
+	Record(t, "vcls/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
@@ -36,9 +36,9 @@ sub vcl_hash {
 
 	// Create
 	var vcl *VCL
-	record(t, "vcls/create", func(c *Client) {
+	Record(t, "vcls/create", func(c *Client) {
 		vcl, err = c.CreateVCL(&CreateVCLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-vcl"),
 			Content:        ToPointer(content),
@@ -50,15 +50,15 @@ sub vcl_hash {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "vcls/cleanup", func(c *Client) {
+		Record(t, "vcls/cleanup", func(c *Client) {
 			_ = c.DeleteVCL(&DeleteVCLInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-vcl",
 			})
 
 			_ = c.DeleteVCL(&DeleteVCLInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-vcl",
 			})
@@ -74,9 +74,9 @@ sub vcl_hash {
 
 	// List
 	var vcls []*VCL
-	record(t, "vcls/list", func(c *Client) {
+	Record(t, "vcls/list", func(c *Client) {
 		vcls, err = c.ListVCLs(&ListVCLsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -89,9 +89,9 @@ sub vcl_hash {
 
 	// Get
 	var nvcl *VCL
-	record(t, "vcls/get", func(c *Client) {
+	Record(t, "vcls/get", func(c *Client) {
 		nvcl, err = c.GetVCL(&GetVCLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-vcl",
 		})
@@ -108,9 +108,9 @@ sub vcl_hash {
 
 	// Update
 	var uvcl *VCL
-	record(t, "vcls/update", func(c *Client) {
+	Record(t, "vcls/update", func(c *Client) {
 		uvcl, err = c.UpdateVCL(&UpdateVCLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-vcl",
 			NewName:        ToPointer("new-test-vcl"),
@@ -125,9 +125,9 @@ sub vcl_hash {
 
 	// Activate
 	var avcl *VCL
-	record(t, "vcls/activate", func(c *Client) {
+	Record(t, "vcls/activate", func(c *Client) {
 		avcl, err = c.ActivateVCL(&ActivateVCLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-vcl",
 		})
@@ -140,9 +140,9 @@ sub vcl_hash {
 	}
 
 	// Delete
-	record(t, "vcls/delete", func(c *Client) {
+	Record(t, "vcls/delete", func(c *Client) {
 		err = c.DeleteVCL(&DeleteVCLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-vcl",
 		})
@@ -154,14 +154,14 @@ sub vcl_hash {
 
 func TestClient_ListVCLs_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListVCLs(&ListVCLsInput{
+	_, err = TestClient.ListVCLs(&ListVCLsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListVCLs(&ListVCLsInput{
+	_, err = TestClient.ListVCLs(&ListVCLsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -172,14 +172,14 @@ func TestClient_ListVCLs_validation(t *testing.T) {
 
 func TestClient_CreateVCL_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateVCL(&CreateVCLInput{
+	_, err = TestClient.CreateVCL(&CreateVCLInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateVCL(&CreateVCLInput{
+	_, err = TestClient.CreateVCL(&CreateVCLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -191,7 +191,7 @@ func TestClient_CreateVCL_validation(t *testing.T) {
 func TestClient_GetVCL_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetVCL(&GetVCLInput{
+	_, err = TestClient.GetVCL(&GetVCLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -199,7 +199,7 @@ func TestClient_GetVCL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetVCL(&GetVCLInput{
+	_, err = TestClient.GetVCL(&GetVCLInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -207,7 +207,7 @@ func TestClient_GetVCL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetVCL(&GetVCLInput{
+	_, err = TestClient.GetVCL(&GetVCLInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -219,7 +219,7 @@ func TestClient_GetVCL_validation(t *testing.T) {
 func TestClient_UpdateVCL_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateVCL(&UpdateVCLInput{
+	_, err = TestClient.UpdateVCL(&UpdateVCLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -227,7 +227,7 @@ func TestClient_UpdateVCL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateVCL(&UpdateVCLInput{
+	_, err = TestClient.UpdateVCL(&UpdateVCLInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -235,7 +235,7 @@ func TestClient_UpdateVCL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateVCL(&UpdateVCLInput{
+	_, err = TestClient.UpdateVCL(&UpdateVCLInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -247,7 +247,7 @@ func TestClient_UpdateVCL_validation(t *testing.T) {
 func TestClient_ActivateVCL_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ActivateVCL(&ActivateVCLInput{
+	_, err = TestClient.ActivateVCL(&ActivateVCLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -255,7 +255,7 @@ func TestClient_ActivateVCL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ActivateVCL(&ActivateVCLInput{
+	_, err = TestClient.ActivateVCL(&ActivateVCLInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -263,7 +263,7 @@ func TestClient_ActivateVCL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ActivateVCL(&ActivateVCLInput{
+	_, err = TestClient.ActivateVCL(&ActivateVCLInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -275,7 +275,7 @@ func TestClient_ActivateVCL_validation(t *testing.T) {
 func TestClient_DeleteVCL_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteVCL(&DeleteVCLInput{
+	err = TestClient.DeleteVCL(&DeleteVCLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -283,7 +283,7 @@ func TestClient_DeleteVCL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteVCL(&DeleteVCLInput{
+	err = TestClient.DeleteVCL(&DeleteVCLInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -291,7 +291,7 @@ func TestClient_DeleteVCL_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteVCL(&DeleteVCLInput{
+	err = TestClient.DeleteVCL(&DeleteVCLInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/vcl_gzip.go
+++ b/fastly/vcl_gzip.go
@@ -43,7 +43,7 @@ func (c *Client) ListGzips(i *ListGzipsInput) ([]*Gzip, error) {
 	defer resp.Body.Close()
 
 	var gzips []*Gzip
-	if err := decodeBodyMap(resp.Body, &gzips); err != nil {
+	if err := DecodeBodyMap(resp.Body, &gzips); err != nil {
 		return nil, err
 	}
 	return gzips, nil
@@ -82,7 +82,7 @@ func (c *Client) CreateGzip(i *CreateGzipInput) (*Gzip, error) {
 	defer resp.Body.Close()
 
 	var gzip *Gzip
-	if err := decodeBodyMap(resp.Body, &gzip); err != nil {
+	if err := DecodeBodyMap(resp.Body, &gzip); err != nil {
 		return nil, err
 	}
 	return gzip, nil
@@ -118,7 +118,7 @@ func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
 	defer resp.Body.Close()
 
 	var b *Gzip
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -162,7 +162,7 @@ func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
 	defer resp.Body.Close()
 
 	var b *Gzip
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -198,7 +198,7 @@ func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl_gzip_test.go
+++ b/fastly/vcl_gzip_test.go
@@ -9,15 +9,15 @@ func TestClient_Gzips(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "gzips/version", func(c *Client) {
+	Record(t, "gzips/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var gzip *Gzip
-	record(t, "gzips/create", func(c *Client) {
+	Record(t, "gzips/create", func(c *Client) {
 		gzip, err = c.CreateGzip(&CreateGzipInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-gzip"),
 			ContentTypes:   ToPointer("text/html text/css"),
@@ -31,9 +31,9 @@ func TestClient_Gzips(t *testing.T) {
 	// Create omissions (GH-7)
 	// NOTE: API should return defaults.
 	var gzipomit *Gzip
-	record(t, "gzips/create_omissions", func(c *Client) {
+	Record(t, "gzips/create_omissions", func(c *Client) {
 		gzipomit, err = c.CreateGzip(&CreateGzipInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-gzip-omit"),
 		})
@@ -50,21 +50,21 @@ func TestClient_Gzips(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "gzips/cleanup", func(c *Client) {
+		Record(t, "gzips/cleanup", func(c *Client) {
 			_ = c.DeleteGzip(&DeleteGzipInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-gzip",
 			})
 
 			_ = c.DeleteGzip(&DeleteGzipInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-gzip-omit",
 			})
 
 			_ = c.DeleteGzip(&DeleteGzipInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-gzip",
 			})
@@ -83,9 +83,9 @@ func TestClient_Gzips(t *testing.T) {
 
 	// List
 	var gzips []*Gzip
-	record(t, "gzips/list", func(c *Client) {
+	Record(t, "gzips/list", func(c *Client) {
 		gzips, err = c.ListGzips(&ListGzipsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -98,9 +98,9 @@ func TestClient_Gzips(t *testing.T) {
 
 	// Get
 	var ngzip *Gzip
-	record(t, "gzips/get", func(c *Client) {
+	Record(t, "gzips/get", func(c *Client) {
 		ngzip, err = c.GetGzip(&GetGzipInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-gzip",
 		})
@@ -120,9 +120,9 @@ func TestClient_Gzips(t *testing.T) {
 
 	// Update
 	var ugzip *Gzip
-	record(t, "gzips/update", func(c *Client) {
+	Record(t, "gzips/update", func(c *Client) {
 		ugzip, err = c.UpdateGzip(&UpdateGzipInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-gzip",
 			NewName:        ToPointer("new-test-gzip"),
@@ -136,9 +136,9 @@ func TestClient_Gzips(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "gzips/delete", func(c *Client) {
+	Record(t, "gzips/delete", func(c *Client) {
 		err = c.DeleteGzip(&DeleteGzipInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-gzip",
 		})
@@ -151,14 +151,14 @@ func TestClient_Gzips(t *testing.T) {
 func TestClient_ListGzips_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.ListGzips(&ListGzipsInput{
+	_, err = TestClient.ListGzips(&ListGzipsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListGzips(&ListGzipsInput{
+	_, err = TestClient.ListGzips(&ListGzipsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -170,14 +170,14 @@ func TestClient_ListGzips_validation(t *testing.T) {
 func TestClient_CreateGzip_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.CreateGzip(&CreateGzipInput{
+	_, err = TestClient.CreateGzip(&CreateGzipInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateGzip(&CreateGzipInput{
+	_, err = TestClient.CreateGzip(&CreateGzipInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -189,7 +189,7 @@ func TestClient_CreateGzip_validation(t *testing.T) {
 func TestClient_GetGzip_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetGzip(&GetGzipInput{
+	_, err = TestClient.GetGzip(&GetGzipInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -197,7 +197,7 @@ func TestClient_GetGzip_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetGzip(&GetGzipInput{
+	_, err = TestClient.GetGzip(&GetGzipInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -205,7 +205,7 @@ func TestClient_GetGzip_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetGzip(&GetGzipInput{
+	_, err = TestClient.GetGzip(&GetGzipInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -217,7 +217,7 @@ func TestClient_GetGzip_validation(t *testing.T) {
 func TestClient_UpdateGzip_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateGzip(&UpdateGzipInput{
+	_, err = TestClient.UpdateGzip(&UpdateGzipInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -225,7 +225,7 @@ func TestClient_UpdateGzip_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateGzip(&UpdateGzipInput{
+	_, err = TestClient.UpdateGzip(&UpdateGzipInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -233,7 +233,7 @@ func TestClient_UpdateGzip_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateGzip(&UpdateGzipInput{
+	_, err = TestClient.UpdateGzip(&UpdateGzipInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -245,7 +245,7 @@ func TestClient_UpdateGzip_validation(t *testing.T) {
 func TestClient_DeleteGzip_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteGzip(&DeleteGzipInput{
+	err = TestClient.DeleteGzip(&DeleteGzipInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -253,7 +253,7 @@ func TestClient_DeleteGzip_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteGzip(&DeleteGzipInput{
+	err = TestClient.DeleteGzip(&DeleteGzipInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -261,7 +261,7 @@ func TestClient_DeleteGzip_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteGzip(&DeleteGzipInput{
+	err = TestClient.DeleteGzip(&DeleteGzipInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/vcl_header.go
+++ b/fastly/vcl_header.go
@@ -94,7 +94,7 @@ func (c *Client) ListHeaders(i *ListHeadersInput) ([]*Header, error) {
 	defer resp.Body.Close()
 
 	var bs []*Header
-	if err := decodeBodyMap(resp.Body, &bs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	return bs, nil
@@ -149,7 +149,7 @@ func (c *Client) CreateHeader(i *CreateHeaderInput) (*Header, error) {
 	defer resp.Body.Close()
 
 	var b *Header
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -185,7 +185,7 @@ func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
 	defer resp.Body.Close()
 
 	var b *Header
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -245,7 +245,7 @@ func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
 	defer resp.Body.Close()
 
 	var b *Header
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -281,7 +281,7 @@ func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl_header_test.go
+++ b/fastly/vcl_header_test.go
@@ -9,15 +9,15 @@ func TestClient_Headers(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "headers/version", func(c *Client) {
+	Record(t, "headers/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var h *Header
-	record(t, "headers/create", func(c *Client) {
+	Record(t, "headers/create", func(c *Client) {
 		h, err = c.CreateHeader(&CreateHeaderInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-header"),
 			Action:         ToPointer(HeaderActionSet),
@@ -36,15 +36,15 @@ func TestClient_Headers(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "headers/cleanup", func(c *Client) {
+		Record(t, "headers/cleanup", func(c *Client) {
 			_ = c.DeleteHeader(&DeleteHeaderInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-header",
 			})
 
 			_ = c.DeleteHeader(&DeleteHeaderInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-header",
 			})
@@ -81,9 +81,9 @@ func TestClient_Headers(t *testing.T) {
 
 	// List
 	var hs []*Header
-	record(t, "headers/list", func(c *Client) {
+	Record(t, "headers/list", func(c *Client) {
 		hs, err = c.ListHeaders(&ListHeadersInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -96,9 +96,9 @@ func TestClient_Headers(t *testing.T) {
 
 	// Get
 	var nh *Header
-	record(t, "headers/get", func(c *Client) {
+	Record(t, "headers/get", func(c *Client) {
 		nh, err = c.GetHeader(&GetHeaderInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-header",
 		})
@@ -136,9 +136,9 @@ func TestClient_Headers(t *testing.T) {
 
 	// Update
 	var uh *Header
-	record(t, "headers/update", func(c *Client) {
+	Record(t, "headers/update", func(c *Client) {
 		uh, err = c.UpdateHeader(&UpdateHeaderInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-header",
 			NewName:        ToPointer("new-test-header"),
@@ -154,9 +154,9 @@ func TestClient_Headers(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "headers/delete", func(c *Client) {
+	Record(t, "headers/delete", func(c *Client) {
 		err = c.DeleteHeader(&DeleteHeaderInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-header",
 		})
@@ -168,14 +168,14 @@ func TestClient_Headers(t *testing.T) {
 
 func TestClient_ListHeaders_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListHeaders(&ListHeadersInput{
+	_, err = TestClient.ListHeaders(&ListHeadersInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListHeaders(&ListHeadersInput{
+	_, err = TestClient.ListHeaders(&ListHeadersInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -186,14 +186,14 @@ func TestClient_ListHeaders_validation(t *testing.T) {
 
 func TestClient_CreateHeader_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateHeader(&CreateHeaderInput{
+	_, err = TestClient.CreateHeader(&CreateHeaderInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateHeader(&CreateHeaderInput{
+	_, err = TestClient.CreateHeader(&CreateHeaderInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -205,7 +205,7 @@ func TestClient_CreateHeader_validation(t *testing.T) {
 func TestClient_GetHeader_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetHeader(&GetHeaderInput{
+	_, err = TestClient.GetHeader(&GetHeaderInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -213,7 +213,7 @@ func TestClient_GetHeader_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHeader(&GetHeaderInput{
+	_, err = TestClient.GetHeader(&GetHeaderInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -221,7 +221,7 @@ func TestClient_GetHeader_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHeader(&GetHeaderInput{
+	_, err = TestClient.GetHeader(&GetHeaderInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -233,7 +233,7 @@ func TestClient_GetHeader_validation(t *testing.T) {
 func TestClient_UpdateHeader_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateHeader(&UpdateHeaderInput{
+	_, err = TestClient.UpdateHeader(&UpdateHeaderInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -241,7 +241,7 @@ func TestClient_UpdateHeader_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHeader(&UpdateHeaderInput{
+	_, err = TestClient.UpdateHeader(&UpdateHeaderInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -249,7 +249,7 @@ func TestClient_UpdateHeader_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateHeader(&UpdateHeaderInput{
+	_, err = TestClient.UpdateHeader(&UpdateHeaderInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -261,7 +261,7 @@ func TestClient_UpdateHeader_validation(t *testing.T) {
 func TestClient_DeleteHeader_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteHeader(&DeleteHeaderInput{
+	err = TestClient.DeleteHeader(&DeleteHeaderInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -269,7 +269,7 @@ func TestClient_DeleteHeader_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHeader(&DeleteHeaderInput{
+	err = TestClient.DeleteHeader(&DeleteHeaderInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -277,7 +277,7 @@ func TestClient_DeleteHeader_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteHeader(&DeleteHeaderInput{
+	err = TestClient.DeleteHeader(&DeleteHeaderInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/vcl_http3.go
+++ b/fastly/vcl_http3.go
@@ -40,7 +40,7 @@ func (c *Client) GetHTTP3(i *GetHTTP3Input) (*HTTP3, error) {
 	defer resp.Body.Close()
 
 	var h *HTTP3
-	if err := decodeBodyMap(resp.Body, &h); err != nil {
+	if err := DecodeBodyMap(resp.Body, &h); err != nil {
 		return nil, err
 	}
 
@@ -74,7 +74,7 @@ func (c *Client) EnableHTTP3(i *EnableHTTP3Input) (*HTTP3, error) {
 	defer resp.Body.Close()
 
 	var http3 *HTTP3
-	if err := decodeBodyMap(resp.Body, &http3); err != nil {
+	if err := DecodeBodyMap(resp.Body, &http3); err != nil {
 		return nil, err
 	}
 	return http3, nil
@@ -105,7 +105,7 @@ func (c *Client) DisableHTTP3(i *DisableHTTP3Input) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl_http3_test.go
+++ b/fastly/vcl_http3_test.go
@@ -9,16 +9,16 @@ func TestClient_HTTP3(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "http3/version", func(c *Client) {
+	Record(t, "http3/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Enable HTTP3
 	var h *HTTP3
-	record(t, "http3/enable", func(c *Client) {
+	Record(t, "http3/enable", func(c *Client) {
 		h, err = c.EnableHTTP3(&EnableHTTP3Input{
 			FeatureRevision: ToPointer(1),
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 		})
 	})
@@ -32,9 +32,9 @@ func TestClient_HTTP3(t *testing.T) {
 
 	// Get HTTP3 status
 	var gh *HTTP3
-	record(t, "http3/get", func(c *Client) {
+	Record(t, "http3/get", func(c *Client) {
 		gh, err = c.GetHTTP3(&GetHTTP3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -47,9 +47,9 @@ func TestClient_HTTP3(t *testing.T) {
 	}
 
 	// Disable HTTP3
-	record(t, "http3/disable", func(c *Client) {
+	Record(t, "http3/disable", func(c *Client) {
 		err = c.DisableHTTP3(&DisableHTTP3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -58,9 +58,9 @@ func TestClient_HTTP3(t *testing.T) {
 	}
 
 	// Get HTTP3 status again to check disabled
-	record(t, "http3/get-disabled", func(c *Client) {
+	Record(t, "http3/get-disabled", func(c *Client) {
 		gh, err = c.GetHTTP3(&GetHTTP3Input{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -75,14 +75,14 @@ func TestClient_HTTP3(t *testing.T) {
 func TestClient_GetHTTP3_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetHTTP3(&GetHTTP3Input{
+	_, err = TestClient.GetHTTP3(&GetHTTP3Input{
 		ServiceVersion: 1,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetHTTP3(&GetHTTP3Input{
+	_, err = TestClient.GetHTTP3(&GetHTTP3Input{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingServiceVersion {
@@ -92,14 +92,14 @@ func TestClient_GetHTTP3_validation(t *testing.T) {
 
 func TestClient_CreateHTTP3_validation(t *testing.T) {
 	var err error
-	_, err = testClient.EnableHTTP3(&EnableHTTP3Input{
+	_, err = TestClient.EnableHTTP3(&EnableHTTP3Input{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.EnableHTTP3(&EnableHTTP3Input{
+	_, err = TestClient.EnableHTTP3(&EnableHTTP3Input{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -111,14 +111,14 @@ func TestClient_CreateHTTP3_validation(t *testing.T) {
 func TestClient_DeleteHTTP3_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DisableHTTP3(&DisableHTTP3Input{
+	err = TestClient.DisableHTTP3(&DisableHTTP3Input{
 		ServiceVersion: 1,
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DisableHTTP3(&DisableHTTP3Input{
+	err = TestClient.DisableHTTP3(&DisableHTTP3Input{
 		ServiceID: "foo",
 	})
 	if err != ErrMissingServiceVersion {

--- a/fastly/vcl_rate_limiter.go
+++ b/fastly/vcl_rate_limiter.go
@@ -207,7 +207,7 @@ func (c *Client) ListERLs(i *ListERLsInput) ([]*ERL, error) {
 	defer resp.Body.Close()
 
 	var erls []*ERL
-	if err := decodeBodyMap(resp.Body, &erls); err != nil {
+	if err := DecodeBodyMap(resp.Body, &erls); err != nil {
 		return nil, err
 	}
 
@@ -263,7 +263,7 @@ func (c *Client) CreateERL(i *CreateERLInput) (*ERL, error) {
 	defer resp.Body.Close()
 
 	var erl *ERL
-	if err := decodeBodyMap(resp.Body, &erl); err != nil {
+	if err := DecodeBodyMap(resp.Body, &erl); err != nil {
 		return nil, err
 	}
 
@@ -291,7 +291,7 @@ func (c *Client) DeleteERL(i *DeleteERLInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -322,7 +322,7 @@ func (c *Client) GetERL(i *GetERLInput) (*ERL, error) {
 	defer resp.Body.Close()
 
 	var erl *ERL
-	if err := decodeBodyMap(resp.Body, &erl); err != nil {
+	if err := DecodeBodyMap(resp.Body, &erl); err != nil {
 		return nil, err
 	}
 
@@ -374,7 +374,7 @@ func (c *Client) UpdateERL(i *UpdateERLInput) (*ERL, error) {
 	defer resp.Body.Close()
 
 	var erl *ERL
-	if err := decodeBodyMap(resp.Body, &erl); err != nil {
+	if err := DecodeBodyMap(resp.Body, &erl); err != nil {
 		return nil, err
 	}
 

--- a/fastly/vcl_rate_limiter_test.go
+++ b/fastly/vcl_rate_limiter_test.go
@@ -9,16 +9,16 @@ func TestClient_ERL(t *testing.T) {
 	t.Parallel()
 
 	fixtureBase := "erls/"
-	testVersion := createTestVersion(t, fixtureBase+"version", testDeliveryServiceID)
+	testVersion := CreateTestVersion(t, fixtureBase+"version", TestDeliveryServiceID)
 
 	// Create
 	var (
 		e   *ERL
 		err error
 	)
-	record(t, fixtureBase+"create", func(c *Client) {
+	Record(t, fixtureBase+"create", func(c *Client) {
 		e, err = c.CreateERL(&CreateERLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           ToPointer("test_erl"),
 			Action:         ToPointer(ERLActionResponse),
@@ -45,7 +45,7 @@ func TestClient_ERL(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"cleanup", func(c *Client) {
+		Record(t, fixtureBase+"cleanup", func(c *Client) {
 			_ = c.DeleteERL(&DeleteERLInput{
 				ERLID: *e.RateLimiterID,
 			})
@@ -70,9 +70,9 @@ func TestClient_ERL(t *testing.T) {
 
 	// List
 	var es []*ERL
-	record(t, fixtureBase+"list", func(c *Client) {
+	Record(t, fixtureBase+"list", func(c *Client) {
 		es, err = c.ListERLs(&ListERLsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 		})
 	})
@@ -89,7 +89,7 @@ func TestClient_ERL(t *testing.T) {
 
 	// Get
 	var ge *ERL
-	record(t, fixtureBase+"get", func(c *Client) {
+	Record(t, fixtureBase+"get", func(c *Client) {
 		ge, err = c.GetERL(&GetERLInput{
 			ERLID: *e.RateLimiterID,
 		})
@@ -103,7 +103,7 @@ func TestClient_ERL(t *testing.T) {
 
 	// Update
 	var ua *ERL
-	record(t, fixtureBase+"update", func(c *Client) {
+	Record(t, fixtureBase+"update", func(c *Client) {
 		ua, err = c.UpdateERL(&UpdateERLInput{
 			ERLID: *e.RateLimiterID,
 			Name:  ToPointer("test_erl"),
@@ -117,7 +117,7 @@ func TestClient_ERL(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"delete", func(c *Client) {
+	Record(t, fixtureBase+"delete", func(c *Client) {
 		err = c.DeleteERL(&DeleteERLInput{
 			ERLID: *ge.RateLimiterID,
 		})
@@ -128,9 +128,9 @@ func TestClient_ERL(t *testing.T) {
 
 	// Create logger type
 	var elog *ERL
-	record(t, fixtureBase+"logger_create", func(c *Client) {
+	Record(t, fixtureBase+"logger_create", func(c *Client) {
 		elog, err = c.CreateERL(&CreateERLInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *testVersion.Number,
 			Name:           ToPointer("test_erl"),
 			Action:         ToPointer(ERLActionLogOnly),
@@ -153,7 +153,7 @@ func TestClient_ERL(t *testing.T) {
 	}
 
 	defer func() {
-		record(t, fixtureBase+"logger_cleanup", func(c *Client) {
+		Record(t, fixtureBase+"logger_cleanup", func(c *Client) {
 			_ = c.DeleteERL(&DeleteERLInput{
 				ERLID: *elog.RateLimiterID,
 			})
@@ -171,14 +171,14 @@ func TestClient_ERL(t *testing.T) {
 
 func TestClient_ListERLs_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListERLs(&ListERLsInput{
+	_, err = TestClient.ListERLs(&ListERLsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("error: %s", err)
 	}
 
-	_, err = testClient.ListERLs(&ListERLsInput{
+	_, err = TestClient.ListERLs(&ListERLsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -189,14 +189,14 @@ func TestClient_ListERLs_validation(t *testing.T) {
 
 func TestClient_CreateERL_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateERL(&CreateERLInput{
+	_, err = TestClient.CreateERL(&CreateERLInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("error: %s", err)
 	}
 
-	_, err = testClient.CreateERL(&CreateERLInput{
+	_, err = TestClient.CreateERL(&CreateERLInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -206,7 +206,7 @@ func TestClient_CreateERL_validation(t *testing.T) {
 }
 
 func TestClient_GetERL_validation(t *testing.T) {
-	_, err := testClient.GetERL(&GetERLInput{
+	_, err := TestClient.GetERL(&GetERLInput{
 		ERLID: "",
 	})
 	if err != ErrMissingERLID {
@@ -215,7 +215,7 @@ func TestClient_GetERL_validation(t *testing.T) {
 }
 
 func TestClient_UpdateERL_validation(t *testing.T) {
-	_, err := testClient.UpdateERL(&UpdateERLInput{
+	_, err := TestClient.UpdateERL(&UpdateERLInput{
 		ERLID: "",
 	})
 	if err != ErrMissingERLID {
@@ -224,7 +224,7 @@ func TestClient_UpdateERL_validation(t *testing.T) {
 }
 
 func TestClient_DeleteERL_validation(t *testing.T) {
-	err := testClient.DeleteERL(&DeleteERLInput{
+	err := TestClient.DeleteERL(&DeleteERLInput{
 		ERLID: "",
 	})
 	if err != ErrMissingERLID {

--- a/fastly/vcl_request_setting.go
+++ b/fastly/vcl_request_setting.go
@@ -87,7 +87,7 @@ func (c *Client) ListRequestSettings(i *ListRequestSettingsInput) ([]*RequestSet
 	defer resp.Body.Close()
 
 	var bs []*RequestSetting
-	if err := decodeBodyMap(resp.Body, &bs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	return bs, nil
@@ -143,7 +143,7 @@ func (c *Client) CreateRequestSetting(i *CreateRequestSettingInput) (*RequestSet
 	defer resp.Body.Close()
 
 	var b *RequestSetting
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -179,7 +179,7 @@ func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, 
 	defer resp.Body.Close()
 
 	var b *RequestSetting
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -240,7 +240,7 @@ func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSet
 	defer resp.Body.Close()
 
 	var b *RequestSetting
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -276,7 +276,7 @@ func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl_request_setting_test.go
+++ b/fastly/vcl_request_setting_test.go
@@ -9,15 +9,15 @@ func TestClient_RequestSettings(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "request_settings/version", func(c *Client) {
+	Record(t, "request_settings/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var rs *RequestSetting
-	record(t, "request_settings/create", func(c *Client) {
+	Record(t, "request_settings/create", func(c *Client) {
 		rs, err = c.CreateRequestSetting(&CreateRequestSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-request-setting"),
 			ForceMiss:      ToPointer(Compatibool(true)),
@@ -38,15 +38,15 @@ func TestClient_RequestSettings(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "request_settings/cleanup", func(c *Client) {
+		Record(t, "request_settings/cleanup", func(c *Client) {
 			_ = c.DeleteRequestSetting(&DeleteRequestSettingInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-request-setting",
 			})
 
 			_ = c.DeleteRequestSetting(&DeleteRequestSettingInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-request-setting",
 			})
@@ -89,9 +89,9 @@ func TestClient_RequestSettings(t *testing.T) {
 
 	// List
 	var rss []*RequestSetting
-	record(t, "request_settings/list", func(c *Client) {
+	Record(t, "request_settings/list", func(c *Client) {
 		rss, err = c.ListRequestSettings(&ListRequestSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -104,9 +104,9 @@ func TestClient_RequestSettings(t *testing.T) {
 
 	// Get
 	var nrs *RequestSetting
-	record(t, "request_settings/get", func(c *Client) {
+	Record(t, "request_settings/get", func(c *Client) {
 		nrs, err = c.GetRequestSetting(&GetRequestSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-request-setting",
 		})
@@ -150,9 +150,9 @@ func TestClient_RequestSettings(t *testing.T) {
 
 	// Update
 	var urs *RequestSetting
-	record(t, "request_settings/update", func(c *Client) {
+	Record(t, "request_settings/update", func(c *Client) {
 		urs, err = c.UpdateRequestSetting(&UpdateRequestSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-request-setting",
 			NewName:        ToPointer("new-test-request-setting"),
@@ -171,9 +171,9 @@ func TestClient_RequestSettings(t *testing.T) {
 
 	// Update 2 (wrap empty string with RequestSettingAction)
 	var urs2 *RequestSetting
-	record(t, "request_settings/update-2", func(c *Client) {
+	Record(t, "request_settings/update-2", func(c *Client) {
 		urs2, err = c.UpdateRequestSetting(&UpdateRequestSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-request-setting",
 			Action:         ToPointer(RequestSettingAction("")),
@@ -188,9 +188,9 @@ func TestClient_RequestSettings(t *testing.T) {
 
 	// Update 3 (use explicit RequestSettingActionUnset type)
 	var urs3 *RequestSetting
-	record(t, "request_settings/update-3", func(c *Client) {
+	Record(t, "request_settings/update-3", func(c *Client) {
 		urs3, err = c.UpdateRequestSetting(&UpdateRequestSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-request-setting",
 			Action:         ToPointer(RequestSettingActionUnset),
@@ -204,9 +204,9 @@ func TestClient_RequestSettings(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "request_settings/delete", func(c *Client) {
+	Record(t, "request_settings/delete", func(c *Client) {
 		err = c.DeleteRequestSetting(&DeleteRequestSettingInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-request-setting",
 		})
@@ -218,14 +218,14 @@ func TestClient_RequestSettings(t *testing.T) {
 
 func TestClient_ListRequestSettings_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListRequestSettings(&ListRequestSettingsInput{
+	_, err = TestClient.ListRequestSettings(&ListRequestSettingsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListRequestSettings(&ListRequestSettingsInput{
+	_, err = TestClient.ListRequestSettings(&ListRequestSettingsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -236,14 +236,14 @@ func TestClient_ListRequestSettings_validation(t *testing.T) {
 
 func TestClient_CreateRequestSetting_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateRequestSetting(&CreateRequestSettingInput{
+	_, err = TestClient.CreateRequestSetting(&CreateRequestSettingInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateRequestSetting(&CreateRequestSettingInput{
+	_, err = TestClient.CreateRequestSetting(&CreateRequestSettingInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -255,7 +255,7 @@ func TestClient_CreateRequestSetting_validation(t *testing.T) {
 func TestClient_GetRequestSetting_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetRequestSetting(&GetRequestSettingInput{
+	_, err = TestClient.GetRequestSetting(&GetRequestSettingInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -263,7 +263,7 @@ func TestClient_GetRequestSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetRequestSetting(&GetRequestSettingInput{
+	_, err = TestClient.GetRequestSetting(&GetRequestSettingInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -271,7 +271,7 @@ func TestClient_GetRequestSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetRequestSetting(&GetRequestSettingInput{
+	_, err = TestClient.GetRequestSetting(&GetRequestSettingInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -283,7 +283,7 @@ func TestClient_GetRequestSetting_validation(t *testing.T) {
 func TestClient_UpdateRequestSetting_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateRequestSetting(&UpdateRequestSettingInput{
+	_, err = TestClient.UpdateRequestSetting(&UpdateRequestSettingInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -291,7 +291,7 @@ func TestClient_UpdateRequestSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateRequestSetting(&UpdateRequestSettingInput{
+	_, err = TestClient.UpdateRequestSetting(&UpdateRequestSettingInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -299,7 +299,7 @@ func TestClient_UpdateRequestSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateRequestSetting(&UpdateRequestSettingInput{
+	_, err = TestClient.UpdateRequestSetting(&UpdateRequestSettingInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -311,7 +311,7 @@ func TestClient_UpdateRequestSetting_validation(t *testing.T) {
 func TestClient_DeleteRequestSetting_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteRequestSetting(&DeleteRequestSettingInput{
+	err = TestClient.DeleteRequestSetting(&DeleteRequestSettingInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -319,7 +319,7 @@ func TestClient_DeleteRequestSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteRequestSetting(&DeleteRequestSettingInput{
+	err = TestClient.DeleteRequestSetting(&DeleteRequestSettingInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -327,7 +327,7 @@ func TestClient_DeleteRequestSetting_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteRequestSetting(&DeleteRequestSettingInput{
+	err = TestClient.DeleteRequestSetting(&DeleteRequestSettingInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/vcl_response_object.go
+++ b/fastly/vcl_response_object.go
@@ -47,7 +47,7 @@ func (c *Client) ListResponseObjects(i *ListResponseObjectsInput) ([]*ResponseOb
 	defer resp.Body.Close()
 
 	var bs []*ResponseObject
-	if err := decodeBodyMap(resp.Body, &bs); err != nil {
+	if err := DecodeBodyMap(resp.Body, &bs); err != nil {
 		return nil, err
 	}
 	return bs, nil
@@ -93,7 +93,7 @@ func (c *Client) CreateResponseObject(i *CreateResponseObjectInput) (*ResponseOb
 	defer resp.Body.Close()
 
 	var b *ResponseObject
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -129,7 +129,7 @@ func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, 
 	defer resp.Body.Close()
 
 	var b *ResponseObject
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -180,7 +180,7 @@ func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseOb
 	defer resp.Body.Close()
 
 	var b *ResponseObject
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -216,7 +216,7 @@ func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {

--- a/fastly/vcl_response_object_test.go
+++ b/fastly/vcl_response_object_test.go
@@ -9,15 +9,15 @@ func TestClient_ResponseObjects(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "response_objects/version", func(c *Client) {
+	Record(t, "response_objects/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Create
 	var ro *ResponseObject
-	record(t, "response_objects/create", func(c *Client) {
+	Record(t, "response_objects/create", func(c *Client) {
 		ro, err = c.CreateResponseObject(&CreateResponseObjectInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer("test-response-object"),
 			Status:         ToPointer(200),
@@ -32,15 +32,15 @@ func TestClient_ResponseObjects(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, "response_objects/cleanup", func(c *Client) {
+		Record(t, "response_objects/cleanup", func(c *Client) {
 			_ = c.DeleteResponseObject(&DeleteResponseObjectInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "test-response-object",
 			})
 
 			_ = c.DeleteResponseObject(&DeleteResponseObjectInput{
-				ServiceID:      testDeliveryServiceID,
+				ServiceID:      TestDeliveryServiceID,
 				ServiceVersion: *tv.Number,
 				Name:           "new-test-response-object",
 			})
@@ -65,9 +65,9 @@ func TestClient_ResponseObjects(t *testing.T) {
 
 	// List
 	var ros []*ResponseObject
-	record(t, "response_objects/list", func(c *Client) {
+	Record(t, "response_objects/list", func(c *Client) {
 		ros, err = c.ListResponseObjects(&ListResponseObjectsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -80,9 +80,9 @@ func TestClient_ResponseObjects(t *testing.T) {
 
 	// Get
 	var nro *ResponseObject
-	record(t, "response_objects/get", func(c *Client) {
+	Record(t, "response_objects/get", func(c *Client) {
 		nro, err = c.GetResponseObject(&GetResponseObjectInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-response-object",
 		})
@@ -108,9 +108,9 @@ func TestClient_ResponseObjects(t *testing.T) {
 
 	// Update
 	var uro *ResponseObject
-	record(t, "response_objects/update", func(c *Client) {
+	Record(t, "response_objects/update", func(c *Client) {
 		uro, err = c.UpdateResponseObject(&UpdateResponseObjectInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "test-response-object",
 			NewName:        ToPointer("new-test-response-object"),
@@ -124,9 +124,9 @@ func TestClient_ResponseObjects(t *testing.T) {
 	}
 
 	// Delete
-	record(t, "response_objects/delete", func(c *Client) {
+	Record(t, "response_objects/delete", func(c *Client) {
 		err = c.DeleteResponseObject(&DeleteResponseObjectInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           "new-test-response-object",
 		})
@@ -138,14 +138,14 @@ func TestClient_ResponseObjects(t *testing.T) {
 
 func TestClient_ListResponseObjects_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListResponseObjects(&ListResponseObjectsInput{
+	_, err = TestClient.ListResponseObjects(&ListResponseObjectsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListResponseObjects(&ListResponseObjectsInput{
+	_, err = TestClient.ListResponseObjects(&ListResponseObjectsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -156,14 +156,14 @@ func TestClient_ListResponseObjects_validation(t *testing.T) {
 
 func TestClient_CreateResponseObject_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateResponseObject(&CreateResponseObjectInput{
+	_, err = TestClient.CreateResponseObject(&CreateResponseObjectInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateResponseObject(&CreateResponseObjectInput{
+	_, err = TestClient.CreateResponseObject(&CreateResponseObjectInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -175,7 +175,7 @@ func TestClient_CreateResponseObject_validation(t *testing.T) {
 func TestClient_GetResponseObject_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.GetResponseObject(&GetResponseObjectInput{
+	_, err = TestClient.GetResponseObject(&GetResponseObjectInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -183,7 +183,7 @@ func TestClient_GetResponseObject_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetResponseObject(&GetResponseObjectInput{
+	_, err = TestClient.GetResponseObject(&GetResponseObjectInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -191,7 +191,7 @@ func TestClient_GetResponseObject_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetResponseObject(&GetResponseObjectInput{
+	_, err = TestClient.GetResponseObject(&GetResponseObjectInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -203,7 +203,7 @@ func TestClient_GetResponseObject_validation(t *testing.T) {
 func TestClient_UpdateResponseObject_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateResponseObject(&UpdateResponseObjectInput{
+	_, err = TestClient.UpdateResponseObject(&UpdateResponseObjectInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -211,7 +211,7 @@ func TestClient_UpdateResponseObject_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateResponseObject(&UpdateResponseObjectInput{
+	_, err = TestClient.UpdateResponseObject(&UpdateResponseObjectInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -219,7 +219,7 @@ func TestClient_UpdateResponseObject_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateResponseObject(&UpdateResponseObjectInput{
+	_, err = TestClient.UpdateResponseObject(&UpdateResponseObjectInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})
@@ -231,7 +231,7 @@ func TestClient_UpdateResponseObject_validation(t *testing.T) {
 func TestClient_DeleteResponseObject_validation(t *testing.T) {
 	var err error
 
-	err = testClient.DeleteResponseObject(&DeleteResponseObjectInput{
+	err = TestClient.DeleteResponseObject(&DeleteResponseObjectInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -239,7 +239,7 @@ func TestClient_DeleteResponseObject_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteResponseObject(&DeleteResponseObjectInput{
+	err = TestClient.DeleteResponseObject(&DeleteResponseObjectInput{
 		Name:           "test",
 		ServiceVersion: 1,
 	})
@@ -247,7 +247,7 @@ func TestClient_DeleteResponseObject_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteResponseObject(&DeleteResponseObjectInput{
+	err = TestClient.DeleteResponseObject(&DeleteResponseObjectInput{
 		Name:      "test",
 		ServiceID: "foo",
 	})

--- a/fastly/vcl_settings.go
+++ b/fastly/vcl_settings.go
@@ -37,7 +37,7 @@ func (c *Client) GetSettings(i *GetSettingsInput) (*Settings, error) {
 	defer resp.Body.Close()
 
 	var b *Settings
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil
@@ -76,7 +76,7 @@ func (c *Client) UpdateSettings(i *UpdateSettingsInput) (*Settings, error) {
 	defer resp.Body.Close()
 
 	var b *Settings
-	if err := decodeBodyMap(resp.Body, &b); err != nil {
+	if err := DecodeBodyMap(resp.Body, &b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/fastly/vcl_settings_test.go
+++ b/fastly/vcl_settings_test.go
@@ -11,15 +11,15 @@ func TestClient_Settings(t *testing.T) {
 
 	var err error
 	var tv *Version
-	record(t, "settings/version", func(c *Client) {
+	Record(t, "settings/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	// Get
 	var ns *Settings
-	record(t, "settings/get", func(c *Client) {
+	Record(t, "settings/get", func(c *Client) {
 		ns, err = c.GetSettings(&GetSettingsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -32,9 +32,9 @@ func TestClient_Settings(t *testing.T) {
 
 	// Update
 	var us *Settings
-	record(t, "settings/update", func(c *Client) {
+	Record(t, "settings/update", func(c *Client) {
 		us, err = c.UpdateSettings(&UpdateSettingsInput{
-			ServiceID:       testDeliveryServiceID,
+			ServiceID:       TestDeliveryServiceID,
 			ServiceVersion:  *tv.Number,
 			DefaultTTL:      ToPointer(uint(1800)),
 			StaleIfError:    ToPointer(true),
@@ -77,14 +77,14 @@ func TestClient_UpdateSettingsInput_default_ttl(t *testing.T) {
 
 func TestClient_GetSettings_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetSettings(&GetSettingsInput{
+	_, err = TestClient.GetSettings(&GetSettingsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetSettings(&GetSettingsInput{
+	_, err = TestClient.GetSettings(&GetSettingsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -95,14 +95,14 @@ func TestClient_GetSettings_validation(t *testing.T) {
 
 func TestClient_UpdateSettings_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateSettings(&UpdateSettingsInput{
+	_, err = TestClient.UpdateSettings(&UpdateSettingsInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateSettings(&UpdateSettingsInput{
+	_, err = TestClient.UpdateSettings(&UpdateSettingsInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})

--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -93,7 +93,7 @@ func (c *Client) CreateSnippet(i *CreateSnippetInput) (*Snippet, error) {
 	defer resp.Body.Close()
 
 	var snippet *Snippet
-	if err := decodeBodyMap(resp.Body, &snippet); err != nil {
+	if err := DecodeBodyMap(resp.Body, &snippet); err != nil {
 		return nil, err
 	}
 	return snippet, err
@@ -137,7 +137,7 @@ func (c *Client) UpdateSnippet(i *UpdateSnippetInput) (*Snippet, error) {
 	defer resp.Body.Close()
 
 	var snippet *Snippet
-	if err := decodeBodyMap(resp.Body, &snippet); err != nil {
+	if err := DecodeBodyMap(resp.Body, &snippet); err != nil {
 		return nil, err
 	}
 	return snippet, err
@@ -181,7 +181,7 @@ func (c *Client) UpdateDynamicSnippet(i *UpdateDynamicSnippetInput) (*DynamicSni
 	defer resp.Body.Close()
 
 	var updateSnippet *DynamicSnippet
-	if err := decodeBodyMap(resp.Body, &updateSnippet); err != nil {
+	if err := DecodeBodyMap(resp.Body, &updateSnippet); err != nil {
 		return nil, err
 	}
 	return updateSnippet, err
@@ -217,7 +217,7 @@ func (c *Client) DeleteSnippet(i *DeleteSnippetInput) error {
 	defer resp.Body.Close()
 
 	var r *statusResp
-	if err := decodeBodyMap(resp.Body, &r); err != nil {
+	if err := DecodeBodyMap(resp.Body, &r); err != nil {
 		return err
 	}
 	if !r.Ok() {
@@ -254,7 +254,7 @@ func (c *Client) ListSnippets(i *ListSnippetsInput) ([]*Snippet, error) {
 	defer resp.Body.Close()
 
 	var snippets []*Snippet
-	if err := decodeBodyMap(resp.Body, &snippets); err != nil {
+	if err := DecodeBodyMap(resp.Body, &snippets); err != nil {
 		return nil, err
 	}
 	return snippets, nil
@@ -293,7 +293,7 @@ func (c *Client) GetSnippet(i *GetSnippetInput) (*Snippet, error) {
 	defer resp.Body.Close()
 
 	var snippet *Snippet
-	if err := decodeBodyMap(resp.Body, &snippet); err != nil {
+	if err := DecodeBodyMap(resp.Body, &snippet); err != nil {
 		return nil, err
 	}
 	return snippet, nil
@@ -327,7 +327,7 @@ func (c *Client) GetDynamicSnippet(i *GetDynamicSnippetInput) (*DynamicSnippet, 
 	defer resp.Body.Close()
 
 	var snippet *DynamicSnippet
-	if err := decodeBodyMap(resp.Body, &snippet); err != nil {
+	if err := DecodeBodyMap(resp.Body, &snippet); err != nil {
 		return nil, err
 	}
 	return snippet, nil

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -18,19 +18,19 @@ func TestClient_Snippets(t *testing.T) {
 	)
 
 	var tv *Version
-	record(t, "vcl_snippets/version", func(c *Client) {
+	Record(t, "vcl_snippets/version", func(c *Client) {
 		tv = testVersion(t, c)
 	})
 
 	var err error
 	var cs *Snippet
 
-	record(t, "vcl_snippets/create_with_required_fields_only", func(c *Client) {
+	Record(t, "vcl_snippets/create_with_required_fields_only", func(c *Client) {
 		cs, err = c.CreateSnippet(&CreateSnippetInput{
 			Content:        ToPointer(vclContent),
 			Dynamic:        ToPointer(0),
 			Name:           ToPointer(svName),
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Type:           ToPointer(SnippetTypeFetch),
 		})
@@ -39,8 +39,8 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *cs.ServiceID != testDeliveryServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testDeliveryServiceID, *cs.ServiceID)
+	if *cs.ServiceID != TestDeliveryServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", TestDeliveryServiceID, *cs.ServiceID)
 	}
 	if *cs.Name != svName {
 		t.Errorf("incorrect Name: want %v, have %q", svName, *cs.Name)
@@ -61,9 +61,9 @@ func TestClient_Snippets(t *testing.T) {
 	dynamic := 1
 	priority := 123
 
-	record(t, "vcl_snippets/create_with_all_fields", func(c *Client) {
+	Record(t, "vcl_snippets/create_with_all_fields", func(c *Client) {
 		cs, err = c.CreateSnippet(&CreateSnippetInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           ToPointer(sdName),
 			Content:        ToPointer(vclContent),
@@ -76,8 +76,8 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *cs.ServiceID != testDeliveryServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testDeliveryServiceID, *cs.ServiceID)
+	if *cs.ServiceID != TestDeliveryServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", TestDeliveryServiceID, *cs.ServiceID)
 	}
 	if *cs.Name != sdName {
 		t.Errorf("incorrect Name: want %v, have %q", sdName, *cs.Name)
@@ -97,9 +97,9 @@ func TestClient_Snippets(t *testing.T) {
 
 	var ls []*Snippet
 
-	record(t, "vcl_snippets/list", func(c *Client) {
+	Record(t, "vcl_snippets/list", func(c *Client) {
 		ls, err = c.ListSnippets(&ListSnippetsInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 		})
 	})
@@ -109,8 +109,8 @@ func TestClient_Snippets(t *testing.T) {
 	}
 
 	for _, s := range ls {
-		if *s.ServiceID != testDeliveryServiceID {
-			t.Errorf("incorrect ServiceID: want %v, have %q", testDeliveryServiceID, *s.ServiceID)
+		if *s.ServiceID != TestDeliveryServiceID {
+			t.Errorf("incorrect ServiceID: want %v, have %q", TestDeliveryServiceID, *s.ServiceID)
 		}
 		if *s.Type != SnippetTypeFetch {
 			t.Errorf("incorrect Name: want %v, have %q", SnippetTypeFetch, *s.Type)
@@ -140,9 +140,9 @@ func TestClient_Snippets(t *testing.T) {
 
 	var vs *Snippet
 
-	record(t, "vcl_snippets/get_versioned", func(c *Client) {
+	Record(t, "vcl_snippets/get_versioned", func(c *Client) {
 		vs, err = c.GetSnippet(&GetSnippetInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           svName,
 		})
@@ -151,8 +151,8 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *vs.ServiceID != testDeliveryServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testDeliveryServiceID, *vs.ServiceID)
+	if *vs.ServiceID != TestDeliveryServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", TestDeliveryServiceID, *vs.ServiceID)
 	}
 	if *vs.Name != svName {
 		t.Errorf("incorrect Name: want %v, have %q", svName, *vs.Name)
@@ -172,9 +172,9 @@ func TestClient_Snippets(t *testing.T) {
 
 	var ds *DynamicSnippet
 
-	record(t, "vcl_snippets/get_dynamic", func(c *Client) {
+	Record(t, "vcl_snippets/get_dynamic", func(c *Client) {
 		ds, err = c.GetDynamicSnippet(&GetDynamicSnippetInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			SnippetID: *cs.SnippetID,
 		})
 	})
@@ -182,8 +182,8 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *ds.ServiceID != testDeliveryServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testDeliveryServiceID, *ds.ServiceID)
+	if *ds.ServiceID != TestDeliveryServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", TestDeliveryServiceID, *ds.ServiceID)
 	}
 	if *ds.SnippetID != *cs.SnippetID {
 		t.Errorf("incorrect ID: want %v, have %q", *cs.SnippetID, *ds.SnippetID)
@@ -195,9 +195,9 @@ func TestClient_Snippets(t *testing.T) {
 	priority = 456
 	hit := SnippetTypeHit
 
-	record(t, "vcl_snippets/update_versioned", func(c *Client) {
+	Record(t, "vcl_snippets/update_versioned", func(c *Client) {
 		vs, err = c.UpdateSnippet(&UpdateSnippetInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           svName,
 			NewName:        ToPointer(svNameUpdated),
@@ -210,8 +210,8 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *vs.ServiceID != testDeliveryServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testDeliveryServiceID, *vs.ServiceID)
+	if *vs.ServiceID != TestDeliveryServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", TestDeliveryServiceID, *vs.ServiceID)
 	}
 	if *vs.Name != svNameUpdated {
 		t.Errorf("incorrect Name: want %v, have %q", svNameUpdated, *vs.Name)
@@ -229,9 +229,9 @@ func TestClient_Snippets(t *testing.T) {
 		t.Errorf("incorrect Name: want %v, have %q", hit, *vs.Type)
 	}
 
-	record(t, "vcl_snippets/update_dynamic", func(c *Client) {
+	Record(t, "vcl_snippets/update_dynamic", func(c *Client) {
 		ds, err = c.UpdateDynamicSnippet(&UpdateDynamicSnippetInput{
-			ServiceID: testDeliveryServiceID,
+			ServiceID: TestDeliveryServiceID,
 			SnippetID: *cs.SnippetID,
 			Content:   ToPointer(vclContentUpdated),
 		})
@@ -240,8 +240,8 @@ func TestClient_Snippets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *ds.ServiceID != testDeliveryServiceID {
-		t.Errorf("incorrect ServiceID: want %v, have %q", testDeliveryServiceID, *ds.ServiceID)
+	if *ds.ServiceID != TestDeliveryServiceID {
+		t.Errorf("incorrect ServiceID: want %v, have %q", TestDeliveryServiceID, *ds.ServiceID)
 	}
 	if *ds.SnippetID != *cs.SnippetID {
 		t.Errorf("incorrect ID: want %v, have %q", cs.SnippetID, *ds.SnippetID)
@@ -250,9 +250,9 @@ func TestClient_Snippets(t *testing.T) {
 		t.Errorf("incorrect Content: want %v, have %q", vclContentUpdated, *ds.Content)
 	}
 
-	record(t, "vcl_snippets/delete_versioned", func(c *Client) {
+	Record(t, "vcl_snippets/delete_versioned", func(c *Client) {
 		err = c.DeleteSnippet(&DeleteSnippetInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           svNameUpdated,
 		})
@@ -262,9 +262,9 @@ func TestClient_Snippets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, "vcl_snippets/delete_dynamic", func(c *Client) {
+	Record(t, "vcl_snippets/delete_dynamic", func(c *Client) {
 		err = c.DeleteSnippet(&DeleteSnippetInput{
-			ServiceID:      testDeliveryServiceID,
+			ServiceID:      TestDeliveryServiceID,
 			ServiceVersion: *tv.Number,
 			Name:           sdName,
 		})

--- a/fastly/waf_active_rule_test.go
+++ b/fastly/waf_active_rule_test.go
@@ -12,7 +12,7 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"service/create", "service")
 	defer deleteTestService(t, fixtureBase+"/service/delete", *testService.ServiceID)
 
-	tv := createTestVersion(t, fixtureBase+"/service/version", *testService.ServiceID)
+	tv := CreateTestVersion(t, fixtureBase+"/service/version", *testService.ServiceID)
 
 	createTestLogging(t, fixtureBase+"/logging/create", *testService.ServiceID, *tv.Number)
 	defer deleteTestLogging(t, fixtureBase+"/logging/delete", *testService.ServiceID, *tv.Number)
@@ -29,7 +29,7 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 	var err error
 
 	var rulesResp *WAFActiveRuleResponse
-	record(t, fixtureBase+"/list_empty", func(c *Client) {
+	Record(t, fixtureBase+"/list_empty", func(c *Client) {
 		rulesResp, err = c.ListWAFActiveRules(&ListWAFActiveRulesInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -44,7 +44,7 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 
 	rulesIn := buildWAFRules("log")
 	var rulesOut []*WAFActiveRule
-	record(t, fixtureBase+"/create", func(c *Client) {
+	Record(t, fixtureBase+"/create", func(c *Client) {
 		rulesOut, err = c.BatchModificationWAFActiveRules(&BatchModificationWAFActiveRulesInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -59,7 +59,7 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 		t.Errorf("expected 0 waf version: got %d", len(rulesOut))
 	}
 
-	record(t, fixtureBase+"/list_not_empty", func(c *Client) {
+	Record(t, fixtureBase+"/list_not_empty", func(c *Client) {
 		rulesResp, err = c.ListWAFActiveRules(&ListWAFActiveRulesInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -81,7 +81,7 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 	}
 
 	rulesIn = buildWAFRules("block")
-	record(t, fixtureBase+"/update", func(c *Client) {
+	Record(t, fixtureBase+"/update", func(c *Client) {
 		rulesOut, err = c.BatchModificationWAFActiveRules(&BatchModificationWAFActiveRulesInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -96,7 +96,7 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 		t.Errorf("expected 0 waf version: got %d", len(rulesOut))
 	}
 
-	record(t, fixtureBase+"/list_not_empty2", func(c *Client) {
+	Record(t, fixtureBase+"/list_not_empty2", func(c *Client) {
 		rulesResp, err = c.ListWAFActiveRules(&ListWAFActiveRulesInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -120,7 +120,7 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 	rules := []*WAFActiveRule{{
 		ModSecID: 1010070,
 	}}
-	record(t, fixtureBase+"/delete_one", func(c *Client) {
+	Record(t, fixtureBase+"/delete_one", func(c *Client) {
 		rulesOut, err = c.BatchModificationWAFActiveRules(&BatchModificationWAFActiveRulesInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -132,7 +132,7 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record(t, fixtureBase+"/list_after_delete", func(c *Client) {
+	Record(t, fixtureBase+"/list_after_delete", func(c *Client) {
 		rulesResp, err = c.ListWAFActiveRules(&ListWAFActiveRulesInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -148,14 +148,14 @@ func TestClient_WAF_Active_Rules(t *testing.T) {
 
 func TestClient_ListWAFActiveRules_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListWAFActiveRules(&ListWAFActiveRulesInput{
+	_, err = TestClient.ListWAFActiveRules(&ListWAFActiveRulesInput{
 		WAFID: "",
 	})
 	if err != ErrMissingWAFID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListWAFActiveRules(&ListWAFActiveRulesInput{
+	_, err = TestClient.ListWAFActiveRules(&ListWAFActiveRulesInput{
 		WAFID:            "1",
 		WAFVersionNumber: 0,
 	})
@@ -166,14 +166,14 @@ func TestClient_ListWAFActiveRules_validation(t *testing.T) {
 
 func TestClient_ListAllWAFActiveRules_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListAllWAFActiveRules(&ListAllWAFActiveRulesInput{
+	_, err = TestClient.ListAllWAFActiveRules(&ListAllWAFActiveRulesInput{
 		WAFID: "",
 	})
 	if err != ErrMissingWAFID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.ListAllWAFActiveRules(&ListAllWAFActiveRulesInput{
+	_, err = TestClient.ListAllWAFActiveRules(&ListAllWAFActiveRulesInput{
 		WAFID:            "1",
 		WAFVersionNumber: 0,
 	})
@@ -184,14 +184,14 @@ func TestClient_ListAllWAFActiveRules_validation(t *testing.T) {
 
 func TestClient_CreateWAFActiveRules_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateWAFActiveRules(&CreateWAFActiveRulesInput{
+	_, err = TestClient.CreateWAFActiveRules(&CreateWAFActiveRulesInput{
 		WAFID: "",
 	})
 	if err != ErrMissingWAFID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateWAFActiveRules(&CreateWAFActiveRulesInput{
+	_, err = TestClient.CreateWAFActiveRules(&CreateWAFActiveRulesInput{
 		WAFID:            "1",
 		WAFVersionNumber: 0,
 	})
@@ -199,7 +199,7 @@ func TestClient_CreateWAFActiveRules_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateWAFActiveRules(&CreateWAFActiveRulesInput{
+	_, err = TestClient.CreateWAFActiveRules(&CreateWAFActiveRulesInput{
 		WAFID:            "1",
 		WAFVersionNumber: 1,
 		Rules:            []*WAFActiveRule{},
@@ -211,7 +211,7 @@ func TestClient_CreateWAFActiveRules_validation(t *testing.T) {
 
 func TestClient_BatchModificationWAFActiveRules_validation(t *testing.T) {
 	var err error
-	_, err = testClient.BatchModificationWAFActiveRules(&BatchModificationWAFActiveRulesInput{})
+	_, err = TestClient.BatchModificationWAFActiveRules(&BatchModificationWAFActiveRulesInput{})
 	if err == nil {
 		t.Errorf("error expected")
 	}
@@ -220,7 +220,7 @@ func TestClient_BatchModificationWAFActiveRules_validation(t *testing.T) {
 	for i := 0; i <= BatchModifyMaximumOperations; i++ {
 		rules = append(rules, &WAFActiveRule{})
 	}
-	_, err = testClient.BatchModificationWAFActiveRules(&BatchModificationWAFActiveRulesInput{
+	_, err = TestClient.BatchModificationWAFActiveRules(&BatchModificationWAFActiveRulesInput{
 		Rules: rules,
 	})
 	if err != ErrMaxExceededRules {
@@ -230,7 +230,7 @@ func TestClient_BatchModificationWAFActiveRules_validation(t *testing.T) {
 
 func TestClient_DeleteWAFActiveRules_validation(t *testing.T) {
 	var err error
-	err = testClient.DeleteWAFActiveRules(&DeleteWAFActiveRulesInput{
+	err = TestClient.DeleteWAFActiveRules(&DeleteWAFActiveRulesInput{
 		WAFID: "",
 	})
 
@@ -238,7 +238,7 @@ func TestClient_DeleteWAFActiveRules_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteWAFActiveRules(&DeleteWAFActiveRulesInput{
+	err = TestClient.DeleteWAFActiveRules(&DeleteWAFActiveRulesInput{
 		WAFID:            "1",
 		WAFVersionNumber: 0,
 	})
@@ -247,7 +247,7 @@ func TestClient_DeleteWAFActiveRules_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteWAFActiveRules(&DeleteWAFActiveRulesInput{
+	err = TestClient.DeleteWAFActiveRules(&DeleteWAFActiveRulesInput{
 		WAFID:            "1",
 		WAFVersionNumber: 1,
 		Rules:            []*WAFActiveRule{},

--- a/fastly/waf_rule_exclusion.go
+++ b/fastly/waf_rule_exclusion.go
@@ -284,7 +284,7 @@ func (c *Client) UpdateWAFRuleExclusion(i *UpdateWAFRuleExclusionInput) (*WAFRul
 	defer resp.Body.Close()
 
 	var exc *WAFRuleExclusion
-	if err := decodeBodyMap(resp.Body, &exc); err != nil {
+	if err := DecodeBodyMap(resp.Body, &exc); err != nil {
 		return nil, err
 	}
 	return exc, nil

--- a/fastly/waf_rule_exclusion_test.go
+++ b/fastly/waf_rule_exclusion_test.go
@@ -170,7 +170,7 @@ func TestClient_WAF_Rule_Exclusion_list_validation(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		if _, err := testClient.ListWAFRuleExclusions(c.input); err.Error() != c.expectedError {
+		if _, err := TestClient.ListWAFRuleExclusions(c.input); err.Error() != c.expectedError {
 			t.Errorf("bad error: %s", err)
 		}
 	}
@@ -198,7 +198,7 @@ func TestClient_WAF_Rule_Exclusion_list_all_validation(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		if _, err := testClient.ListAllWAFRuleExclusions(c.input); err.Error() != c.expectedError {
+		if _, err := TestClient.ListAllWAFRuleExclusions(c.input); err.Error() != c.expectedError {
 			t.Errorf("bad error: %s", err)
 		}
 	}
@@ -233,7 +233,7 @@ func TestClient_WAF_Rule_Exclusion_create_validation(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		if _, err := testClient.CreateWAFRuleExclusion(c.input); err.Error() != c.expectedError {
+		if _, err := TestClient.CreateWAFRuleExclusion(c.input); err.Error() != c.expectedError {
 			t.Errorf("bad error: %s", err)
 		}
 	}
@@ -276,7 +276,7 @@ func TestClient_WAF_Rule_Exclusion_update_validation(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		if _, err := testClient.UpdateWAFRuleExclusion(c.input); err.Error() != c.expectedError {
+		if _, err := TestClient.UpdateWAFRuleExclusion(c.input); err.Error() != c.expectedError {
 			t.Errorf("bad error: %s", err)
 		}
 	}
@@ -311,7 +311,7 @@ func TestClient_WAF_Rule_Exclusion_delete_validation(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		if err := testClient.DeleteWAFRuleExclusion(c.input); err.Error() != c.expectedError {
+		if err := TestClient.DeleteWAFRuleExclusion(c.input); err.Error() != c.expectedError {
 			t.Errorf("bad error: %s", err)
 		}
 	}
@@ -347,7 +347,7 @@ func createWAFWithRulesForExclusion(t *testing.T, fixtureBase string, testServic
 
 	var err error
 	rulesIn := buildWAFRulesForExclusion("log")
-	record(t, fixtureBase+"active_rules/create", func(c *Client) {
+	Record(t, fixtureBase+"active_rules/create", func(c *Client) {
 		_, err = c.BatchModificationWAFActiveRules(&BatchModificationWAFActiveRulesInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -387,7 +387,7 @@ func createServiceForWAF(t *testing.T, fixtureBase string) (*Service, *Version, 
 		return nil, nil, "", err
 	}
 	service := createTestService(t, fixtureBase+"service/create", "service-"+strconv.Itoa(int(n.Int64())))
-	version := createTestVersion(t, fixtureBase+"service/version", *service.ServiceID)
+	version := CreateTestVersion(t, fixtureBase+"service/version", *service.ServiceID)
 	responseName := "WAf_Response"
 	createTestWAFResponseObject(t, fixtureBase+"response_object/create", *service.ServiceID, responseName, *version.Number)
 	return service, version, responseName, nil
@@ -396,7 +396,7 @@ func createServiceForWAF(t *testing.T, fixtureBase string) (*Service, *Version, 
 func createWAFRuleExclusion(t *testing.T, fixture string, excl1In *CreateWAFRuleExclusionInput) *WAFRuleExclusion {
 	var excl1Out *WAFRuleExclusion
 	var err error
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		excl1Out, err = c.CreateWAFRuleExclusion(excl1In)
 	})
 	if err != nil {
@@ -408,7 +408,7 @@ func createWAFRuleExclusion(t *testing.T, fixture string, excl1In *CreateWAFRule
 func updateWAFExclusion(t *testing.T, fixture string, updateExcl *UpdateWAFRuleExclusionInput) *WAFRuleExclusion {
 	var err error
 	var out *WAFRuleExclusion
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		out, err = c.UpdateWAFRuleExclusion(updateExcl)
 	})
 	if err != nil {
@@ -419,7 +419,7 @@ func updateWAFExclusion(t *testing.T, fixture string, updateExcl *UpdateWAFRuleE
 
 func deleteWAFExclusion(t *testing.T, fixture string, updateExcl *DeleteWAFRuleExclusionInput) {
 	var err error
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		err = c.DeleteWAFRuleExclusion(updateExcl)
 	})
 	if err != nil {
@@ -430,7 +430,7 @@ func deleteWAFExclusion(t *testing.T, fixture string, updateExcl *DeleteWAFRuleE
 func listWAFRuleExclusions(t *testing.T, fixture string, waf *WAF) *WAFRuleExclusionResponse {
 	var err error
 	var exclResp *WAFRuleExclusionResponse
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		exclResp, err = c.ListAllWAFRuleExclusions(&ListAllWAFRuleExclusionsInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -446,7 +446,7 @@ func listWAFRuleExclusions(t *testing.T, fixture string, waf *WAF) *WAFRuleExclu
 func listWAFExclusionsWithFilters(t *testing.T, fixture string, request *ListAllWAFRuleExclusionsInput) *WAFRuleExclusionResponse {
 	var err error
 	var exclResp *WAFRuleExclusionResponse
-	record(t, fixture, func(c *Client) {
+	Record(t, fixture, func(c *Client) {
 		exclResp, err = c.ListAllWAFRuleExclusions(request)
 	})
 	if err != nil {

--- a/fastly/waf_rules_test.go
+++ b/fastly/waf_rules_test.go
@@ -13,7 +13,7 @@ func TestClient_WAF_Rules(t *testing.T) {
 	var err error
 	var rulesResp *WAFRuleResponse
 	publisher := "owasp"
-	record(t, fixtureBase+"/list_owasp", func(c *Client) {
+	Record(t, fixtureBase+"/list_owasp", func(c *Client) {
 		rulesResp, err = c.ListWAFRules(&ListWAFRulesInput{
 			FilterPublishers: []string{publisher},
 		})
@@ -33,7 +33,7 @@ func TestClient_WAF_Rules(t *testing.T) {
 
 	publisher = "fastly"
 	var fastlyRulesNumber int
-	record(t, fixtureBase+"/list_all_fastly", func(c *Client) {
+	Record(t, fixtureBase+"/list_all_fastly", func(c *Client) {
 		rulesResp, err = c.ListAllWAFRules(&ListAllWAFRulesInput{
 			FilterPublishers: []string{publisher},
 		})
@@ -52,7 +52,7 @@ func TestClient_WAF_Rules(t *testing.T) {
 	}
 	fastlyRulesNumber = len(rulesResp.Items)
 
-	record(t, fixtureBase+"/list_all_fastly_exclusion", func(c *Client) {
+	Record(t, fixtureBase+"/list_all_fastly_exclusion", func(c *Client) {
 		rulesResp, err = c.ListAllWAFRules(&ListAllWAFRulesInput{
 			FilterPublishers: []string{publisher},
 			ExcludeMocSecIDs: []int{4170020},
@@ -75,7 +75,7 @@ func TestClient_WAF_Rules(t *testing.T) {
 		t.Errorf("expected %d rules: got %d", fastlyRulesNumber-1, len(rulesResp.Items))
 	}
 
-	record(t, fixtureBase+"/list_all_fastly_filter_by_rule_ids", func(c *Client) {
+	Record(t, fixtureBase+"/list_all_fastly_filter_by_rule_ids", func(c *Client) {
 		rulesResp, err = c.ListAllWAFRules(&ListAllWAFRulesInput{
 			FilterModSecIDs: []int{1010060, 1010070},
 		})

--- a/fastly/waf_test.go
+++ b/fastly/waf_test.go
@@ -13,7 +13,7 @@ func TestClient_WAFs(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"service/create", "service2")
 	defer deleteTestService(t, fixtureBase+"/service/delete", *testService.ServiceID)
 
-	tv := createTestVersion(t, fixtureBase+"/service/version", *testService.ServiceID)
+	tv := CreateTestVersion(t, fixtureBase+"/service/version", *testService.ServiceID)
 
 	prefetch := "WAF_Prefetch"
 	condition := createTestWAFCondition(t, fixtureBase+"/condition/create", *testService.ServiceID, prefetch, *tv.Number)
@@ -29,7 +29,7 @@ func TestClient_WAFs(t *testing.T) {
 
 	var err error
 	var waf *WAF
-	record(t, fixtureBase+"/create", func(c *Client) {
+	Record(t, fixtureBase+"/create", func(c *Client) {
 		waf, err = c.CreateWAF(&CreateWAFInput{
 			ServiceID:         *testService.ServiceID,
 			ServiceVersion:    *tv.Number,
@@ -43,7 +43,7 @@ func TestClient_WAFs(t *testing.T) {
 
 	// List
 	var wafsResp *WAFResponse
-	record(t, fixtureBase+"/list", func(c *Client) {
+	Record(t, fixtureBase+"/list", func(c *Client) {
 		wafsResp, err = c.ListWAFs(&ListWAFsInput{
 			FilterService: *testService.ServiceID,
 			FilterVersion: *tv.Number,
@@ -58,7 +58,7 @@ func TestClient_WAFs(t *testing.T) {
 
 	// Ensure deleted
 	defer func() {
-		record(t, fixtureBase+"/cleanup", func(c *Client) {
+		Record(t, fixtureBase+"/cleanup", func(c *Client) {
 			_ = c.DeleteWAF(&DeleteWAFInput{
 				ServiceVersion: *tv.Number,
 				ID:             waf.ID,
@@ -66,7 +66,7 @@ func TestClient_WAFs(t *testing.T) {
 		})
 	}()
 
-	record(t, fixtureBase+"/deploy", func(c *Client) {
+	Record(t, fixtureBase+"/deploy", func(c *Client) {
 		err = c.DeployWAFVersion(&DeployWAFVersionInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -78,7 +78,7 @@ func TestClient_WAFs(t *testing.T) {
 
 	// Get
 	var nwaf *WAF
-	record(t, fixtureBase+"/get", func(c *Client) {
+	Record(t, fixtureBase+"/get", func(c *Client) {
 		nwaf, err = c.GetWAF(&GetWAFInput{
 			ServiceID:      *testService.ServiceID,
 			ServiceVersion: *tv.Number,
@@ -96,7 +96,7 @@ func TestClient_WAFs(t *testing.T) {
 	}
 
 	var uwaf *WAF
-	record(t, fixtureBase+"/update", func(c *Client) {
+	Record(t, fixtureBase+"/update", func(c *Client) {
 		uwaf, err = c.UpdateWAF(&UpdateWAFInput{
 			ServiceID:      testService.ServiceID,
 			ServiceVersion: tv.Number,
@@ -112,7 +112,7 @@ func TestClient_WAFs(t *testing.T) {
 	}
 
 	var dwaf *WAF
-	record(t, fixtureBase+"/disable", func(c *Client) {
+	Record(t, fixtureBase+"/disable", func(c *Client) {
 		dwaf, err = c.UpdateWAF(&UpdateWAFInput{
 			ID:       waf.ID,
 			Disabled: ToPointer(true),
@@ -126,7 +126,7 @@ func TestClient_WAFs(t *testing.T) {
 	}
 
 	var ewaf *WAF
-	record(t, fixtureBase+"/enable", func(c *Client) {
+	Record(t, fixtureBase+"/enable", func(c *Client) {
 		ewaf, err = c.UpdateWAF(&UpdateWAFInput{
 			ID:       waf.ID,
 			Disabled: ToPointer(false),
@@ -140,7 +140,7 @@ func TestClient_WAFs(t *testing.T) {
 	}
 
 	// Delete
-	record(t, fixtureBase+"/delete", func(c *Client) {
+	Record(t, fixtureBase+"/delete", func(c *Client) {
 		err = c.DeleteWAF(&DeleteWAFInput{
 			ServiceVersion: *tv.Number,
 			ID:             waf.ID,
@@ -153,14 +153,14 @@ func TestClient_WAFs(t *testing.T) {
 
 func TestClient_CreateWAF_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateWAF(&CreateWAFInput{
+	_, err = TestClient.CreateWAF(&CreateWAFInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CreateWAF(&CreateWAFInput{
+	_, err = TestClient.CreateWAF(&CreateWAFInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -171,14 +171,14 @@ func TestClient_CreateWAF_validation(t *testing.T) {
 
 func TestClient_GetWAF_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetWAF(&GetWAFInput{
+	_, err = TestClient.GetWAF(&GetWAFInput{
 		ServiceID: "",
 	})
 	if err != ErrMissingServiceID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetWAF(&GetWAFInput{
+	_, err = TestClient.GetWAF(&GetWAFInput{
 		ServiceID:      "foo",
 		ServiceVersion: 0,
 	})
@@ -186,7 +186,7 @@ func TestClient_GetWAF_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetWAF(&GetWAFInput{
+	_, err = TestClient.GetWAF(&GetWAFInput{
 		ServiceID:      "foo",
 		ServiceVersion: 1,
 	})
@@ -198,14 +198,14 @@ func TestClient_GetWAF_validation(t *testing.T) {
 func TestClient_UpdateWAF_validation(t *testing.T) {
 	var err error
 
-	_, err = testClient.UpdateWAF(&UpdateWAFInput{
+	_, err = TestClient.UpdateWAF(&UpdateWAFInput{
 		ID: "",
 	})
 	if err != ErrMissingID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateWAF(&UpdateWAFInput{
+	_, err = TestClient.UpdateWAF(&UpdateWAFInput{
 		ID: "123999",
 	})
 	if err != ErrMissingServiceID {
@@ -214,7 +214,7 @@ func TestClient_UpdateWAF_validation(t *testing.T) {
 
 	serviceID := "foo"
 
-	_, err = testClient.UpdateWAF(&UpdateWAFInput{
+	_, err = TestClient.UpdateWAF(&UpdateWAFInput{
 		ID:        "123",
 		ServiceID: &serviceID,
 	})
@@ -225,14 +225,14 @@ func TestClient_UpdateWAF_validation(t *testing.T) {
 
 func TestClient_DeleteWAF_validation(t *testing.T) {
 	var err error
-	err = testClient.DeleteWAF(&DeleteWAFInput{
+	err = TestClient.DeleteWAF(&DeleteWAFInput{
 		ServiceVersion: 0,
 	})
 	if err != ErrMissingServiceVersion {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeleteWAF(&DeleteWAFInput{
+	err = TestClient.DeleteWAF(&DeleteWAFInput{
 		ServiceVersion: 1,
 		ID:             "",
 	})
@@ -243,7 +243,7 @@ func TestClient_DeleteWAF_validation(t *testing.T) {
 
 func TestClient_UpdateWAF_Enable_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateWAF(&UpdateWAFInput{
+	_, err = TestClient.UpdateWAF(&UpdateWAFInput{
 		ID:       "",
 		Disabled: ToPointer(false),
 	})
@@ -254,7 +254,7 @@ func TestClient_UpdateWAF_Enable_validation(t *testing.T) {
 
 func TestClient_UpdateWAF_Disable_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateWAF(&UpdateWAFInput{
+	_, err = TestClient.UpdateWAF(&UpdateWAFInput{
 		ID:       "",
 		Disabled: ToPointer(true),
 	})

--- a/fastly/waf_version_test.go
+++ b/fastly/waf_version_test.go
@@ -15,7 +15,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 	testService := createTestService(t, fixtureBase+"service/create", "service3")
 	defer deleteTestService(t, fixtureBase+"/service/delete", *testService.ServiceID)
 
-	tv := createTestVersion(t, fixtureBase+"/service/version", *testService.ServiceID)
+	tv := CreateTestVersion(t, fixtureBase+"/service/version", *testService.ServiceID)
 
 	createTestLogging(t, fixtureBase+"/logging/create", *testService.ServiceID, *tv.Number)
 	defer deleteTestLogging(t, fixtureBase+"/logging/delete", *testService.ServiceID, *tv.Number)
@@ -30,7 +30,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 
 	var err error
 	var waf *WAF
-	record(t, fixtureBase+"/waf/create", func(c *Client) {
+	Record(t, fixtureBase+"/waf/create", func(c *Client) {
 		waf, err = c.CreateWAF(&CreateWAFInput{
 			ServiceID:         *testService.ServiceID,
 			ServiceVersion:    *tv.Number,
@@ -42,7 +42,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		record(t, fixtureBase+"/waf/delete", func(c *Client) {
+		Record(t, fixtureBase+"/waf/delete", func(c *Client) {
 			if err := c.DeleteWAF(&DeleteWAFInput{
 				ServiceVersion: *tv.Number,
 				ID:             waf.ID,
@@ -53,7 +53,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 	}()
 
 	var wafVerResp *WAFVersionResponse
-	record(t, fixtureBase+"/list", func(c *Client) {
+	Record(t, fixtureBase+"/list", func(c *Client) {
 		wafVerResp, err = c.ListWAFVersions(&ListWAFVersionsInput{
 			WAFID: waf.ID,
 		})
@@ -68,7 +68,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 		t.Errorf("unexpected waf deployment status: \"%s\"", wafVerResp.Items[0].LastDeploymentStatus)
 	}
 
-	record(t, fixtureBase+"/deploy", func(c *Client) {
+	Record(t, fixtureBase+"/deploy", func(c *Client) {
 		err = c.DeployWAFVersion(&DeployWAFVersionInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -80,7 +80,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 
 	var wafVerPD *WAFVersion
 	for i := 0; i < 120 && (wafVerPD == nil || wafVerPD.LastDeploymentStatus != WAFVersionDeploymentStatusCompleted); i++ {
-		record(t, fmt.Sprintf("%s/getPostDeploy_%d", fixtureBase, i), func(c *Client) {
+		Record(t, fmt.Sprintf("%s/getPostDeploy_%d", fixtureBase, i), func(c *Client) {
 			wafVerPD, err = c.GetWAFVersion(&GetWAFVersionInput{
 				WAFID:            waf.ID,
 				WAFVersionNumber: 1,
@@ -110,7 +110,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 	}
 
 	var wafVer *WAFVersion
-	record(t, fixtureBase+"/clone", func(c *Client) {
+	Record(t, fixtureBase+"/clone", func(c *Client) {
 		wafVer, err = c.CloneWAFVersion(&CloneWAFVersionInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 1,
@@ -123,7 +123,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 		t.Errorf("expected 1 waf: got %d", len(wafVerResp.Items))
 	}
 
-	record(t, fixtureBase+"/get", func(c *Client) {
+	Record(t, fixtureBase+"/get", func(c *Client) {
 		wafVer, err = c.GetWAFVersion(&GetWAFVersionInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 2,
@@ -140,7 +140,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 	input.WAFID = &waf.ID
 	input.WAFVersionNumber = intToPtr(2)
 	input.WAFVersionID = &wafVer.ID
-	record(t, fixtureBase+"/update", func(c *Client) {
+	Record(t, fixtureBase+"/update", func(c *Client) {
 		wafVer, err = c.UpdateWAFVersion(input)
 	})
 	if err != nil {
@@ -151,7 +151,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 	}
 	verifyWAFVersionUpdate(t, input, wafVer)
 
-	record(t, fixtureBase+"/lock", func(c *Client) {
+	Record(t, fixtureBase+"/lock", func(c *Client) {
 		wafVer, err = c.LockWAFVersion(&LockWAFVersionInput{
 			WAFID:            waf.ID,
 			WAFVersionNumber: 2,
@@ -167,7 +167,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 		t.Errorf("expected locked = true waf: got locked == %v", wafVer.Locked)
 	}
 
-	record(t, fixtureBase+"/list_all", func(c *Client) {
+	Record(t, fixtureBase+"/list_all", func(c *Client) {
 		wafVerResp, err = c.ListAllWAFVersions(&ListAllWAFVersionsInput{
 			WAFID: waf.ID,
 		})
@@ -179,7 +179,7 @@ func TestClient_WAF_Versions(t *testing.T) {
 		t.Errorf("expected 2 waf: got %d", len(wafVerResp.Items))
 	}
 
-	record(t, fixtureBase+"/create_empty", func(c *Client) {
+	Record(t, fixtureBase+"/create_empty", func(c *Client) {
 		wafVer, err = c.CreateEmptyWAFVersion(&CreateEmptyWAFVersionInput{
 			WAFID: waf.ID,
 		})
@@ -383,7 +383,7 @@ func TestClient_listWAFVersions_formatFilters(t *testing.T) {
 
 func TestClient_ListWAFVersions_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListWAFVersions(&ListWAFVersionsInput{
+	_, err = TestClient.ListWAFVersions(&ListWAFVersionsInput{
 		WAFID: "",
 	})
 	if err != ErrMissingWAFID {
@@ -393,7 +393,7 @@ func TestClient_ListWAFVersions_validation(t *testing.T) {
 
 func TestClient_ListAllWAFVersions_validation(t *testing.T) {
 	var err error
-	_, err = testClient.ListAllWAFVersions(&ListAllWAFVersionsInput{
+	_, err = TestClient.ListAllWAFVersions(&ListAllWAFVersionsInput{
 		WAFID: "",
 	})
 	if err != ErrMissingWAFID {
@@ -403,14 +403,14 @@ func TestClient_ListAllWAFVersions_validation(t *testing.T) {
 
 func TestClient_GetWAFVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.GetWAFVersion(&GetWAFVersionInput{
+	_, err = TestClient.GetWAFVersion(&GetWAFVersionInput{
 		WAFID: "",
 	})
 	if err != ErrMissingWAFID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.GetWAFVersion(&GetWAFVersionInput{
+	_, err = TestClient.GetWAFVersion(&GetWAFVersionInput{
 		WAFID:            "1",
 		WAFVersionNumber: 0,
 	})
@@ -421,14 +421,14 @@ func TestClient_GetWAFVersion_validation(t *testing.T) {
 
 func TestClient_UpdateWAFVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.UpdateWAFVersion(&UpdateWAFVersionInput{
+	_, err = TestClient.UpdateWAFVersion(&UpdateWAFVersionInput{
 		WAFID: strToPtr(""),
 	})
 	if err != ErrMissingWAFID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateWAFVersion(&UpdateWAFVersionInput{
+	_, err = TestClient.UpdateWAFVersion(&UpdateWAFVersionInput{
 		WAFID:            strToPtr("1"),
 		WAFVersionNumber: intToPtr(0),
 	})
@@ -436,7 +436,7 @@ func TestClient_UpdateWAFVersion_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.UpdateWAFVersion(&UpdateWAFVersionInput{
+	_, err = TestClient.UpdateWAFVersion(&UpdateWAFVersionInput{
 		WAFID:            strToPtr("1"),
 		WAFVersionNumber: intToPtr(1),
 		WAFVersionID:     strToPtr(""),
@@ -448,14 +448,14 @@ func TestClient_UpdateWAFVersion_validation(t *testing.T) {
 
 func TestClient_LockWAFVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.LockWAFVersion(&LockWAFVersionInput{
+	_, err = TestClient.LockWAFVersion(&LockWAFVersionInput{
 		WAFID: "",
 	})
 	if err != ErrMissingWAFID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.LockWAFVersion(&LockWAFVersionInput{
+	_, err = TestClient.LockWAFVersion(&LockWAFVersionInput{
 		WAFID:            "1",
 		WAFVersionNumber: 0,
 	})
@@ -466,14 +466,14 @@ func TestClient_LockWAFVersion_validation(t *testing.T) {
 
 func TestClient_CloneWAFVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CloneWAFVersion(&CloneWAFVersionInput{
+	_, err = TestClient.CloneWAFVersion(&CloneWAFVersionInput{
 		WAFID: "",
 	})
 	if err != ErrMissingWAFID {
 		t.Errorf("bad error: %s", err)
 	}
 
-	_, err = testClient.CloneWAFVersion(&CloneWAFVersionInput{
+	_, err = TestClient.CloneWAFVersion(&CloneWAFVersionInput{
 		WAFID:            "1",
 		WAFVersionNumber: 0,
 	})
@@ -484,7 +484,7 @@ func TestClient_CloneWAFVersion_validation(t *testing.T) {
 
 func TestClient_DeployWAFVersion_validation(t *testing.T) {
 	var err error
-	err = testClient.DeployWAFVersion(&DeployWAFVersionInput{
+	err = TestClient.DeployWAFVersion(&DeployWAFVersionInput{
 		WAFID: "",
 	})
 
@@ -492,7 +492,7 @@ func TestClient_DeployWAFVersion_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 
-	err = testClient.DeployWAFVersion(&DeployWAFVersionInput{
+	err = TestClient.DeployWAFVersion(&DeployWAFVersionInput{
 		WAFID:            "1",
 		WAFVersionNumber: 0,
 	})
@@ -535,7 +535,7 @@ func TestClient_UpdateWAFVersionInput_HasChanges(t *testing.T) {
 
 func TestClient_CreateEmptyWAFVersion_validation(t *testing.T) {
 	var err error
-	_, err = testClient.CreateEmptyWAFVersion(&CreateEmptyWAFVersionInput{
+	_, err = TestClient.CreateEmptyWAFVersion(&CreateEmptyWAFVersionInput{
 		WAFID: "",
 	})
 

--- a/scripts/fixFixtures.sh
+++ b/scripts/fixFixtures.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 set -e
 
-FASTLY_TEST_SERVICE_ID=${1}
-DEFAULT_TEST_SERVICE_ID=${2}
+FASTLY_TEST_RESOURCE_ID=${1}
+DEFAULT_TEST_RESOURCE_ID=${2}
 FIXTURESDIR="$(pwd)/fastly/fixtures/"
 
 if [[ -z "${1}" ]]; then
-  echo "You must supply a service ID as the first argument"
+  echo "You must supply a resource ID as the first argument"
   exit
 fi
 
 if [[ -z "${2}" ]]; then
-  echo "You must supply a service ID as the second argument"
+  echo "You must supply a resource ID as the second argument"
   exit
 fi
 
-for file in $(grep --recursive --files-with-matches "${FASTLY_TEST_SERVICE_ID}" "${FIXTURESDIR}")
+for file in $(grep --recursive --files-with-matches "${FASTLY_TEST_RESOURCE_ID}" "${FIXTURESDIR}")
 do
-  sed -i "s/${FASTLY_TEST_SERVICE_ID}/${DEFAULT_TEST_SERVICE_ID}/g" "${file}"
+  sed -i "s/${FASTLY_TEST_RESOURCE_ID}/${DEFAULT_TEST_RESOURCE_ID}/g" "${file}"
 done


### PR DESCRIPTION
To support future API endpoints being located outside of the 'fastly' package, a number of types/functions/variables used in the implementations of those endpoints (and their unit tests) need to be exposed from the 'fastly' package.

In addition, the 'fastly_test.go' file must be given a different name, as files named '..._test.go' cannot expose any of their declarations outside of their package.

Finally, add support for Next-Gen WAF workspace IDs along side Delivery and Compute service IDs, as future API endpoints will require them.