### PR TITLE
Allow untrusted root option on CreateCustomTLSCertificateInput

### DIFF
--- a/fastly/tls_custom_certificate.go
+++ b/fastly/tls_custom_certificate.go
@@ -145,6 +145,11 @@ type CreateCustomTLSCertificateInput struct {
 	ID string `jsonapi:"primary,tls_certificate"` // ID value does not need to be set.
 	// Name is a customizable name for your certificate.
 	Name string `jsonapi:"attr,name,omitempty"`
+	// AllowUntrustedRoot enables the upload of a certificate signed by a self-signing CA as the root.
+	// The main use case for enabling this setting is to enable a fully localized development setup where you are generating your own certificates.
+	// In most cases, this setting should never be turned on since it makes it possible for the uploading of conflicting certificates that may interfere with production traffic.
+	// If you are going to enable this feature make sure to take proper precaution and only upload self-signed certificates that certify "dummy" domains that do not overlap with the actual domains you own.
+	AllowUntrustedRoot `jsonapi:"attr,allow_untrusted_root,omitempty"`
 }
 
 // CreateCustomTLSCertificate creates a new resource.

--- a/fastly/tls_custom_certificate.go
+++ b/fastly/tls_custom_certificate.go
@@ -149,7 +149,7 @@ type CreateCustomTLSCertificateInput struct {
 	// The main use case for enabling this setting is to enable a fully localized development setup where you are generating your own certificates.
 	// In most cases, this setting should never be turned on since it makes it possible for the uploading of conflicting certificates that may interfere with production traffic.
 	// If you are going to enable this feature make sure to take proper precaution and only upload self-signed certificates that certify "dummy" domains that do not overlap with the actual domains you own.
-	AllowUntrustedRoot `jsonapi:"attr,allow_untrusted_root,omitempty"`
+	AllowUntrustedRoot bool `jsonapi:"attr,allow_untrusted_root,omitempty"`
 }
 
 // CreateCustomTLSCertificate creates a new resource.

--- a/fastly/tls_custom_configuration_test.go
+++ b/fastly/tls_custom_configuration_test.go
@@ -118,3 +118,12 @@ func TestClient_UpdateCustomTLSConfiguration_validation(t *testing.T) {
 		t.Errorf("bad error: %s", err)
 	}
 }
+
+func TestClient_CreateCustomTLSCertificateInput_default_values(t *testing.T) {
+	t.Parallel()
+
+	certificateInput := CreateCustomTLSCertificateInput{}
+	if certificateInput.AllowUntrustedRoot {
+		t.Errorf("allow untrusted root attribute cannot be enabled by default")
+	}
+}


### PR DESCRIPTION
# Details

The fastly api for creating / uploading custom TLS certificates allows for passing in the `allow_untrusted_root` flag, indicating that a self signed CA (untrusted) is permitted to sign the server auth certificates that get uploaded.

The go-fastly client does not support this flag, presumably because exposing this option could potentially lead to negative consequences (someone uploading a self signed cert that browsers don't trust for a domain that is already seeing production traffic).

Without this change, we (SeatGeek) am unable to have a fully localized test environment leveraging a self signed CA that I create on the fly to test / validate our integration with the fastly custom tls cert upload process.

## Rationale

* This attribute `allow_untrusted_root` is available on the API, so it should also be present on the official sdk.
* This attribute is off by default, with a full description of the drawbacks to using this flag.
* Even if clients were to set this flag, **this feature is still gated behind an account level flag** that must be turned on by someone internal to Fastly.

Given the multiple layers of protection and the "default off" behavior of this flag, I think that this attribute can be safely reflected in the schema without consequence to customers

Without this, we wont be able to leverage the go-fastly client which would be a bummer.

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

* [x] What is the user impact of this change?

This change is backwards compatible with existing behavior.

This change will allow clients to enable `allow_untrusted_root` when uploading a custom TLS cert

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->
None