### PR TITLE
fix(vcl_condition.go): update type of vcl condition to match api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [Full Changelog](https://github.com/fastly/go-fastly/compare/v10.0.0...)
 
 ### Breaking:
+- fix(vcl_condition): Correct type of 'Priority' field from integer to string. [#650](https://github.com/fastly/go-fastly/pull/650)
 
 ### Enhancements:
 

--- a/fastly/vcl_condition.go
+++ b/fastly/vcl_condition.go
@@ -55,7 +55,7 @@ type CreateConditionInput struct {
 	// Name is the name of the condition.
 	Name *string `url:"name,omitempty"`
 	// Priority is a numeric string. Priority determines execution order. Lower numbers execute first.
-	Priority *int `url:"priority,omitempty"`
+	Priority *string `url:"priority,omitempty"`
 	// ServiceID is the ID of the service (required).
 	ServiceID string `url:"-"`
 	// ServiceVersion is the specific configuration version (required).

--- a/fastly/vcl_condition_test.go
+++ b/fastly/vcl_condition_test.go
@@ -23,7 +23,7 @@ func TestClient_Conditions(t *testing.T) {
 			Name:           ToPointer("test/condition"),
 			Statement:      ToPointer("req.url~+\"index.html\""),
 			Type:           ToPointer("REQUEST"),
-			Priority:       ToPointer(1),
+			Priority:       ToPointer("1"),
 		})
 	})
 	if err != nil {


### PR DESCRIPTION
BREAKING CHANGE:

type change of priority from int to string

The API says that this field is now a `string` updating to match the spec https://www.fastly.com/documentation/reference/api/vcl-services/condition/
<img width="464" alt="Screenshot 2025-04-03 at 10 01 08 AM" src="https://github.com/user-attachments/assets/4dc39d5c-a266-4517-b804-6aaab062f0c2" />

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass tests?
