### PR TITLE
Trigger workflow when PR labels are changed.

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -4,6 +4,8 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
+      - unlabeled
     branches:
       - main
 name: Test


### PR DESCRIPTION
If a PR submitter forgets to add labels before opening the PR, then adds them later, the workflow does not re-run and the results don't take into account the label changes.

 All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?
