### PR TITLE
fix(domains): parse error response correctly

### DIFF
--- a/fastly/domains/v1/fixtures/create.yaml
+++ b/fastly/domains/v1/fixtures/create.yaml
@@ -14,18 +14,18 @@ interactions:
     url: https://api.fastly.com/domains/v1
     method: POST
   response:
-    body: '{"id":"hbRABkI8yvSnUbCLRiqUbQ","created_at":"2025-01-14T14:21:09.000Z","fqdn":"fastly-sdk-gofastly-testing.com","updated_at":"2025-01-14T14:21:09.000Z","service_id":null}'
+    body: '{"id":"bN7Iz1AyGJAZs3q9KFiVYg","created_at":"2025-01-20T18:11:45.000Z","fqdn":"fastly-sdk-gofastly-testing.com","updated_at":"2025-01-20T18:11:45.000Z","service_id":null}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "170"
+      - "171"
       Content-Type:
       - application/json
       Date:
-      - Tue, 14 Jan 2025 14:21:09 GMT
+      - Mon, 20 Jan 2025 18:11:45 GMT
       Pragma:
       - no-cache
       Server:
@@ -41,9 +41,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-chi-kigq8000095-CHI, cache-lon420121-LON
+      - cache-chi-kigq8000095-CHI, cache-lon420104-LON
       X-Timer:
-      - S1736864469.862284,VS0,VE211
+      - S1737396705.078453,VS0,VE201
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/domains/v1/fixtures/create_duplicate.yaml
+++ b/fastly/domains/v1/fixtures/create_duplicate.yaml
@@ -2,22 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"fqdn":"fastly-sdk-gofastly-testing.com","service_id":null}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
-    url: https://api.fastly.com/domains/v1?fqdn=fastly-sdk-gofastly-testing.com&limit=10&sort=fqdn
-    method: GET
+    url: https://api.fastly.com/domains/v1
+    method: POST
   response:
-    body: '{"data":[{"id":"bN7Iz1AyGJAZs3q9KFiVYg","created_at":"2025-01-20T18:11:45.000Z","fqdn":"fastly-sdk-gofastly-testing.com","updated_at":"2025-01-20T18:11:45.000Z","service_id":null}],"meta":{"total":1,"limit":10}}'
+    body: '{"errors":[{"title":"Invalid value for fqdn","detail":"fqdn has already
+      been taken"}]}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "212"
+      - "86"
       Content-Type:
       - application/json
       Date:
@@ -37,9 +42,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-chi-klot8100046-CHI, cache-lon420104-LON
+      - cache-chi-kigq8000095-CHI, cache-lon420104-LON
       X-Timer:
-      - S1737396706.523168,VS0,VE179
-    status: 200 OK
-    code: 200
+      - S1737396705.304617,VS0,VE193
+    status: 400 Bad Request
+    code: 400
     duration: ""

--- a/fastly/domains/v1/fixtures/delete.yaml
+++ b/fastly/domains/v1/fixtures/delete.yaml
@@ -7,7 +7,7 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
-    url: https://api.fastly.com/domains/v1/hbRABkI8yvSnUbCLRiqUbQ
+    url: https://api.fastly.com/domains/v1/bN7Iz1AyGJAZs3q9KFiVYg
     method: DELETE
   response:
     body: ""
@@ -17,7 +17,7 @@ interactions:
       Cache-Control:
       - no-store
       Date:
-      - Tue, 14 Jan 2025 14:21:10 GMT
+      - Mon, 20 Jan 2025 18:11:46 GMT
       Pragma:
       - no-cache
       Server:
@@ -33,9 +33,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-chi-kigq8000030-CHI, cache-lon420121-LON
+      - cache-chi-kigq8000149-CHI, cache-lon420104-LON
       X-Timer:
-      - S1736864470.818474,VS0,VE211
+      - S1737396706.248403,VS0,VE254
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/domains/v1/fixtures/get.yaml
+++ b/fastly/domains/v1/fixtures/get.yaml
@@ -7,21 +7,21 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
-    url: https://api.fastly.com/domains/v1/hbRABkI8yvSnUbCLRiqUbQ
+    url: https://api.fastly.com/domains/v1/bN7Iz1AyGJAZs3q9KFiVYg
     method: GET
   response:
