### PR TITLE
Update linter setup in CI and locally

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,3 +1,5 @@
+name: Test
+
 on:
   pull_request:
     types:
@@ -8,7 +10,6 @@ on:
       - unlabeled
     branches:
       - main
-name: Test
 jobs:
   changelog:
     if: github.actor != 'dependabot[bot]'
@@ -27,6 +28,30 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.4.0
+  golangci-latest:
+    name: lint-latest (informational)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.24.x
+      - name: Run golangci-lint@latest
+        id: lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+        continue-on-error: true
+      - name: Report lint summary
+        run: |
+          if [ "${{ steps.lint.outcome }}" == "success" ]; then
+            echo "✅ golangci-lint@latest passed." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ golangci-lint@latest failed (informational only)." >> $GITHUB_STEP_SUMMARY
+          fi
   test:
     strategy:
       matrix:


### PR DESCRIPTION
### Change summary

This PR adds a second `golangci-lint` job (lint-latest (informational)) that runs with the latest version of the linter. This job is non-blocking (`continue-on-error: true`) and will not fail future PRs.

This PR also ensures consistent linting locally :

- Pinning `golangci-lint` to version `v2.4.0`.
- Downloading it to a local `./bin` directory for use in `make lint` and `make fmt`.
- Supporting cross-platform (Linux + macOS) detection for correct binary download.

Added the following targets to the Makefile:

- `install-linter`: installs the correct linter version locally.
- `check-linter-version`: ensures the expected version is being used.
- `clean-bin`: removes the local ./bin directory if needed.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?