### PR TITLE
refactor: Ensure that HTTP response body objects are always closed.

### DIFF
--- a/fastly/automation_token.go
+++ b/fastly/automation_token.go
@@ -142,10 +142,11 @@ type CreateAutomationTokenInput struct {
 //
 // Requires sudo capability for the token being used.
 func (c *Client) CreateAutomationToken(i *CreateAutomationTokenInput) (*AutomationToken, error) {
-	_, err := c.PostForm("/sudo", i, nil)
+	ignored, err := c.PostForm("/sudo", i, nil)
 	if err != nil {
 		return nil, err
 	}
+	defer ignored.Body.Close()
 
 	resp, err := c.PostJSON("/automation-tokens", i, nil)
 	if err != nil {

--- a/fastly/domain.go
+++ b/fastly/domain.go
@@ -189,8 +189,12 @@ func (c *Client) DeleteDomain(i *DeleteDomainInput) error {
 
 	path := ToSafeURL("service", i.ServiceID, "version", strconv.Itoa(i.ServiceVersion), "domain", i.Name)
 
-	_, err := c.Delete(path, nil)
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }
 
 // ValidateDomainInput is used as input to the ValidateDomain function.

--- a/fastly/kv_store.go
+++ b/fastly/kv_store.go
@@ -463,8 +463,12 @@ func (c *Client) InsertKVStoreKey(i *InsertKVStoreKeyInput) error {
 	}
 	defer resp.Body.Close()
 
-	_, err = checkResp(resp, err)
-	return err
+	ignored, err := checkResp(resp, err)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }
 
 // DeleteKVStoreKeyInput is the input to the DeleteKVStoreKey function.
@@ -534,6 +538,10 @@ func (c *Client) BatchModifyKVStoreKey(i *BatchModifyKVStoreKeyInput) error {
 	}
 	defer resp.Body.Close()
 
-	_, err = checkResp(resp, err)
-	return err
+	ignored, err := checkResp(resp, err)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/managed_logging.go
+++ b/fastly/managed_logging.go
@@ -92,6 +92,10 @@ func (c *Client) DeleteManagedLogging(i *DeleteManagedLoggingInput) error {
 		return ErrNotImplemented
 	}
 
-	_, err := c.Delete(path, nil)
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/product_enablement.go
+++ b/fastly/product_enablement.go
@@ -127,6 +127,10 @@ func (c *Client) DisableProduct(i *ProductEnablementInput) error {
 
 	path := ToSafeURL("enabled-products", i.ProductID.String(), "services", i.ServiceID)
 
-	_, err := c.Delete(path, nil)
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/service_authorization.go
+++ b/fastly/service_authorization.go
@@ -219,7 +219,10 @@ func (c *Client) DeleteServiceAuthorization(i *DeleteServiceAuthorizationInput) 
 
 	path := ToSafeURL("service-authorizations", i.ID)
 
-	_, err := c.Delete(path, nil)
-
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/tls_custom_activation.go
+++ b/fastly/tls_custom_activation.go
@@ -221,6 +221,10 @@ func (c *Client) DeleteTLSActivation(i *DeleteTLSActivationInput) error {
 
 	path := ToSafeURL("tls", "activations", i.ID)
 
-	_, err := c.Delete(path, nil)
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/tls_custom_certificate.go
+++ b/fastly/tls_custom_certificate.go
@@ -222,6 +222,10 @@ func (c *Client) DeleteCustomTLSCertificate(i *DeleteCustomTLSCertificateInput) 
 
 	path := ToSafeURL("tls", "certificates", i.ID)
 
-	_, err := c.Delete(path, nil)
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/tls_mutual_authentication.go
+++ b/fastly/tls_mutual_authentication.go
@@ -204,6 +204,10 @@ func (c *Client) DeleteTLSMutualAuthentication(i *DeleteTLSMutualAuthenticationI
 
 	path := ToSafeURL("tls", "mutual_authentications", i.ID)
 
-	_, err := c.Delete(path, nil)
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/tls_platform.go
+++ b/fastly/tls_platform.go
@@ -236,6 +236,10 @@ func (c *Client) DeleteBulkCertificate(i *DeleteBulkCertificateInput) error {
 
 	path := ToSafeURL("tls", "bulk", "certificates", i.ID)
 
-	_, err := c.Delete(path, nil)
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/tls_private_keys.go
+++ b/fastly/tls_private_keys.go
@@ -164,6 +164,10 @@ func (c *Client) DeletePrivateKey(i *DeletePrivateKeyInput) error {
 
 	path := ToSafeURL("tls", "private_keys", i.ID)
 
-	_, err := c.Delete(path, nil)
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/tls_subscription.go
+++ b/fastly/tls_subscription.go
@@ -319,6 +319,10 @@ func (c *Client) DeleteTLSSubscription(i *DeleteTLSSubscriptionInput) error {
 
 	path := ToSafeURL("tls", "subscriptions", i.ID)
 
-	_, err := c.Delete(path, &ro)
-	return err
+	ignored, err := c.Delete(path, &ro)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/token.go
+++ b/fastly/token.go
@@ -118,10 +118,11 @@ type CreateTokenInput struct {
 
 // CreateToken creates a new resource.
 func (c *Client) CreateToken(i *CreateTokenInput) (*Token, error) {
-	_, err := c.PostForm("/sudo", i, nil)
+	ignored, err := c.PostForm("/sudo", i, nil)
 	if err != nil {
 		return nil, err
 	}
+	defer ignored.Body.Close()
 
 	resp, err := c.PostForm("/tokens", i, nil)
 	if err != nil {
@@ -194,6 +195,10 @@ func (c *Client) BatchDeleteTokens(i *BatchDeleteTokensInput) error {
 	if len(i.Tokens) == 0 {
 		return ErrMissingTokensValue
 	}
-	_, err := c.DeleteJSONAPIBulk("/tokens", i.Tokens, nil)
-	return err
+	ignored, err := c.DeleteJSONAPIBulk("/tokens", i.Tokens, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/waf.go
+++ b/fastly/waf.go
@@ -273,8 +273,12 @@ func (c *Client) DeleteWAF(i *DeleteWAFInput) error {
 
 	path := ToSafeURL("waf", "firewalls", i.ID)
 
-	_, err := c.DeleteJSONAPI(path, i, nil)
-	return err
+	ignored, err := c.DeleteJSONAPI(path, i, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }
 
 // infoResponse is used to pull the links and meta from the result.

--- a/fastly/waf_active_rule.go
+++ b/fastly/waf_active_rule.go
@@ -298,6 +298,10 @@ func (c *Client) DeleteWAFActiveRules(i *DeleteWAFActiveRulesInput) error {
 
 	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "active-rules")
 
-	_, err := c.DeleteJSONAPIBulk(path, i.Rules, nil)
-	return err
+	ignored, err := c.DeleteJSONAPIBulk(path, i.Rules, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/waf_rule_exclusion.go
+++ b/fastly/waf_rule_exclusion.go
@@ -304,6 +304,10 @@ func (c *Client) DeleteWAFRuleExclusion(i *DeleteWAFRuleExclusionInput) error {
 
 	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "exclusions", strconv.Itoa(i.Number))
 
-	_, err := c.Delete(path, nil)
-	return err
+	ignored, err := c.Delete(path, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }

--- a/fastly/waf_version.go
+++ b/fastly/waf_version.go
@@ -437,8 +437,12 @@ func (c *Client) DeployWAFVersion(i *DeployWAFVersionInput) error {
 
 	path := ToSafeURL("waf", "firewalls", i.WAFID, "versions", strconv.Itoa(i.WAFVersionNumber), "activate")
 
-	_, err := c.PutJSONAPI(path, &DeployWAFVersionInput{}, nil)
-	return err
+	ignored, err := c.PutJSONAPI(path, &DeployWAFVersionInput{}, nil)
+	if err != nil {
+		return err
+	}
+	defer ignored.Body.Close()
+	return nil
 }
 
 // CreateEmptyWAFVersionInput creates a new resource.


### PR DESCRIPTION
This PR fixes a potential resource leak issue in our code. Previously, the HTTP response body was being ignored in cases like:
```
_, err := c.PostForm("/sudo", i, nil)
```
This oversight could lead to resource exhaustion over time. ([Reference](https://stackoverflow.com/a/33238755/2949645))


### Changes:
	•	Explicitly added resp.Body.Close() in all relevant places where HTTP requests are made.
	•	Ensures that resources are properly released after the response is handled.

### Testing
I ran `make all` and this is my output after these changes

```
go-fastly % make all
==> Downloading Go module
==> Downloading development dependencies
Warning: semgrep 1.104.0 is already installed and up-to-date.
To reinstall 1.104.0, run:
	brew reinstall semgrep
==> Tidying module
==> Running gofmt
==> Fixing imports
==> Testing go-fastly
?       github.com/fastly/go-fastly/v9/fastly/domains   [no test files]
?       github.com/fastly/go-fastly/v9/fastly/products  [no test files]
?       github.com/fastly/go-fastly/v9/internal/test_utils      [no test files]
ok      github.com/fastly/go-fastly/v9/fastly   2.628s
ok      github.com/fastly/go-fastly/v9/fastly/computeacls       (cached)
ok      github.com/fastly/go-fastly/v9/fastly/domains/v1        (cached)
ok      github.com/fastly/go-fastly/v9/fastly/imageoptimizerdefaultsettings     (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/botmanagement    (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/brotlicompression        (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/ddosprotection   (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/domaininspector  (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/fanout   (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/imageoptimizer   (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/logexplorerinsights      (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/ngwaf    (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/origininspector  (cached)
ok      github.com/fastly/go-fastly/v9/fastly/products/websockets       (cached)
ok      github.com/fastly/go-fastly/v9/internal/productcore     (cached)
==> Running go vet
==> Running staticcheck
staticcheck 2023.1.7 (v0.4.7)
if command -v semgrep &> /dev/null; then semgrep ci --config auto --exclude-rule generic.secrets.security.detected-private-key.detected-private-key ; fi
					
					
┌────────────────┐
│ Debugging Info │
└────────────────┘
					
	SCAN ENVIRONMENT
	versions    - semgrep 1.104.0 on python 3.13.1                       
	environment - running in environment git, triggering event is unknown
																														
	Scanning 1282 files (only git-tracked) with 1057 Code rules:
			
	CODE RULES
																														
	Language      Rules   Files          Origin      Rules                                                                
	─────────────────────────────        ───────────────────                                                               
	<multilang>      47    1162          Community    1057                                                                
	yaml             31     988                                                                                           
	go               83     153                                                                                           
	bash              4       5                                                                                           
																														
					
	SUPPLY CHAIN RULES
					
	No rules to run.
					
			
	PROGRESS
	
	━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00                                                                                                                        
				
				
┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
	Scan was limited to files tracked by git.
	Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
	Scan skipped: 1 files larger than 1.0 MB, 119 files matching .semgrepignore patterns
	For a full list of skipped files, run semgrep with the --verbose flag.

(need more rules? `semgrep login` for additional free Semgrep Registry rules)

CI scan completed successfully.
	Found 0 findings (0 blocking) from 1057 rules.
	No blocking findings so exiting with code 0

```