### PR TITLE
build(go): upgrade Go from 1.20 to 1.22

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
+        go-version: 1.22.x
     - name: Installing necessary tools
       run: make dev-dependencies
       shell: bash
@@ -31,7 +31,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.22.x]
+        go-version: [1.22.x, 1.23.x, 1.24.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 
 **Enhancements:**
 
-- build(pr_test.yml): add changelog diff check to pr flow
+- build(pr_test.yml): add changelog diff check to pr flow [#604](https://github.com/fastly/go-fastly/pull/604)
 
 **Bug fixes:**
 
 **Dependencies:**
+
+- build(deps): upgrade Go from 1.20 to 1.22 [#606](https://github.com/fastly/go-fastly/pull/606)
 
 ## [v9.13.0](https://github.com/fastly/go-fastly/releases/tag/v9.13.0) (2025-01-27)
 

--- a/go.mod
+++ b/go.mod
@@ -26,4 +26,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.20
+go 1.22.0

--- a/go.sum
+++ b/go.sum
@@ -42,4 +42,5 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+honnef.co/go/tools v0.5.1 h1:4bH5o3b5ZULQ4UrBmP+63W9r7qIkqJClEA9ko5YKx+I=
 honnef.co/go/tools v0.5.1/go.mod h1:e9irvo83WDG9/irijV44wr3tbhcFeRnfpVlRqVwpzMs=


### PR DESCRIPTION
Upgraded Go by running the following commands:

```
$ go1.22.12 mod edit -go 1.22.0
$ go1.22.12 mod tidy
```

All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?