### PR TITLE
Support `max_use` and `max_lifetime` backend parameters

### DIFF
--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -22,6 +22,8 @@ type Backend struct {
 	Hostname            *string    `mapstructure:"hostname"`
 	KeepAliveTime       *int       `mapstructure:"keepalive_time"`
 	MaxConn             *int       `mapstructure:"max_conn"`
+	MaxUse              *int       `mapstructure:"max_use"`
+	MaxLifetime         *int       `mapstructure:"max_lifetime"`
 	MaxTLSVersion       *string    `mapstructure:"max_tls_version"`
 	MinTLSVersion       *string    `mapstructure:"min_tls_version"`
 	Name                *string    `mapstructure:"name"`
@@ -103,6 +105,10 @@ type CreateBackendInput struct {
 	KeepAliveTime *int `url:"keepalive_time,omitempty"`
 	// MaxConn is the maximum number of concurrent connections this backend will accept.
 	MaxConn *int `url:"max_conn,omitempty"`
+	// MaxUse is the maximum number of times an HTTP keepalive connection can be used. `0` is unlimited.
+	MaxUse *int `url:"max_use,omitempty"`
+	// MaxLifetime is the upper bound in milliseconds for how long an HTTP keepalive connection can be open before it is no longer used. `0` is unlimited.
+	MaxLifetime *int `url:"max_lifetime,omitempty"`
 	// MaxTLSVersion is the maximum allowed TLS version on SSL connections to this backend.
 	MaxTLSVersion *string `url:"max_tls_version,omitempty"`
 	// MinTLSVersion is the minimum allowed TLS version on SSL connections to this backend.
@@ -236,6 +242,10 @@ type UpdateBackendInput struct {
 	KeepAliveTime *int `url:"keepalive_time,omitempty"`
 	// MaxConn is the maximum number of concurrent connections this backend will accept.
 	MaxConn *int `url:"max_conn,omitempty"`
+	// MaxUse is the maximum number of times an HTTP keepalive connection can be used. `0` is unlimited.
+	MaxUse *int `url:"max_use,omitempty"`
+	// MaxLifetime is the upper bound in milliseconds for how long an HTTP keepalive connection can be open before it is no longer used. `0` is unlimited.
+	MaxLifetime *int `url:"max_lifetime,omitempty"`
 	// MaxTLSVersion is the maximum allowed TLS version on SSL connections to this backend.
 	MaxTLSVersion *string `url:"max_tls_version,omitempty"`
 	// MinTLSVersion is the minimum allowed TLS version on SSL connections to this backend.


### PR DESCRIPTION
### Change summary

This is a draft PR for adding support for two different backend fields that are going to be added to the API:

- `max_use`, which specifies how many times an HTTP keepalive connection can be used before it's no longer pooled.
- `max_lifetime`, which specifies in milliseconds an upper bound for how long an HTTP keepalive connection can be open before it's no longer used.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
    * Yes

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
    * I didn't add any tests, since this just updates what can be passed in the struct to the API.
* [x] Have you successfully run tests with your changes locally?
    * Yes

### User Impact

This will allow using a newly exposed feature in both Delivery and Compute, which have added support for honoring these backend parameters in their connection pooling logic.

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->