-    body: '{"id":"hbRABkI8yvSnUbCLRiqUbQ","created_at":"2025-01-14T14:21:09.000Z","fqdn":"fastly-sdk-gofastly-testing.com","updated_at":"2025-01-14T14:21:09.000Z","service_id":null}'
+    body: '{"id":"bN7Iz1AyGJAZs3q9KFiVYg","created_at":"2025-01-20T18:11:45.000Z","fqdn":"fastly-sdk-gofastly-testing.com","updated_at":"2025-01-20T18:11:45.000Z","service_id":null}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "170"
+      - "171"
       Content-Type:
       - application/json
       Date:
-      - Tue, 14 Jan 2025 14:21:09 GMT
+      - Mon, 20 Jan 2025 18:11:45 GMT
       Pragma:
       - no-cache
       Server:
@@ -37,9 +37,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-chi-kigq8000030-CHI, cache-lon420121-LON
+      - cache-chi-kigq8000149-CHI, cache-lon420104-LON
       X-Timer:
-      - S1736864469.304457,VS0,VE192
+      - S1737396706.730595,VS0,VE205
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/domains/v1/fixtures/update.yaml
+++ b/fastly/domains/v1/fixtures/update.yaml
@@ -11,21 +11,21 @@ interactions:
       - application/json
       User-Agent:
       - FastlyGo/9.11.0 (+github.com/fastly/go-fastly; go1.20.14)
-    url: https://api.fastly.com/domains/v1/hbRABkI8yvSnUbCLRiqUbQ
+    url: https://api.fastly.com/domains/v1/bN7Iz1AyGJAZs3q9KFiVYg
     method: PATCH
   response:
-    body: '{"id":"hbRABkI8yvSnUbCLRiqUbQ","created_at":"2025-01-14T14:21:09.000Z","fqdn":"fastly-sdk-gofastly-testing.com","updated_at":"2025-01-14T14:21:09.000Z","service_id":"kKJb5bOFI47uHeBVluGfX1"}'
+    body: '{"id":"bN7Iz1AyGJAZs3q9KFiVYg","created_at":"2025-01-20T18:11:45.000Z","fqdn":"fastly-sdk-gofastly-testing.com","updated_at":"2025-01-20T18:11:46.000Z","service_id":"kKJb5bOFI47uHeBVluGfX1"}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "190"
+      - "191"
       Content-Type:
       - application/json
       Date:
-      - Tue, 14 Jan 2025 14:21:09 GMT
+      - Mon, 20 Jan 2025 18:11:46 GMT
       Pragma:
       - no-cache
       Server:
@@ -41,9 +41,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - cache-chi-kigq8000030-CHI, cache-lon420121-LON
+      - cache-chi-kigq8000149-CHI, cache-lon420104-LON
       X-Timer:
-      - S1736864470.527836,VS0,VE260
+      - S1737396706.961460,VS0,VE263
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -458,13 +458,21 @@ func NewHTTPError(resp *http.Response) *HTTPError {
 					if r, ok := le["reason"]; ok {
 						detail, _ = r.(string)
 					}
+					if d, ok := le["detail"]; ok {
+						detail, _ = d.(string)
+					}
+					var title string
 					if i, ok := le["index"]; ok {
 						index, _ = i.(float64)
+						title = fmt.Sprintf("error at index: %v", index)
+					}
+					if t, ok := le["title"]; ok {
+						title, _ = t.(string)
 					}
 					e.Errors = append(e.Errors, &ErrorObject{
 						Code:   code,
 						Detail: detail,
-						Title:  fmt.Sprintf("error at index: %v", index),
+						Title:  title,
 					})
 				}
 			} else {


### PR DESCRIPTION
The UDM `/domains/v1` endpoints do not support the recommended `application/problem+json`.

This resulted in go-fastly incorrectly parsing the error response.

I stumbled into this when integrating the latest go-fastly commit into the Fastly CLI and I accidentally attempted to create the same domain twice. I then was greeted with a very confusing error message that made no sense. I checked the API and found it was returning a more sensible error and so I realised the issue was in go-fastly.

> [!NOTE]
> Even if the UDM API was to update its API response (as it's in beta, this is always possible), this PR is still worth implementing as there may be other APIs returning a similar structure and so this would enable the "legacy" format to handle those cases and return something more useful. 