### PR TITLE
Correct type of 'Priority' field for VCL snippets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/fastly/go-fastly/compare/v9.14.0...)
 
+### Breaking:
+
+- fix(vcl_snippets): Correct type of 'Priority' field from integer to string.
+
 ### Enhancements:
 
 ### Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking:
 
-- fix(vcl_snippets): Correct type of 'Priority' field from integer to string.
+- fix(vcl_snippets): Correct type of 'Priority' field from integer to string. [#644](https://github.com/fastly/go-fastly/pull/644)
 
 ### Enhancements:
 

--- a/fastly/fixtures/vcl_snippets/create_with_all_fields.yaml
+++ b/fastly/fixtures/vcl_snippets/create_with_all_fields.yaml
@@ -18,11 +18,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/88/snippet
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/36/snippet
     method: POST
   response:
-    body: '{"content":null,"dynamic":1,"name":"snipdyn","priority":"123","type":"fetch","service_id":"kKJb5bOFI47uHeBVluGfX1","version":"88","updated_at":"2022-11-07T12:19:34Z","created_at":"2022-11-07T12:19:34Z","id":"ZoMomE3AaTnyJjM4cslCA1","deleted_at":null}'
+    body: '{"content":null,"dynamic":"1","name":"snipdyn","priority":"123","type":"fetch","service_id":"kKJb5bOFI47uHeBVluGfX1","version":"36","created_at":"2025-03-20T18:15:36Z","updated_at":"2025-03-20T18:15:36Z","id":"lE4es0twkrfKltSI0nU1k0","deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -31,11 +31,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:34 GMT
+      - Thu, 20 Mar 2025 18:15:37 GMT
       Fastly-Ratelimit-Remaining:
-      - "9990"
+      - "9997"
       Fastly-Ratelimit-Reset:
-      - "1667826000"
+      - "1742497200"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -49,9 +53,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-kigq8000082-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823575.777307,VS0,VE203
+      - S1742494537.837657,VS0,VE169
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/vcl_snippets/create_with_required_fields_only.yaml
+++ b/fastly/fixtures/vcl_snippets/create_with_required_fields_only.yaml
@@ -16,11 +16,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/88/snippet
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/36/snippet
     method: POST
   response:
-    body: '{"content":"#vcl","dynamic":0,"name":"snipver","type":"fetch","service_id":"kKJb5bOFI47uHeBVluGfX1","version":"88","priority":100,"deleted_at":null,"created_at":"2022-11-07T12:19:34Z","id":"WT2ibuLy1IEgBOgN7ZvtI4","updated_at":"2022-11-07T12:19:34Z"}'
+    body: '{"content":"#vcl","dynamic":"0","name":"snipver","type":"fetch","service_id":"kKJb5bOFI47uHeBVluGfX1","version":"36","created_at":"2025-03-20T18:15:36Z","deleted_at":null,"updated_at":"2025-03-20T18:15:36Z","priority":"100","id":"i33J0p7U8HIVZDGqxncM92"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -29,11 +29,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:34 GMT
+      - Thu, 20 Mar 2025 18:15:36 GMT
       Fastly-Ratelimit-Remaining:
-      - "9991"
+      - "9998"
       Fastly-Ratelimit-Reset:
-      - "1667826000"
+      - "1742497200"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +51,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-kigq8000082-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823574.462572,VS0,VE281
+      - S1742494537.631634,VS0,VE193
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/vcl_snippets/delete_dynamic.yaml
+++ b/fastly/fixtures/vcl_snippets/delete_dynamic.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/88/snippet/snipdyn
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/36/snippet/snipdyn
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:37 GMT
+      - Thu, 20 Mar 2025 18:15:38 GMT
       Fastly-Ratelimit-Remaining:
-      - "9986"
+      - "9993"
       Fastly-Ratelimit-Reset:
-      - "1667826000"
+      - "1742497200"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-2-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-klot8100037-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823577.933810,VS0,VE198
+      - S1742494538.467157,VS0,VE227
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/vcl_snippets/delete_versioned.yaml
+++ b/fastly/fixtures/vcl_snippets/delete_versioned.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/88/snippet/snipverUpdated
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/36/snippet/snipverUpdated
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:36 GMT
+      - Thu, 20 Mar 2025 18:15:38 GMT
       Fastly-Ratelimit-Remaining:
-      - "9987"
+      - "9994"
       Fastly-Ratelimit-Reset:
-      - "1667826000"
+      - "1742497200"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-klot8100033-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823577.647762,VS0,VE185
+      - S1742494538.278623,VS0,VE185
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/vcl_snippets/get_dynamic.yaml
+++ b/fastly/fixtures/vcl_snippets/get_dynamic.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/snippet/ZoMomE3AaTnyJjM4cslCA1
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/snippet/lE4es0twkrfKltSI0nU1k0
     method: GET
   response:
-    body: '{"snippet_id":"ZoMomE3AaTnyJjM4cslCA1","created_at":"2022-11-07T12:19:34Z","updated_at":"2022-11-07T12:19:34Z","service_id":"kKJb5bOFI47uHeBVluGfX1","content":"#vcl"}'
+    body: '{"content":"#vcl","snippet_id":"lE4es0twkrfKltSI0nU1k0","created_at":"2025-03-20T18:15:36Z","updated_at":"2025-03-20T18:15:36Z","service_id":"kKJb5bOFI47uHeBVluGfX1"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:36 GMT
+      - Thu, 20 Mar 2025 18:15:37 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-klot8100153-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823576.712839,VS0,VE301
+      - S1742494537.283106,VS0,VE118
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/vcl_snippets/get_versioned.yaml
+++ b/fastly/fixtures/vcl_snippets/get_versioned.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/88/snippet/snipver
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/36/snippet/snipver
     method: GET
   response:
-    body: '{"version":"88","updated_at":"2022-11-07T12:19:34Z","priority":"100","id":"WT2ibuLy1IEgBOgN7ZvtI4","created_at":"2022-11-07T12:19:34Z","type":"fetch","service_id":"kKJb5bOFI47uHeBVluGfX1","deleted_at":null,"dynamic":"0","name":"snipver","content":"#vcl"}'
+    body: '{"version":"36","deleted_at":null,"name":"snipver","priority":"100","service_id":"kKJb5bOFI47uHeBVluGfX1","type":"fetch","id":"i33J0p7U8HIVZDGqxncM92","updated_at":"2025-03-20T18:15:36Z","created_at":"2025-03-20T18:15:36Z","content":"#vcl","dynamic":"0"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:35 GMT
+      - Thu, 20 Mar 2025 18:15:37 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-4-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-kigq8000175-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823575.377706,VS0,VE303
+      - S1742494537.170019,VS0,VE109
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/vcl_snippets/list.yaml
+++ b/fastly/fixtures/vcl_snippets/list.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/88/snippet
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/36/snippet
     method: GET
   response:
-    body: '[{"name":"snipdyn","version":"88","created_at":"2022-11-07T12:19:34Z","dynamic":"1","type":"fetch","deleted_at":null,"service_id":"kKJb5bOFI47uHeBVluGfX1","priority":"123","content":null,"id":"ZoMomE3AaTnyJjM4cslCA1","updated_at":"2022-11-07T12:19:34Z"},{"priority":"100","updated_at":"2022-11-07T12:19:34Z","id":"WT2ibuLy1IEgBOgN7ZvtI4","content":"#vcl","version":"88","name":"snipver","created_at":"2022-11-07T12:19:34Z","deleted_at":null,"service_id":"kKJb5bOFI47uHeBVluGfX1","dynamic":"0","type":"fetch"}]'
+    body: '[{"version":"36","id":"lE4es0twkrfKltSI0nU1k0","updated_at":"2025-03-20T18:15:36Z","service_id":"kKJb5bOFI47uHeBVluGfX1","deleted_at":null,"content":null,"dynamic":"1","name":"snipdyn","created_at":"2025-03-20T18:15:36Z","type":"fetch","priority":"123"},{"version":"36","id":"i33J0p7U8HIVZDGqxncM92","updated_at":"2025-03-20T18:15:36Z","service_id":"kKJb5bOFI47uHeBVluGfX1","dynamic":"0","deleted_at":null,"content":"#vcl","name":"snipver","created_at":"2025-03-20T18:15:36Z","type":"fetch","priority":"100"}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:35 GMT
+      - Thu, 20 Mar 2025 18:15:37 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -33,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-kigq8000082-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823575.008395,VS0,VE332
+      - S1742494537.027726,VS0,VE138
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/vcl_snippets/update_dynamic.yaml
+++ b/fastly/fixtures/vcl_snippets/update_dynamic.yaml
@@ -10,11 +10,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/snippet/ZoMomE3AaTnyJjM4cslCA1
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/snippet/lE4es0twkrfKltSI0nU1k0
     method: PUT
   response:
-    body: '{"created_at":"2022-11-07T12:19:34Z","content":"#vclUpdated","snippet_id":"ZoMomE3AaTnyJjM4cslCA1","service_id":"kKJb5bOFI47uHeBVluGfX1","updated_at":"2022-11-07T12:19:34Z"}'
+    body: '{"content":"#vclUpdated","snippet_id":"lE4es0twkrfKltSI0nU1k0","created_at":"2025-03-20T18:15:36Z","updated_at":"2025-03-20T18:15:36Z","service_id":"kKJb5bOFI47uHeBVluGfX1"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -23,11 +23,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:36 GMT
+      - Thu, 20 Mar 2025 18:15:38 GMT
       Fastly-Ratelimit-Remaining:
-      - "9988"
+      - "9995"
       Fastly-Ratelimit-Reset:
-      - "1667826000"
+      - "1742497200"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +45,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-klot8100153-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823576.344554,VS0,VE209
+      - S1742494538.665167,VS0,VE535
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/vcl_snippets/update_versioned.yaml
+++ b/fastly/fixtures/vcl_snippets/update_versioned.yaml
@@ -16,11 +16,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/88/snippet/snipver
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/36/snippet/snipver
     method: PUT
   response:
-    body: '{"id":"WT2ibuLy1IEgBOgN7ZvtI4","version":"88","deleted_at":null,"content":"#vclUpdated","name":"snipverUpdated","service_id":"kKJb5bOFI47uHeBVluGfX1","type":"hit","priority":"456","created_at":"2022-11-07T12:19:34Z","updated_at":"2022-11-07T12:19:34Z","dynamic":"0"}'
+    body: '{"updated_at":"2025-03-20T18:15:36Z","content":"#vclUpdated","deleted_at":null,"priority":"456","type":"hit","id":"i33J0p7U8HIVZDGqxncM92","dynamic":"0","name":"snipverUpdated","created_at":"2025-03-20T18:15:36Z","version":"36","service_id":"kKJb5bOFI47uHeBVluGfX1"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -29,11 +29,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:36 GMT
+      - Thu, 20 Mar 2025 18:15:37 GMT
       Fastly-Ratelimit-Remaining:
-      - "9989"
+      - "9996"
       Fastly-Ratelimit-Reset:
-      - "1667826000"
+      - "1742497200"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +51,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-6-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-kigq8000175-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823576.047992,VS0,VE176
+      - S1742494537.406117,VS0,VE196
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/vcl_snippets/version.yaml
+++ b/fastly/fixtures/vcl_snippets/version.yaml
@@ -8,11 +8,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/6.8.0 (+github.com/fastly/go-fastly; go1.16.15)
+      - FastlyGo/9.13.1 (+github.com/fastly/go-fastly; go1.24.0)
     url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version
     method: POST
   response:
-    body: '{"service_id":"kKJb5bOFI47uHeBVluGfX1","number":88}'
+    body: '{"service_id":"kKJb5bOFI47uHeBVluGfX1","number":36}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 07 Nov 2022 12:19:34 GMT
+      - Thu, 20 Mar 2025 18:15:36 GMT
       Fastly-Ratelimit-Remaining:
-      - "9992"
+      - "9999"
       Fastly-Ratelimit-Reset:
-      - "1667826000"
+      - "1742497200"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly control-gateway
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-control-cp-aws-us-east-1-prod-5-CONTROL-AWS, cache-man4131-MAN
+      - cache-chi-kigq8000025-CHI, cache-lga21986-LGA
       X-Timer:
-      - S1667823574.234363,VS0,VE183
+      - S1742494536.383678,VS0,VE242
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/vcl_snippets.go
+++ b/fastly/vcl_snippets.go
@@ -51,7 +51,7 @@ type Snippet struct {
 	Dynamic        *int         `mapstructure:"dynamic"`
 	SnippetID      *string      `mapstructure:"id"`
 	Name           *string      `mapstructure:"name"`
-	Priority       *int         `mapstructure:"priority"`
+	Priority       *string      `mapstructure:"priority"`
 	ServiceID      *string      `mapstructure:"service_id"`
 	ServiceVersion *int         `mapstructure:"version"`
 	Type           *SnippetType `mapstructure:"type"`
@@ -67,7 +67,7 @@ type CreateSnippetInput struct {
 	// Name is the name for the snippet (required).
 	Name *string `url:"name,omitempty"`
 	// Priority determines the ordering for multiple snippets. Lower numbers execute first.
-	Priority *int `url:"priority,omitempty"`
+	Priority *string `url:"priority,omitempty"`
 	// ServiceID is the ID of the service to add the snippet to (required).
 	ServiceID string `url:"-"`
 	// ServiceVersion is the editable configuration version (required).
@@ -108,7 +108,7 @@ type UpdateSnippetInput struct {
 	// NewName is the new name for the resource.
 	NewName *string `url:"name,omitempty"`
 	// Priority determines the ordering for multiple snippets. Lower numbers execute first.
-	Priority *int `url:"priority,omitempty"`
+	Priority *string `url:"priority,omitempty"`
 	// ServiceID is the ID of the service to add the snippet to (required).
 	ServiceID string `url:"-"`
 	// ServiceVersion is the editable configuration version (required).

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -11,7 +11,7 @@ func TestClient_Snippets(t *testing.T) {
 		svName            = "snipver"
 		sdName            = "snipdyn"
 		svNameUpdated     = "snipverUpdated"
-		defaultPriority   = 100
+		defaultPriority   = "100"
 		defaultDynamic    = 0
 		vclContent        = "#vcl"
 		vclContentUpdated = "#vclUpdated"
@@ -59,7 +59,7 @@ func TestClient_Snippets(t *testing.T) {
 	}
 
 	dynamic := 1
-	priority := 123
+	priority := "123"
 
 	Record(t, "vcl_snippets/create_with_all_fields", func(c *Client) {
 		cs, err = c.CreateSnippet(&CreateSnippetInput{
@@ -192,7 +192,7 @@ func TestClient_Snippets(t *testing.T) {
 		t.Errorf("incorrect Content: want %v, have %q", vclContent, *ds.Content)
 	}
 
-	priority = 456
+	priority = "456"
 	hit := SnippetTypeHit
 
 	Record(t, "vcl_snippets/update_versioned", func(c *Client) {


### PR DESCRIPTION
The Fastly API was recently changed to return this field as a string, as specified in the public documentation.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### User Impact

* [X] What is the user impact of this change?

### Are there any considerations that need to be addressed for release?

This is a breaking change as the type of a structure field has changed, however all previous releases of go-fastly are unusable for managing VCL snippets as of March 13, 2025 when the Fastly API began returning this field as a string (as it was documented to do).