### PR TITLE
Fix #576: Revert to original sed command for compatibility

### DIFF
--- a/scripts/fixFixtures.sh
+++ b/scripts/fixFixtures.sh
@@ -17,5 +17,5 @@ fi
 
 for file in $(grep --recursive --files-with-matches "${FASTLY_TEST_RESOURCE_ID}" "${FIXTURESDIR}")
 do
-  sed -i "s/${FASTLY_TEST_RESOURCE_ID}/${DEFAULT_TEST_RESOURCE_ID}/g" "${file}"
+  sed -i.bak "s/${FASTLY_TEST_RESOURCE_ID}/${DEFAULT_TEST_RESOURCE_ID}/g" "$file" && rm "${file}.bak"
 done


### PR DESCRIPTION
This PR reverts the `sed` command to its original form as suggested by the maintainer. It ensures compatibility across environments (macOS and Linux) and resolves the bug reported in #576.

### Testing
I executed `make all` after making this change, and here is the output.

```
go-fastly % make all
==> Downloading Go module
==> Downloading development dependencies
Warning: semgrep 1.104.0 is already installed and up-to-date.
To reinstall 1.104.0, run:
  brew reinstall semgrep
==> Tidying module
==> Running gofmt
==> Fixing imports
==> Testing go-fastly
?       github.com/fastly/go-fastly/v9/fastly/domains   [no test files]
?       github.com/fastly/go-fastly/v9/fastly/products  [no test files]
ok      github.com/fastly/go-fastly/v9/fastly   (cached)
ok      github.com/fastly/go-fastly/v9/fastly/domains/v1        (cached)
ok      github.com/fastly/go-fastly/v9/fastly/image_optimizer_default_settings  (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/bot_management   (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/brotli_compression       (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/ddos_protection  (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/domain_inspector (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/fanout   (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/image_optimizer  (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/log_explorer_insights    (cached)
?       github.com/fastly/go-fastly/v9/internal/test_utils      [no test files]
ok      github.com/fastly/go-fastly/v9/fastly/products/ngwaf    (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/origin_inspector (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/websockets       (cached)
ok      github.com/fastly/go-fastly/v9/internal/productcore     (cached)
==> Running go vet
==> Running staticcheck
staticcheck 2023.1.3 (v0.4.3)
if command -v semgrep &> /dev/null; then semgrep ci --config auto --exclude-rule generic.secrets.security.detected-private-key.detected-private-key ; fi
                  
                  
┌────────────────┐
│ Debugging Info │
└────────────────┘
                  
  SCAN ENVIRONMENT
  versions    - semgrep 1.104.0 on python 3.13.1                       
  environment - running in environment git, triggering event is unknown
                                                                                                                        
  Scanning 1263 files (only git-tracked) with 1057 Code rules:
            
  CODE RULES
                                                                                                                        
  Language      Rules   Files          Origin      Rules                                                                
 ─────────────────────────────        ───────────────────                                                               
  <multilang>      47    1144          Community    1057                                                                
  yaml             31     980                                                                                           
  go               83     145                                                                                           
  bash              4       5                                                                                           
                                                                                                                        
                    
  SUPPLY CHAIN RULES
                  
  No rules to run.
                  
          
  PROGRESS
   
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00                                                                                                                        
                
                
┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.
  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
  Scan skipped: 1 files larger than 1.0 MB, 118 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

(need more rules? `semgrep login` for additional free Semgrep Registry rules)

CI scan completed successfully.
  Found 0 findings (0 blocking) from 1057 rules.
  No blocking findings so exiting with code 0
```