### PR TITLE
Pin golangci-lint to v2.4.0

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   pull_request:
     types:
       - opened
@@ -14,7 +14,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-    - uses: dangoslen/changelog-enforcer@v3
+      - uses: dangoslen/changelog-enforcer@v3
   golangci:
     name: lint
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.1.6
   test:
     strategy:
       matrix:
@@ -34,12 +34,12 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v5
-    - name: Install Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Test
-      run: make test
-      shell: bash
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Test
+        run: make test
+        shell: bash

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.6
+          version: v2.4.0
   test:
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,18 @@
 [Full Changelog](https://github.com/fastly/go-fastly/compare/v11.2.0...)
 
 ### Breaking:
-- breaking(ngwaf/rules): group and multival conditions no longer accept a 'type' field
+
+- breaking(ngwaf/rules): group and multival conditions no longer accept a 'type' field ([#755](https://github.com/fastly/go-fastly/pull/755))
+- breaking(ngwaf): rename package `common` to `scope` and `ScopeType` to just `Type` ([#754](https://github.com/fastly/go-fastly/pull/754))
 
 ### Enhancements:
+
 - feat(ngwaf/rules): add support for the multival condition type ([#755](https://github.com/fastly/go-fastly/pull/755))
+
 ### Bug fixes:
 
 ### Dependencies:
+
 - build(deps): `golang.org/x/crypto` from 0.41.0 to 0.42.0 ([#751](https://github.com/fastly/go-fastly/pull/751))
 - build(deps): `golang.org/x/sys` from 0.35.0 to 0.36.0 ([#751](https://github.com/fastly/go-fastly/pull/751))
 - build(deps): `actions/setup-go` from 5 to 6 ([#752](https://github.com/fastly/go-fastly/pull/752))
@@ -21,9 +26,11 @@
 [Full Changelog](https://github.com/fastly/go-fastly/compare/v11.3.0...v11.3.1)
 
 ### Bug fixes:
+
 - fix(logging): Add CompressionCodec and GZipLevel to HTTPS update struct
 
 ### Dependencies:
+
 - build(deps): `golang.org/x/crypto` from 0.40.0 to 0.41.0 ([#740](https://github.com/fastly/go-fastly/pull/740))
 - build(deps): `golang.org/x/sys` from 0.34.0 to 0.35.0 ([#740](https://github.com/fastly/go-fastly/pull/740))
 - build(deps): `github.com/stretchr/testify` from 1.10.0 to 1.11.0 ([#742](https://github.com/fastly/go-fastly/pull/742))

--- a/fastly/ngwaf/v1/lists/api_create.go
+++ b/fastly/ngwaf/v1/lists/api_create.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // CreateInput specifies the information needed for the Create()
@@ -20,7 +20,7 @@ type CreateInput struct {
 	Name *string `json:"name"`
 	// Scope defines where the list is located, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope `json:"-"`
+	Scope *scope.Scope `json:"-"`
 	// Type is the type of the list. Must be one of `string` |
 	// `wildcard` | `ip` | `country` | `signal` (required).
 	Type *string `json:"type"`
@@ -41,7 +41,7 @@ func Create(ctx context.Context, c *fastly.Client, i *CreateInput) (*List, error
 		return nil, fastly.ErrMissingScope
 	}
 
-	path, err := common.BuildPath(i.Scope, "lists", "")
+	path, err := scope.BuildPath(i.Scope, "lists", "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/lists/api_delete.go
+++ b/fastly/ngwaf/v1/lists/api_delete.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // DeleteInput specifies the information needed for the Delete()
@@ -16,7 +16,7 @@ type DeleteInput struct {
 	ListID *string
 	// Scope defines where the list is applied, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 }
 
 // Delete deletes the specified list.
@@ -28,7 +28,7 @@ func Delete(ctx context.Context, c *fastly.Client, i *DeleteInput) error {
 		return fastly.ErrMissingScope
 	}
 
-	path, err := common.BuildPath(i.Scope, "lists", *i.ListID)
+	path, err := scope.BuildPath(i.Scope, "lists", *i.ListID)
 	if err != nil {
 		return fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/lists/api_get.go
+++ b/fastly/ngwaf/v1/lists/api_get.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // GetInput specifies the information needed for the Get() function to
@@ -16,7 +16,7 @@ type GetInput struct {
 	ListID *string
 	// Scope defines where the list is applied, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 }
 
 // Get retrieves the specified list.
@@ -28,7 +28,7 @@ func Get(ctx context.Context, c *fastly.Client, i *GetInput) (*List, error) {
 		return nil, fastly.ErrMissingScope
 	}
 
-	path, err := common.BuildPath(i.Scope, "lists", *i.ListID)
+	path, err := scope.BuildPath(i.Scope, "lists", *i.ListID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/lists/api_list.go
+++ b/fastly/ngwaf/v1/lists/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // ListInput specifies the information needed for the List() function to perform
@@ -14,7 +14,7 @@ import (
 type ListInput struct {
 	// Scope defines where the list is located, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 }
 
 // ListLists retrieves a list of lists for the given workspace.
@@ -23,7 +23,7 @@ func ListLists(ctx context.Context, c *fastly.Client, i *ListInput) (*Lists, err
 		return nil, fastly.ErrMissingScope
 	}
 
-	path, err := common.BuildPath(i.Scope, "lists", "")
+	path, err := scope.BuildPath(i.Scope, "lists", "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/lists/api_test.go
+++ b/fastly/ngwaf/v1/lists/api_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 const (
@@ -20,14 +20,14 @@ const (
 )
 
 func TestClient_Lists_WorkspaceScope(t *testing.T) {
-	runListsTest(t, common.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
+	runListsTest(t, scope.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
 }
 
 func TestClient_Lists_AccountScope(t *testing.T) {
-	runListsTest(t, common.ScopeTypeAccount, "*") // assuming TestNGWAFAccountID exists
+	runListsTest(t, scope.ScopeTypeAccount, "*") // assuming TestNGWAFAccountID exists
 }
 
-func runListsTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
+func runListsTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 	var err error
 	listEntries := []string{listEntry}
 	testListName := listName + string(scopeType)
@@ -40,7 +40,7 @@ func runListsTest(t *testing.T, scopeType common.ScopeType, appliesToID string) 
 			Description: fastly.ToPointer(listDescription),
 			Entries:     fastly.ToPointer(listEntries),
 			Name:        fastly.ToPointer(testListName),
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -77,7 +77,7 @@ func runListsTest(t *testing.T, scopeType common.ScopeType, appliesToID string) 
 		fastly.Record(t, fmt.Sprintf("%s_delete_list", scopeType), func(c *fastly.Client) {
 			err = Delete(context.TODO(), c, &DeleteInput{
 				ListID: fastly.ToPointer(list.ListID),
-				Scope: &common.Scope{
+				Scope: &scope.Scope{
 					Type:      scopeType,
 					AppliesTo: []string{appliesToID},
 				},
@@ -93,7 +93,7 @@ func runListsTest(t *testing.T, scopeType common.ScopeType, appliesToID string) 
 	fastly.Record(t, fmt.Sprintf("%s_get_list", scopeType), func(c *fastly.Client) {
 		getList, err = Get(context.TODO(), c, &GetInput{
 			ListID: fastly.ToPointer(list.ListID),
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -136,7 +136,7 @@ func runListsTest(t *testing.T, scopeType common.ScopeType, appliesToID string) 
 			Description: fastly.ToPointer(updateListDescription),
 			Entries:     fastly.ToPointer(updateListEntries),
 			ListID:      fastly.ToPointer(list.ListID),
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -172,7 +172,7 @@ func runListsTest(t *testing.T, scopeType common.ScopeType, appliesToID string) 
 	// List all lists.
 	fastly.Record(t, fmt.Sprintf("%s_list_lists", scopeType), func(c *fastly.Client) {
 		lists, err = ListLists(context.TODO(), c, &ListInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},

--- a/fastly/ngwaf/v1/lists/api_update.go
+++ b/fastly/ngwaf/v1/lists/api_update.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // UpdateInput specifies the information needed for the Update()
@@ -20,7 +20,7 @@ type UpdateInput struct {
 	ListID *string
 	// Scope defines where the list is located, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 }
 
 // Update updates the specified list.
@@ -29,7 +29,7 @@ func Update(ctx context.Context, c *fastly.Client, i *UpdateInput) (*List, error
 		return nil, fastly.ErrMissingListID
 	}
 
-	path, err := common.BuildPath(i.Scope, "lists", *i.ListID)
+	path, err := scope.BuildPath(i.Scope, "lists", *i.ListID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/rules/api_create.go
+++ b/fastly/ngwaf/v1/rules/api_create.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // CreateInput specifies the information needed for the Create()
@@ -43,7 +43,7 @@ type CreateInput struct {
 	// Scope defines where the rule is applied, including its type
 	// (e.g., "workspace" or "account") and the specific IDs it
 	// applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 	// Type specifies the category of the rule (e.g., "request")
 	// (required).
 	Type *string
@@ -158,7 +158,7 @@ func Create(ctx context.Context, c *fastly.Client, i *CreateInput) (*Rule, error
 		GroupOperator  *string          `json:"group_operator,omitempty"`
 		RateLimit      *CreateRateLimit `json:"rate_limit,omitempty"`
 		RequestLogging *string          `json:"request_logging,omitempty"`
-		Scope          *common.Scope    `json:"scope"`
+		Scope          *scope.Scope     `json:"scope"`
 		Type           *string          `json:"type"`
 	}{
 		Actions:        i.Actions,
@@ -173,7 +173,7 @@ func Create(ctx context.Context, c *fastly.Client, i *CreateInput) (*Rule, error
 		Type:           i.Type,
 	}
 
-	path, err := common.BuildPath(i.Scope, "rules", "")
+	path, err := scope.BuildPath(i.Scope, "rules", "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/rules/api_delete.go
+++ b/fastly/ngwaf/v1/rules/api_delete.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // DeleteInput specifies the information needed for the Delete()
@@ -17,7 +17,7 @@ type DeleteInput struct {
 	// Scope defines where the rule is applied, including its
 	// type (e.g., "workspace" or "account") and the specific
 	// IDs it applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 }
 
 // Delete deletes the specified rule.
@@ -29,7 +29,7 @@ func Delete(ctx context.Context, c *fastly.Client, i *DeleteInput) error {
 		return fastly.ErrMissingScope
 	}
 
-	path, err := common.BuildPath(i.Scope, "rules", *i.RuleID)
+	path, err := scope.BuildPath(i.Scope, "rules", *i.RuleID)
 	if err != nil {
 		return fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/rules/api_get.go
+++ b/fastly/ngwaf/v1/rules/api_get.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // GetInput specifies the information needed for the Get() function
@@ -17,7 +17,7 @@ type GetInput struct {
 	// Scope defines where the rule is applied, including its type
 	// (e.g., "workspace" or "account") and the specific IDs it
 	// applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 }
 
 // Get retrieves the specified rule.
@@ -29,7 +29,7 @@ func Get(ctx context.Context, c *fastly.Client, i *GetInput) (*Rule, error) {
 		return nil, fastly.ErrMissingScope
 	}
 
-	path, err := common.BuildPath(i.Scope, "rules", *i.RuleID)
+	path, err := scope.BuildPath(i.Scope, "rules", *i.RuleID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/rules/api_list.go
+++ b/fastly/ngwaf/v1/rules/api_list.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // ListInput specifies the information needed for the List() function
@@ -24,7 +24,7 @@ type ListInput struct {
 	// Scope defines where the rule is applied, including its type
 	// (e.g., "workspace" or "account") and the specific IDs it
 	// applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 	// Types filter results based on types (accepts more than one
 	// value and performs a union across rules of given types).
 	Types *string
@@ -54,7 +54,7 @@ func List(ctx context.Context, c *fastly.Client, i *ListInput) (*Rules, error) {
 		requestOptions.Params["types"] = *i.Types
 	}
 
-	path, err := common.BuildPath(i.Scope, "rules", "")
+	path, err := scope.BuildPath(i.Scope, "rules", "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/rules/api_test.go
+++ b/fastly/ngwaf/v1/rules/api_test.go
@@ -9,19 +9,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/signals"
 )
 
 func TestClient_Rule_WorkspaceScope(t *testing.T) {
-	runRuleTest(t, common.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
+	runRuleTest(t, scope.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
 }
 
 func TestClient_Rule_AccountScope(t *testing.T) {
-	runRuleTest(t, common.ScopeTypeAccount, "*") // assuming TestNGWAFAccountID exists
+	runRuleTest(t, scope.ScopeTypeAccount, "*") // assuming TestNGWAFAccountID exists
 }
 
-func runRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
+func runRuleTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 	assert := require.New(t)
 
 	var err error
@@ -78,7 +78,7 @@ func runRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
 	var rs *Rules
 	fastly.Record(t, fmt.Sprintf("%s_list_rules", scopeType), func(c *fastly.Client) {
 		rs, err = List(context.TODO(), c, &ListInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -104,7 +104,7 @@ func runRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
 	var rule *Rule
 	fastly.Record(t, fmt.Sprintf("%s_create_rule", scopeType), func(c *fastly.Client) {
 		rule, err = Create(context.TODO(), c, &CreateInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -250,7 +250,7 @@ func runRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
 		fastly.Record(t, fmt.Sprintf("%s_delete_rule", scopeType), func(c *fastly.Client) {
 			err = Delete(context.TODO(), c, &DeleteInput{
 				RuleID: fastly.ToPointer(rule.RuleID),
-				Scope: &common.Scope{
+				Scope: &scope.Scope{
 					Type:      scopeType,
 					AppliesTo: []string{appliesToID},
 				},
@@ -266,7 +266,7 @@ func runRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
 	fastly.Record(t, fmt.Sprintf("%s_get_rule", scopeType), func(c *fastly.Client) {
 		testRule, err = Get(context.TODO(), c, &GetInput{
 			RuleID: fastly.ToPointer(rule.RuleID),
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -376,7 +376,7 @@ func runRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
 	var updatedRule *Rule
 	fastly.Record(t, fmt.Sprintf("%s_update_rule", scopeType), func(c *fastly.Client) {
 		updatedRule, err = Update(context.TODO(), c, &UpdateInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -521,10 +521,10 @@ func runRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
 }
 
 func TestClient_Rate_Limit_Rule_WorkspaceScope(t *testing.T) {
-	runRateLimitRuleTest(t, common.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
+	runRateLimitRuleTest(t, scope.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
 }
 
-func runRateLimitRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
+func runRateLimitRuleTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 	assert := require.New(t)
 
 	var err error
@@ -580,7 +580,7 @@ func runRateLimitRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 	var rs *Rules
 	fastly.Record(t, fmt.Sprintf("%s_rate_limit_list_rules", scopeType), func(c *fastly.Client) {
 		rs, err = List(context.TODO(), c, &ListInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -612,7 +612,7 @@ func runRateLimitRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 		signal, err = signals.Create(context.TODO(), c, &signals.CreateInput{
 			Description: fastly.ToPointer(testDescription),
 			Name:        fastly.ToPointer(testSignalName),
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -630,7 +630,7 @@ func runRateLimitRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 	var rule *Rule
 	fastly.Record(t, fmt.Sprintf("%s_rate_limit_create_rule", scopeType), func(c *fastly.Client) {
 		rule, err = Create(context.TODO(), c, &CreateInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -731,7 +731,7 @@ func runRateLimitRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 		fastly.Record(t, fmt.Sprintf("%s_rate_limit_delete_rule", scopeType), func(c *fastly.Client) {
 			err = Delete(context.TODO(), c, &DeleteInput{
 				RuleID: fastly.ToPointer(rule.RuleID),
-				Scope: &common.Scope{
+				Scope: &scope.Scope{
 					Type:      scopeType,
 					AppliesTo: []string{appliesToID},
 				},
@@ -742,7 +742,7 @@ func runRateLimitRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 		}
 		fastly.Record(t, fmt.Sprintf("%s_rate_limit_delete_signal", scopeType), func(c *fastly.Client) {
 			err = signals.Delete(context.TODO(), c, &signals.DeleteInput{
-				Scope: &common.Scope{
+				Scope: &scope.Scope{
 					Type:      scopeType,
 					AppliesTo: []string{appliesToID},
 				},
@@ -823,7 +823,7 @@ func runRateLimitRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 	fastly.Record(t, fmt.Sprintf("%s_rate_limit_get_rule", scopeType), func(c *fastly.Client) {
 		testRule, err = Get(context.TODO(), c, &GetInput{
 			RuleID: fastly.ToPointer(rule.RuleID),
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -941,7 +941,7 @@ func runRateLimitRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 	var updatedRule *Rule
 	fastly.Record(t, fmt.Sprintf("%s_rate_limit_update_rule", scopeType), func(c *fastly.Client) {
 		updatedRule, err = Update(context.TODO(), c, &UpdateInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -1104,10 +1104,10 @@ func runRateLimitRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 }
 
 func TestClient_Deception_Rule_WorkspaceScope(t *testing.T) {
-	runDeceptionRuleTest(t, common.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
+	runDeceptionRuleTest(t, scope.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
 }
 
-func runDeceptionRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
+func runDeceptionRuleTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 	assert := require.New(t)
 
 	var err error
@@ -1164,7 +1164,7 @@ func runDeceptionRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 	var rs *Rules
 	fastly.Record(t, fmt.Sprintf("%s_deception_list_rules", scopeType), func(c *fastly.Client) {
 		rs, err = List(context.TODO(), c, &ListInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -1190,7 +1190,7 @@ func runDeceptionRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 	var rule *Rule
 	fastly.Record(t, fmt.Sprintf("%s_deception_create_rule", scopeType), func(c *fastly.Client) {
 		rule, err = Create(context.TODO(), c, &CreateInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -1279,7 +1279,7 @@ func runDeceptionRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 		fastly.Record(t, fmt.Sprintf("%s_deception_delete_rule", scopeType), func(c *fastly.Client) {
 			err = Delete(context.TODO(), c, &DeleteInput{
 				RuleID: fastly.ToPointer(rule.RuleID),
-				Scope: &common.Scope{
+				Scope: &scope.Scope{
 					Type:      scopeType,
 					AppliesTo: []string{appliesToID},
 				},
@@ -1352,7 +1352,7 @@ func runDeceptionRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 	fastly.Record(t, fmt.Sprintf("%s_deception_get_rule", scopeType), func(c *fastly.Client) {
 		testRule, err = Get(context.TODO(), c, &GetInput{
 			RuleID: fastly.ToPointer(rule.RuleID),
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -1458,7 +1458,7 @@ func runDeceptionRuleTest(t *testing.T, scopeType common.ScopeType, appliesToID 
 	var updatedRule *Rule
 	fastly.Record(t, fmt.Sprintf("%s_deception_update_rule", scopeType), func(c *fastly.Client) {
 		updatedRule, err = Update(context.TODO(), c, &UpdateInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -1628,8 +1628,8 @@ func TestClient_CreateRule_validation(t *testing.T) {
 	_, err = Create(context.TODO(), fastly.TestClient, &CreateInput{
 		Type:        fastly.ToPointer("request"),
 		Description: fastly.ToPointer("test"),
-		Scope: &common.Scope{
-			Type:      common.ScopeTypeWorkspace,
+		Scope: &scope.Scope{
+			Type:      scope.ScopeTypeWorkspace,
 			AppliesTo: []string{"123"},
 		},
 		Conditions:      []*CreateCondition{},

--- a/fastly/ngwaf/v1/rules/api_update.go
+++ b/fastly/ngwaf/v1/rules/api_update.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // UpdateInput specifies the information needed for the Update()
@@ -45,7 +45,7 @@ type UpdateInput struct {
 	// Scope defines where the rule is applied, including its type
 	// (e.g., "workspace" or "account") and the specific IDs it
 	// applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 	// Type specifies the category of the rule (e.g., "request")
 	// (required).
 	Type *string
@@ -154,7 +154,7 @@ func Update(ctx context.Context, c *fastly.Client, i *UpdateInput) (*Rule, error
 		GroupOperator  *string          `json:"group_operator,omitempty"`
 		RateLimit      *UpdateRateLimit `json:"rate_limit,omitempty"`
 		RequestLogging *string          `json:"request_logging,omitempty"`
-		Scope          *common.Scope    `json:"scope,omitempty"`
+		Scope          *scope.Scope     `json:"scope,omitempty"`
 		Type           *string          `json:"type,omitempty"`
 	}{
 		Actions:        i.Actions,
@@ -169,7 +169,7 @@ func Update(ctx context.Context, c *fastly.Client, i *UpdateInput) (*Rule, error
 		Type:           i.Type,
 	}
 
-	path, err := common.BuildPath(i.Scope, "rules", *i.RuleID)
+	path, err := scope.BuildPath(i.Scope, "rules", *i.RuleID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/scope/pathbuilder.go
+++ b/fastly/ngwaf/v1/scope/pathbuilder.go
@@ -1,4 +1,4 @@
-package common
+package scope
 
 import (
 	"fmt"

--- a/fastly/ngwaf/v1/scope/scope.go
+++ b/fastly/ngwaf/v1/scope/scope.go
@@ -1,11 +1,11 @@
-package common
+package scope
 
-// ScopeType defines the type of scope.
-type ScopeType string
+// Type defines the type of scope.
+type Type string
 
 const (
-	ScopeTypeWorkspace ScopeType = "workspace"
-	ScopeTypeAccount   ScopeType = "account"
+	ScopeTypeWorkspace Type = "workspace"
+	ScopeTypeAccount   Type = "account"
 )
 
 // Scope defines the scope of a resource, specifying its type and applicable workspace identifiers.
@@ -19,7 +19,7 @@ const (
 //   - For "account" scope, this can include multiple workspace IDs or a wildcard "*" to target all workspaces.
 type Scope struct {
 	// Type specifies whether the rule applies at the "workspace" or "account" level (required).
-	Type ScopeType `json:"type"`
+	Type Type `json:"type"`
 	// AppliesTo lists the workspace IDs the rule applies to. For "workspace" type, a single ID is required.
 	// For "account" type, multiple IDs or "*" (wildcard for all workspaces) can be provided.
 	AppliesTo []string `json:"applies_to"`

--- a/fastly/ngwaf/v1/signals/api_create.go
+++ b/fastly/ngwaf/v1/signals/api_create.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // CreateInput specifies the information needed for the Create()
@@ -20,7 +20,7 @@ type CreateInput struct {
 	Name *string `json:"name"`
 	// Scope defines where the signal is located, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope `json:"-"`
+	Scope *scope.Scope `json:"-"`
 }
 
 // Create creates a new signal in the given workspace.
@@ -32,7 +32,7 @@ func Create(ctx context.Context, c *fastly.Client, i *CreateInput) (*Signal, err
 		return nil, fastly.ErrMissingScope
 	}
 
-	path, err := common.BuildPath(i.Scope, "signals", "")
+	path, err := scope.BuildPath(i.Scope, "signals", "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/signals/api_delete.go
+++ b/fastly/ngwaf/v1/signals/api_delete.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // DeleteInput specifies the information needed for the Delete()
@@ -14,7 +14,7 @@ import (
 type DeleteInput struct {
 	// Scope defines where the signal is applied, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 	// SignalID is the signal identifier (required).
 	SignalID *string
 }
@@ -28,7 +28,7 @@ func Delete(ctx context.Context, c *fastly.Client, i *DeleteInput) error {
 		return fastly.ErrMissingScope
 	}
 
-	path, err := common.BuildPath(i.Scope, "signals", *i.SignalID)
+	path, err := scope.BuildPath(i.Scope, "signals", *i.SignalID)
 	if err != nil {
 		return fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/signals/api_get.go
+++ b/fastly/ngwaf/v1/signals/api_get.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // GetInput specifies the information needed for the Get() function to
@@ -14,7 +14,7 @@ import (
 type GetInput struct {
 	// Scope defines where the signal is applied, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 	// SignalID is the signal identifier (required).
 	SignalID *string
 }
@@ -28,7 +28,7 @@ func Get(ctx context.Context, c *fastly.Client, i *GetInput) (*Signal, error) {
 		return nil, fastly.ErrMissingSignalID
 	}
 
-	path, err := common.BuildPath(i.Scope, "signals", *i.SignalID)
+	path, err := scope.BuildPath(i.Scope, "signals", *i.SignalID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/signals/api_list.go
+++ b/fastly/ngwaf/v1/signals/api_list.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // ListInput specifies the information needed for the List() function
@@ -17,7 +17,7 @@ type ListInput struct {
 	Limit *int
 	// Scope defines where the signal is located, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 }
 
 // List retrieves a list of signals for the given workspace, with
@@ -28,7 +28,7 @@ func List(ctx context.Context, c *fastly.Client, i *ListInput) (*Signals, error)
 		requestOptions.Params["limit"] = strconv.Itoa(*i.Limit)
 	}
 
-	path, err := common.BuildPath(i.Scope, "signals", "")
+	path, err := scope.BuildPath(i.Scope, "signals", "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}

--- a/fastly/ngwaf/v1/signals/api_test.go
+++ b/fastly/ngwaf/v1/signals/api_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 const (
@@ -18,14 +18,14 @@ const (
 )
 
 func TestClient_Signals_WorkspaceScope(t *testing.T) {
-	runSignalsTest(t, common.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
+	runSignalsTest(t, scope.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
 }
 
 func TestClient_Signals_AccountScope(t *testing.T) {
-	runSignalsTest(t, common.ScopeTypeAccount, "*") // assuming TestNGWAFAccountID exists
+	runSignalsTest(t, scope.ScopeTypeAccount, "*") // assuming TestNGWAFAccountID exists
 }
 
-func runSignalsTest(t *testing.T, scopeType common.ScopeType, appliesToID string) {
+func runSignalsTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 	var err error
 	var signalID string
 	testSignalName := testName + string(scopeType)
@@ -38,7 +38,7 @@ func runSignalsTest(t *testing.T, scopeType common.ScopeType, appliesToID string
 		signal, err = Create(context.TODO(), c, &CreateInput{
 			Description: fastly.ToPointer(testDescription),
 			Name:        fastly.ToPointer(testSignalName),
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -62,7 +62,7 @@ func runSignalsTest(t *testing.T, scopeType common.ScopeType, appliesToID string
 	defer func() {
 		fastly.Record(t, fmt.Sprintf("%s_delete_signal", scopeType), func(c *fastly.Client) {
 			err = Delete(context.TODO(), c, &DeleteInput{
-				Scope: &common.Scope{
+				Scope: &scope.Scope{
 					Type:      scopeType,
 					AppliesTo: []string{appliesToID},
 				},
@@ -78,7 +78,7 @@ func runSignalsTest(t *testing.T, scopeType common.ScopeType, appliesToID string
 	var getTestSignal *Signal
 	fastly.Record(t, fmt.Sprintf("%s_get_signal", scopeType), func(c *fastly.Client) {
 		getTestSignal, err = Get(context.TODO(), c, &GetInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -102,7 +102,7 @@ func runSignalsTest(t *testing.T, scopeType common.ScopeType, appliesToID string
 	fastly.Record(t, fmt.Sprintf("%s_update_signal", scopeType), func(c *fastly.Client) {
 		updatedSignal, err = Update(context.TODO(), c, &UpdateInput{
 			Description: fastly.ToPointer(string(updatedSignalDescription)),
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -120,7 +120,7 @@ func runSignalsTest(t *testing.T, scopeType common.ScopeType, appliesToID string
 	var listedSignals *Signals
 	fastly.Record(t, fmt.Sprintf("%s_list_signals", scopeType), func(c *fastly.Client) {
 		listedSignals, err = List(context.TODO(), c, &ListInput{
-			Scope: &common.Scope{
+			Scope: &scope.Scope{
 				Type:      scopeType,
 				AppliesTo: []string{appliesToID},
 			},
@@ -159,8 +159,8 @@ func TestClient_GetSignal_validation(t *testing.T) {
 	}
 	_, err = Get(context.TODO(), fastly.TestClient, &GetInput{
 		SignalID: nil,
-		Scope: &common.Scope{
-			Type:      common.ScopeTypeWorkspace,
+		Scope: &scope.Scope{
+			Type:      scope.ScopeTypeWorkspace,
 			AppliesTo: []string{},
 		},
 	})
@@ -204,8 +204,8 @@ func TestClient_UpdateSignal_validation(t *testing.T) {
 	_, err = Update(context.TODO(), fastly.TestClient, &UpdateInput{
 		Description: nil,
 		SignalID:    fastly.ToPointer("someID"),
-		Scope: &common.Scope{
-			Type:      common.ScopeTypeWorkspace,
+		Scope: &scope.Scope{
+			Type:      scope.ScopeTypeWorkspace,
 			AppliesTo: []string{},
 		},
 	})

--- a/fastly/ngwaf/v1/signals/api_update.go
+++ b/fastly/ngwaf/v1/signals/api_update.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/fastly/go-fastly/v11/fastly"
-	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/common"
+	"github.com/fastly/go-fastly/v11/fastly/ngwaf/v1/scope"
 )
 
 // UpdateInput specifies the information needed for the Update()
@@ -17,7 +17,7 @@ type UpdateInput struct {
 	Description *string `json:"description"`
 	// Scope defines where the signal is located, including its type (e.g.,
 	// "workspace" or "account") and the specific IDs it applies to (required).
-	Scope *common.Scope
+	Scope *scope.Scope
 	// SignalID is the id of the signal that's being updated
 	// (required).
 	SignalID *string `json:"-"`
@@ -35,7 +35,7 @@ func Update(ctx context.Context, c *fastly.Client, i *UpdateInput) (*Signal, err
 		return nil, fastly.ErrMissingDescription
 	}
 
-	path, err := common.BuildPath(i.Scope, "signals", *i.SignalID)
+	path, err := scope.BuildPath(i.Scope, "signals", *i.SignalID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build API path: %w", err)
 	}


### PR DESCRIPTION
### Change summary

Bump `golangci-lint` from v2.1.0 to v2.1.6 and also format the workflow file.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?