### PR TITLE
fix(automation_tokens): Fix decodeBodyMap for string to time.Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug fixes:
 
+ - fix(automation_tokens): Fix decodeBodyMap for string to time.Time [#619](https://github.com/fastly/go-fastly/pull/619)
+
 ### Dependencies:
 
 - build(deps): `github.com/google/go-cmp` from 0.6.0 to 0.7.0 ([#617](https://github.com/fastly/go-fastly/pull/617))

--- a/fastly/automation_token.go
+++ b/fastly/automation_token.go
@@ -123,7 +123,7 @@ type CreateAutomationTokenInput struct {
 	ExpiresAt *time.Time `json:"expires_at,omitempty" url:"expires_at,omitempty"`
 	// Name is the name of the token.
 	Name string `json:"name" url:"name,omitempty"`
-	// Password is the token password.
+	// Password is the password of the user the token is assigned to.
 	Password *string `json:"-" url:"password,omitempty"`
 	// Role is the role on the token (billing, engineer, user).
 	Role AutomationTokenRole `json:"role" url:"role,omitempty"`

--- a/fastly/automation_token.go
+++ b/fastly/automation_token.go
@@ -120,7 +120,7 @@ func (c *Client) GetAutomationToken(i *GetAutomationTokenInput) (*AutomationToke
 // CreateAutomationTokenInput is used as input to the CreateAutomationToken function.
 type CreateAutomationTokenInput struct {
 	// ExpiresAt is a time-stamp (UTC) of when the token will expire.
-	ExpiresAt time.Time `json:"expires_at" url:"expires_at,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty" url:"expires_at,omitempty"`
 	// Name is the name of the token.
 	Name string `json:"name" url:"name,omitempty"`
 	// Password is the token password.

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -743,8 +743,13 @@ func stringToTimeHookFunc() mapstructure.DecodeHookFunc {
 			return data, nil
 		}
 
-		// Attempt parsing in RFC3339 format
+		// Fallback to time.Time zero value for empty string
 		str, _ := data.(string) // Safe type assertion; guaranteed by f.Kind()
+		if str == "" {
+			return time.Time{}, nil
+		}
+
+		// Attempt parsing in RFC3339 format
 		if v, err := time.Parse(time.RFC3339, str); err == nil {
 			return v, nil
 		}

--- a/fastly/fixtures/automation_tokens/create.yaml
+++ b/fastly/fixtures/automation_tokens/create.yaml
@@ -18,11 +18,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.22.2)
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
     url: https://api.fastly.com/sudo
     method: POST
   response:
-    body: '{"expiry_time":"2024-09-21T04:01:00+00:00"}'
+    body: '{"expiry_time":"2025-02-25T05:17:56+00:00"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -31,15 +31,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 21 Sep 2024 03:56:00 GMT
+      - Tue, 25 Feb 2025 05:12:56 GMT
       Fastly-Ratelimit-Remaining:
-      - "975"
+      - "978"
       Fastly-Ratelimit-Reset:
-      - "1726891200"
+      - "1740463200"
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -53,14 +53,14 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000058-CHI, cache-per12629-PER
+      - cache-chi-kigq8000020-CHI, cache-per12626-PER
       X-Timer:
-      - S1726890960.858190,VS0,VE534
+      - S1740460377.510933,VS0,VE487
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"expires_at":"0001-01-01T00:00:00Z","name":"my-test-token","role":"engineer","scope":"global","services":null,"tls_access":false}'
+    body: '{"name":"my-test-token","role":"engineer","scope":"global","services":null,"tls_access":false}'
     form: {}
     headers:
       Accept:
@@ -68,33 +68,33 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.22.2)
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
     url: https://api.fastly.com/automation-tokens
     method: POST
   response:
     body: |
-      {"id":"XXXXXXXXXXXXXXXXXXXXXX","services":[],"name":"my-test-token","role":"engineer","access_token":"XXXXXXXXXXXXXXXXXXXXXX","scope":"global","ip":"","created_at":"2024-09-21T03:56:00Z","last_used_at":"0001-01-01T00:00:00Z","expires_at":null,"user_agent":""}
+      {"id":"XXXXXXXXXXXXXXXXXXXXXX","services":[],"name":"my-test-token","role":"engineer","access_token":"XXXXXXXXXXXXXXXXXXXXXX","scope":"global","ip":"","created_at":"2025-02-25T05:12:57Z","last_used_at":"","expires_at":"","user_agent":"","tls_access":false,"customer_id":"XXXXXXXXXXXXXXXXXXXXXX"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "270"
+      - "304"
       Content-Type:
       - application/json
       Date:
-      - Sat, 21 Sep 2024 03:56:01 GMT
-      Fastly-Ratelimit-Remaining:
-      - "993"
-      Fastly-Ratelimit-Reset:
-      - "1726891200"
+      - Tue, 25 Feb 2025 05:12:57 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly control-gateway
+      Status:
+      - 200 OK
       Strict-Transport-Security:
       - max-age=31536000
+      Vary:
+      - Accept-Encoding
       Via:
       - 1.1 varnish, 1.1 varnish
       X-Cache:
@@ -102,9 +102,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000082-CHI, cache-per12629-PER
+      - cache-chi-kigq8000135-CHI, cache-per12626-PER
       X-Timer:
-      - S1726890960.404951,VS0,VE753
+      - S1740460377.012887,VS0,VE685
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/automation_tokens/create.yaml
+++ b/fastly/fixtures/automation_tokens/create.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: name=my-test-token&password=XXXXXXXXXXXXXXXXXXXXXX&role=engineer&scope=global&username=XXXXXXXXXXXXXXXXXXXXXX
+    body: name=my-test-token&password=XXXXXXXXXXXXXXXXXXXXXX&role=engineer&scope=global&services%5B%5D=XXXXXXXXXXXXXXXXXXXXXX&username=XXXXXXXXXXXXXXXXXXXXXX
     form:
       name:
       - my-test-token
@@ -12,6 +12,8 @@ interactions:
       - engineer
       scope:
       - global
+      services[]:
+      - XXXXXXXXXXXXXXXXXXXXXX
       username:
       - XXXXXXXXXXXXXXXXXXXXXX
     headers:
@@ -22,7 +24,7 @@ interactions:
     url: https://api.fastly.com/sudo
     method: POST
   response:
-    body: '{"expiry_time":"2025-02-25T05:17:56+00:00"}'
+    body: '{"expiry_time":"2025-02-25T12:06:38+00:00"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -31,11 +33,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Feb 2025 05:12:56 GMT
+      - Tue, 25 Feb 2025 12:01:38 GMT
       Fastly-Ratelimit-Remaining:
-      - "978"
+      - "993"
       Fastly-Ratelimit-Reset:
-      - "1740463200"
+      - "1740488400"
       Pragma:
       - no-cache
       Server:
@@ -53,14 +55,14 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000020-CHI, cache-per12626-PER
+      - cache-chi-kigq8000020-CHI, cache-per12621-PER
       X-Timer:
-      - S1740460377.510933,VS0,VE487
+      - S1740484898.443480,VS0,VE471
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"my-test-token","role":"engineer","scope":"global","services":null,"tls_access":false}'
+    body: '{"name":"my-test-token","role":"engineer","scope":"global","services":["XXXXXXXXXXXXXXXXXXXXXX"],"tls_access":false}'
     form: {}
     headers:
       Accept:
@@ -73,18 +75,18 @@ interactions:
     method: POST
   response:
     body: |
-      {"id":"XXXXXXXXXXXXXXXXXXXXXX","services":[],"name":"my-test-token","role":"engineer","access_token":"XXXXXXXXXXXXXXXXXXXXXX","scope":"global","ip":"","created_at":"2025-02-25T05:12:57Z","last_used_at":"","expires_at":"","user_agent":"","tls_access":false,"customer_id":"XXXXXXXXXXXXXXXXXXXXXX"}
+      {"id":"XXXXXXXXXXXXXXXXXXXXXX","services":["XXXXXXXXXXXXXXXXXXXXXX"],"name":"my-test-token","role":"engineer","access_token":"XXXXXXXXXXXXXXXXXXXXXX","scope":"global","ip":"","created_at":"2025-02-25T12:01:39Z","last_used_at":"","expires_at":"","user_agent":"","tls_access":false,"customer_id":"XXXXXXXXXXXXXXXXXXXXXX"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "304"
+      - "329"
       Content-Type:
       - application/json
       Date:
-      - Tue, 25 Feb 2025 05:12:57 GMT
+      - Tue, 25 Feb 2025 12:01:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -102,9 +104,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000135-CHI, cache-per12626-PER
+      - cache-chi-kigq8000135-CHI, cache-per12621-PER
       X-Timer:
-      - S1740460377.012887,VS0,VE685
+      - S1740484899.929537,VS0,VE681
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/automation_tokens/delete.yaml
+++ b/fastly/fixtures/automation_tokens/delete.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.22.2)
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
     url: https://api.fastly.com/tokens/XXXXXXXXXXXXXXXXXXXXXX
     method: DELETE
   response:
@@ -17,15 +17,15 @@ interactions:
       Cache-Control:
       - no-store
       Date:
-      - Sat, 21 Sep 2024 03:56:00 GMT
+      - Tue, 25 Feb 2025 05:15:04 GMT
       Fastly-Ratelimit-Remaining:
       - "976"
       Fastly-Ratelimit-Reset:
-      - "1726891200"
+      - "1740463200"
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly control-gateway
       Status:
       - 204 No Content
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100064-CHI, cache-per12629-PER
+      - cache-chi-kigq8000084-CHI, cache-per12627-PER
       X-Timer:
-      - S1726890960.858157,VS0,VE659
+      - S1740460504.631124,VS0,VE503
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/fixtures/automation_tokens/get.yaml
+++ b/fastly/fixtures/automation_tokens/get.yaml
@@ -6,27 +6,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.22.2)
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
     url: https://api.fastly.com/automation-tokens/XXXXXXXXXXXXXXXXXXXXXX
     method: GET
   response:
     body: |
-      {"id":"XXXXXXXXXXXXXXXXXXXXXX","services":["kKJb5bOFI47uHeBVluGfX1"],"name":"test-token","role":"engineer","access_token":"","scope":"global","ip":null,"created_at":"2024-09-21T03:50:43Z","last_used_at":null,"expires_at":null,"user_agent":null}
+      {"id":"XXXXXXXXXXXXXXXXXXXXXX","services":null,"name":"my-test-token","role":"engineer","access_token":"","scope":"global","ip":null,"created_at":"2025-02-25T05:12:57Z","last_used_at":null,"expires_at":null,"user_agent":null}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "270"
+      - "225"
       Content-Type:
       - application/json
       Date:
-      - Sat, 21 Sep 2024 03:56:00 GMT
+      - Tue, 25 Feb 2025 05:13:56 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly control-gateway
       Strict-Transport-Security:
       - max-age=31536000
       Via:
@@ -36,9 +36,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100074-CHI, cache-per12629-PER
+      - cache-chi-klot8100158-CHI, cache-per12626-PER
       X-Timer:
-      - S1726890960.858137,VS0,VE346
+      - S1740460436.009064,VS0,VE312
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/automation_tokens/list.yaml
+++ b/fastly/fixtures/automation_tokens/list.yaml
@@ -6,27 +6,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.8.0 (+github.com/fastly/go-fastly; go1.22.2)
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
     url: https://api.fastly.com/automation-tokens?page=1&per_page=100
     method: GET
   response:
     body: |
-      {"data":[{"id":"XXXXXXXXXXXXXXXXXXXXXX","creator_id":"XXXXXXXXXXXXXXXXXXXXXX","customer_id":"XXXXXXXXXXXXXXXXXXXXXX","name":"my-test-token","access_token":"","role":"engineer","ip":null,"user_agent":null,"scopes":"global","services":[],"service_id":null,"sudo_expires_at":null,"last_used_at":null,"created_at":"2024-09-21T03:56:00Z","expires_at":null,"tls_access":false}],"meta":{"per_page":100,"current_page":1,"record_count":1,"total_pages":1}}
+      {"data":[{"id":"XXXXXXXXXXXXXXXXXXXXXX","creator_id":"XXXXXXXXXXXXXXXXXXXXXX","customer_id":"XXXXXXXXXXXXXXXXXXXXXX","name":"fastly-exporter","access_token":"","role":"engineer","ip":"116.255.31.196","user_agent":"Fastly-Exporter (9.0.0)","scopes":"global:read","services":[],"service_id":null,"sudo_expires_at":null,"last_used_at":"2025-02-22T03:27:50Z","created_at":"2024-10-15T11:51:55Z","expires_at":null,"tls_access":false},{"id":"XXXXXXXXXXXXXXXXXXXXXX","creator_id":"XXXXXXXXXXXXXXXXXXXXXX","customer_id":"XXXXXXXXXXXXXXXXXXXXXX","name":"my-test-token","access_token":"","role":"engineer","ip":null,"user_agent":null,"scopes":"global","services":null,"service_id":null,"sudo_expires_at":null,"last_used_at":null,"created_at":"2025-02-25T05:12:57Z","expires_at":null,"tls_access":false}],"meta":{"per_page":100,"current_page":1,"record_count":2,"total_pages":1}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "445"
+      - "864"
       Content-Type:
       - application/json
       Date:
-      - Sat, 21 Sep 2024 04:30:21 GMT
+      - Tue, 25 Feb 2025 05:14:22 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly control-gateway
       Strict-Transport-Security:
       - max-age=31536000
       Via:
@@ -36,9 +36,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100166-CHI, cache-per12624-PER
+      - cache-chi-klot8100115-CHI, cache-per12625-PER
       X-Timer:
-      - S1726893021.414551,VS0,VE346
+      - S1740460462.015453,VS0,VE317
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Resolves #575 

This change resolves the issue in decodeBodyMap when attempting to parse strings as `time.Time` when the returned value is an empty string.

It appears the API changed its default behaviour since support for `AutomationTokens` was added, most notably:
- In the request it used to accept the zero value of `time.Time` (`0001-01-01T00:00:00Z`) for `ExpiresAt` which resulted in a token with no expiry (`"expires_at":null`)
    - This no longer works and a time in the past is invalid input, to create a token with no expiry you must explicitly set `"expires_at":null` or omit it from the request.
 - In the response it used to return the zero value of `time.Time` for `last_used_at` (can be seen in the diff for the test fixtures) which decoded fine but the default response has changed to an empty string which now fails to parse.
     - A token with no expiry now returns `"expires_at":""` which will result in the same error being seen by `"last_used_at":""` in the linked issue.

### Are there any considerations that need to be addressed for release?

This should be low risk as the change only impacts the decoding of objects that have a `time.Time` field, and only changes the behaviour if the endpoint returned an empty string for that field - meaning the endpoint wouldn't currently work without this change.