### PR TITLE
Improve reliability of KV Store API tests

### DIFF
--- a/fastly/kv_store_test.go
+++ b/fastly/kv_store_test.go
@@ -6,12 +6,34 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// wait for generation marker of testKey to change
+func waitForItemGeneration(t *testing.T, storeID, key string, generation uint64) {
+	// these API operations are intentionally not wrapped in Record()
+	require.EventuallyWithT(
+		t,
+		func(c *assert.CollectT) {
+			updatedItem, err := DefaultClient().GetKVStoreItem(&GetKVStoreItemInput{
+				StoreID: storeID,
+				Key:     key,
+			})
+			assert.NoErrorf(c, err, "fetching key %q", key)
+			assert.NotEqual(c, generation, updatedItem.Generation, "generation marker change")
+		},
+		3*time.Second,
+		1*time.Second,
+		"updated item is not readable",
+	)
+}
+
 func TestClient_KVStore(t *testing.T) {
+	// wrapper objects to simplify invocation of functions in the
+	// 'assert' and 'require' modules
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -188,6 +210,8 @@ func TestClient_KVStore(t *testing.T) {
 		expectedMetadata = "meta"
 	})
 
+	waitForItemGeneration(t, kvStore.StoreID, testKey, item.Generation)
+
 	Record(t, "kv_store/get-item-round-2", func(c *Client) {
 		updatedItem, err := c.GetKVStoreItem(&GetKVStoreItemInput{
 			StoreID: kvStore.StoreID,
@@ -228,6 +252,8 @@ func TestClient_KVStore(t *testing.T) {
 
 		expectedValue = expectedValue + "suffix"
 	})
+
+	waitForItemGeneration(t, kvStore.StoreID, testKey, item.Generation)
 
 	Record(t, "kv_store/get-item-round-3", func(c *Client) {
 		updatedItem, err := c.GetKVStoreItem(&GetKVStoreItemInput{


### PR DESCRIPTION
Writing and then reading an item in the KV Store can sometimes fail, as the newly-written content has to replace the existing content in the cache and that does not happen instantaneously.

This PR adds logic to loop for up to 3 seconds in the KV Store tests to ensure that the newly-written content can be read.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [X] Does your submission pass tests?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### User Impact

* [ ] What is the user impact of this change?

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->