### PR TITLE
build(go.mod): upgrade go to 1.23.6 from 1.22.0

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.x
+        go-version: 1.23.x
     - name: Installing necessary tools
       run: make dev-dependencies
       shell: bash
@@ -51,7 +51,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.23.x, 1.24.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Dependencies:
 - build(deps): `github.com/google/go-cmp` from 0.6.0 to 0.7.0 ([#617](https://github.com/fastly/go-fastly/pull/617))
+- build(deps): upgrade go to 1.23.6
 
 ## [v9.13.1](https://github.com/fastly/go-fastly/releases/tag/v9.13.1) (2025-02-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 ### Bug fixes:
 
 ### Dependencies:
+
 - build(deps): `github.com/google/go-cmp` from 0.6.0 to 0.7.0 ([#617](https://github.com/fastly/go-fastly/pull/617))
-- build(deps): upgrade go to 1.23.6
+- build(deps): upgrade Go from 1.22 to 1.23 ([#624](https://github.com/fastly/go-fastly/pull/624/files))
 
 ## [v9.13.1](https://github.com/fastly/go-fastly/releases/tag/v9.13.1) (2025-02-14)
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ mod-download: ## Downloads the Go module.
 
 dev-dependencies: ## Downloads the necessary dev dependencies.
 	@echo "==> Downloading development dependencies"
-	@$(GO) install honnef.co/go/tools/cmd/staticcheck@v0.4.7
+	@$(GO) install honnef.co/go/tools/cmd/staticcheck@v0.6.0
 	@$(GO) install golang.org/x/tools/cmd/goimports@v0.24.0
 	@if [[ "$$(uname)" == 'Darwin' ]]; then brew install semgrep; fi
 .PHONY: dev-dependencies

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ mod-download: ## Downloads the Go module.
 dev-dependencies: ## Downloads the necessary dev dependencies.
 	@echo "==> Downloading development dependencies"
 	@$(GO) install honnef.co/go/tools/cmd/staticcheck@v0.6.0
-	@$(GO) install golang.org/x/tools/cmd/goimports@v0.24.0
+	@$(GO) install golang.org/x/tools/cmd/goimports@v0.30.0
 	@if [[ "$$(uname)" == 'Darwin' ]]; then brew install semgrep; fi
 .PHONY: dev-dependencies
 

--- a/go.mod
+++ b/go.mod
@@ -26,5 +26,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.22.0
-toolchain go1.22.5
+go 1.23.0
+
+toolchain go1.23.6


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

### Are there any considerations that need to be addressed for release?
I don't think we need to tell people we are upgrading to 1.23.6, but happy to open it up to discussions

Various dependabot upgrades require 1.23 ([618](https://github.com/fastly/go-fastly/pull/618) and [610](https://github.com/fastly/go-fastly/pull/610))