### PR TITLE
Serialize tests for Next-Gen WAF.

### DIFF
--- a/fastly/ngwaf/v1/events/api_test.go
+++ b/fastly/ngwaf/v1/events/api_test.go
@@ -13,8 +13,6 @@ const (
 )
 
 func TestClient_GetEvent(t *testing.T) {
-	t.Parallel()
-
 	getEventInput := new(GetInput)
 	getEventInput.EventID = fastly.ToPointer(TestEventID)
 	getEventInput.WorkspaceID = fastly.ToPointer(fastly.TestNGWAFWorkspaceID)

--- a/fastly/ngwaf/v1/lists/api_test.go
+++ b/fastly/ngwaf/v1/lists/api_test.go
@@ -16,8 +16,6 @@ const (
 )
 
 func TestClient_List(t *testing.T) {
-	t.Parallel()
-
 	var err error
 	listEntries := []string{listEntry}
 

--- a/fastly/ngwaf/v1/redactions/api_test.go
+++ b/fastly/ngwaf/v1/redactions/api_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestClient_Redactions(t *testing.T) {
-	t.Parallel()
 	var err error
 	testField := "somefield"
 	testType := "request_parameter"

--- a/fastly/ngwaf/v1/requests/api_test.go
+++ b/fastly/ngwaf/v1/requests/api_test.go
@@ -15,8 +15,6 @@ const (
 )
 
 func TestClient_requests(t *testing.T) {
-	t.Parallel()
-
 	getrequestInput := new(GetInput)
 	getrequestInput.RequestID = fastly.ToPointer(string(TestRequestID))
 	getrequestInput.WorkspaceID = fastly.ToPointer(fastly.TestNGWAFWorkspaceID)

--- a/fastly/ngwaf/v1/rules/api_test.go
+++ b/fastly/ngwaf/v1/rules/api_test.go
@@ -12,8 +12,6 @@ import (
 func TestClient_Rule(t *testing.T) {
 	assert := require.New(t)
 
-	t.Parallel()
-
 	var err error
 
 	ruleType := "request"

--- a/fastly/ngwaf/v1/signals/api_test.go
+++ b/fastly/ngwaf/v1/signals/api_test.go
@@ -14,7 +14,6 @@ const (
 )
 
 func TestClient_Signals(t *testing.T) {
-	t.Parallel()
 	var err error
 	var signalID string
 

--- a/fastly/ngwaf/v1/timeseries/api_test.go
+++ b/fastly/ngwaf/v1/timeseries/api_test.go
@@ -24,8 +24,6 @@ var (
 )
 
 func TestTime_Series(t *testing.T) {
-	t.Parallel()
-
 	var err error
 	var ts *TimeSeries
 

--- a/fastly/ngwaf/v1/virtualpatches/api_test.go
+++ b/fastly/ngwaf/v1/virtualpatches/api_test.go
@@ -14,8 +14,6 @@ var testWorkspaceID = fastly.TestNGWAFWorkspaceID
 const vpID = "CVE-2017-5638"
 
 func TestVirtual_Patches(t *testing.T) {
-	t.Parallel()
-
 	var err error
 	var vps *VirtualPatches
 

--- a/fastly/ngwaf/v1/workspaces/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/api_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestClient_Workspace(t *testing.T) {
-	t.Parallel()
-
 	const wsName = "test-workspace"
 	const wsDescription = "test-description"
 	const wsMode = "log"


### PR DESCRIPTION
The Next-Gen WAF tests must not be run in parallel.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?
