### PR TITLE
fix(domain discovery): add omitempty to response fields and add error handling test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - feat(ngwaf): add support for workspaces ([#679](https://github.com/fastly/go-fastly/pull/679))
 
 ### Bug fixes:
+- fix(Domain Discovery): add `omitempty` tag to response types for `suggest` and `status` endpoints.
 
 ### Dependencies:
 

--- a/fastly/domains/v1/tools/status/api_response.go
+++ b/fastly/domains/v1/tools/status/api_response.go
@@ -3,30 +3,30 @@ package status
 // Status is the API response structure for the status endpoint.
 type Status struct {
 	// Domain is the domain whose status is being checked.
-	Domain string `json:"domain"`
+	Domain string `json:"domain,omitempty"`
 	// Zone is the top level domain or registered domain portion (e.g ".com")
-	Zone string `json:"zone"`
+	Zone string `json:"zone,omitempty"`
 	// Status is a space-delimited list of status types for the given domain
 	// in increasing order of precedence.
 	// The right-most value can be considered the most important value.
-	Status string `json:"status"`
+	Status string `json:"status,omitempty"`
 	// Scope reflects the type of availability check that was performed.
 	// Scope will only be present if an estimated status check was performed.
 	// `estimate` provides DNS and aftermarket availability.
-	Scope *Scope `json:"scope"`
+	Scope *Scope `json:"scope,omitempty"`
 	// Tags is a space-delimited string containing the varying tags associated with the domain.
-	Tags string `json:"tags"`
+	Tags string `json:"tags,omitempty"`
 	// Offers if present, contains a list of offers from domain aftermarket vendors.
-	Offers []Offer `json:"offers"`
+	Offers []Offer `json:"offers,omitempty"`
 }
 
 // Offer represents an offer from an aftermarket vendor for a given domain.
 type Offer struct {
 	// Vendor is the name of the aftermarket vendor.
-	Vendor string `json:"vendor"`
+	Vendor string `json:"vendor,omitempty"`
 	// Price is the price of the domain from the aftermarket vendor.
-	Price string `json:"price"`
+	Price string `json:"price,omitempty"`
 	// Currency is the currency for the aftermarket offer.
 	// A three-letter country currency code.
-	Currency string `json:"currency"`
+	Currency string `json:"currency,omitempty"`
 }

--- a/fastly/domains/v1/tools/status/fixtures/get_error.yaml
+++ b/fastly/domains/v1/tools/status/fixtures/get_error.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/10.1.0 (+github.com/fastly/go-fastly; go1.24.2)
+    url: https://api.fastly.com/domains/v1/tools/status?domain=fastly-sdk-gofastly-testing
+    method: GET
+  response:
+    body: '{"title":"Domain not found","status":400,"detail":"fastly-sdk-gofastly-testing"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Age:
+      - "1"
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/problem+json
+      Date:
+      - Wed, 21 May 2025 14:33:47 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - "0"
+      X-Served-By:
+      - cache-ewr-kewr1740082-EWR, cache-ewr-kewr1740040-EWR
+      X-Timer:
+      - S1747838028.703547,VS0,VE281
+    status: 400 Bad Request
+    code: 400
+    duration: ""

--- a/fastly/domains/v1/tools/suggest/api_response.go
+++ b/fastly/domains/v1/tools/suggest/api_response.go
@@ -8,11 +8,11 @@ type Suggestions struct {
 // Suggestion represents an individual suggestion.
 type Suggestion struct {
 	// Domain is the full domain name suggestion.
-	Domain string `json:"domain"`
+	Domain string `json:"domain,omitempty"`
 	// Subdomain is the portion of the domain before the zone.
-	Subdomain string `json:"subdomain"`
+	Subdomain string `json:"subdomain,omitempty"`
 	// Zone is the top level domain or registered domain portion (e.g ".com").
-	Zone string `json:"zone"`
+	Zone string `json:"zone,omitempty"`
 	// Path if present, is the path is to be appended to the domain to complete the suggestion.
-	Path *string `json:"path"`
+	Path *string `json:"path,omitempty"`
 }


### PR DESCRIPTION
 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Update the responses to include `omitempty` for json responses. This is particularly useful when consuming the data from the CLI. The fields that are not set, should not be displayed, this is how the upstream api handles the missing fields.

Also added a test for error handling to ensure that the error response is handled accordingly.

### User Impact

* [x] What is the user impact of this change?

Users should expect the field to not appear instead of `null`

### Are there any considerations that need to be addressed for release?

When marshaling the struct, fields that do not appear will not appear in the json