### PR TITLE
Creates getservicedetailsinput with filters array and version field to support query parameters per fastly api specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking:
 
-- feat(service_details): creates getservicedetailsinput with filters array and version field to support query parameters per fastly api specification ([#806](https://github.com/fastly/go-fastly/pull/806))
+- feat(service_details): Add support for filters in GetServiceDetails ([#806](https://github.com/fastly/go-fastly/pull/806))
 
 ### Enhancements:
 - feat(dns): add support for DNS Zones and TSIG Keys ([#805](https://github.com/fastly/go-fastly/pull/805))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking:
 
+- feat(service_details): creates getservicedetailsinput with filters array and version field to support query parameters per fastly api specification ([#806](https://github.com/fastly/go-fastly/pull/806))
+
 ### Enhancements:
 - feat(dns): add support for DNS Zones and TSIG Keys ([#805](https://github.com/fastly/go-fastly/pull/805))
 

--- a/fastly/fixtures/services/details_with_filters/active.yaml
+++ b/fastly/fixtures/services/details_with_filters/active.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/14.2.0 (+github.com/fastly/go-fastly; go1.25.5)
+    url: https://api.fastly.com/service/DCsx1c14IixEK8PqF0TvqK/details?filter%5Bversions.active%5D=true
+    method: GET
+  response:
+    body: '{"created_at":"2026-05-06T18:10:59Z","comment":"test filters","deleted_at":null,"updated_at":"2026-05-06T18:10:59Z","versions":[{"service_id":"DCsx1c14IixEK8PqF0TvqK","comment":"","locked":false,"active":false,"staging":false,"updated_at":"2026-05-06T18:10:59Z","deployed":false,"deleted_at":null,"testing":false,"number":1,"environments":[],"created_at":"2026-05-06T18:10:59Z"}],"environments":[],"name":"test-service-filters","type":"vcl","customer_id":"4dOhK7xEkULiabovMyhRBu","id":"DCsx1c14IixEK8PqF0TvqK","version":{"number":1,"deleted_at":null,"comment":"","service_id":"DCsx1c14IixEK8PqF0TvqK","staging":false,"active":false,"updated_at":"2026-05-06T18:10:59Z","testing":false,"deployed":false,"environments":[],"locked":false,"created_at":"2026-05-06T18:10:59Z","acls":[],"backends":[],"cache_settings":[],"conditions":[],"dictionaries":[],"directors":[],"domains":[],"gzips":[],"headers":[],"healthchecks":[],"request_settings":[],"response_objects":[],"snippets":[],"vcls":[],"wordpress":[],"settings":{"general.stale_if_error":false,"general.default_pci":0,"general.default_ttl":3600,"general.stale_if_error_ttl":43200,"general.default_host":""}},"active_version":null}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2026 18:11:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-kigq8000102-CHI, cache-ewr-kewr1740073-EWR
+      X-Timer:
+      - S1778091059.434858,VS0,VE755
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/services/details_with_filters/cleanup.yaml
+++ b/fastly/fixtures/services/details_with_filters/cleanup.yaml
@@ -1,0 +1,49 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/14.2.0 (+github.com/fastly/go-fastly; go1.25.5)
+    url: https://api.fastly.com/service/DCsx1c14IixEK8PqF0TvqK
+    method: DELETE
+  response:
+    body: '{"msg":"Bad request","detail":"Service ''DCsx1c14IixEK8PqF0TvqK'' is deleted"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2026 18:11:01 GMT
+      Fastly-Ratelimit-Remaining:
+      - "9997"
+      Fastly-Ratelimit-Reset:
+      - "1778094000"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly
+      Status:
+      - 400 Bad Request
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-kigq8000176-CHI, cache-ewr-kewr1740073-EWR
+      X-Timer:
+      - S1778091062.607509,VS0,VE204
+    status: 400 Bad Request
+    code: 400
+    duration: ""

--- a/fastly/fixtures/services/details_with_filters/create.yaml
+++ b/fastly/fixtures/services/details_with_filters/create.yaml
@@ -1,0 +1,55 @@
+---
+version: 1
+interactions:
+- request:
+    body: comment=test+filters&name=test-service-filters
+    form:
+      comment:
+      - test filters
+      name:
+      - test-service-filters
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - FastlyGo/14.2.0 (+github.com/fastly/go-fastly; go1.25.5)
+    url: https://api.fastly.com/service
+    method: POST
+  response:
+    body: '{"customer_id":"4dOhK7xEkULiabovMyhRBu","comment":"test filters","name":"test-service-filters","type":"vcl","created_at":"2026-05-06T18:10:59Z","publish_key":"","deleted_at":null,"paused":false,"id":"DCsx1c14IixEK8PqF0TvqK","updated_at":"2026-05-06T18:10:59Z","versions":[{"service_id":"DCsx1c14IixEK8PqF0TvqK","testing":false,"deleted_at":null,"created_at":"2026-05-06T18:10:59Z","deployed":false,"number":1,"locked":false,"staging":false,"active":false,"comment":"","updated_at":"2026-05-06T18:10:59Z","environments":[]}],"environments":[]}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2026 18:10:59 GMT
+      Fastly-Ratelimit-Remaining:
+      - "9999"
+      Fastly-Ratelimit-Reset:
+      - "1778094000"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-kigq8000098-CHI, cache-ewr-kewr1740073-EWR
+      X-Timer:
+      - S1778091059.826880,VS0,VE577
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/services/details_with_filters/delete.yaml
+++ b/fastly/fixtures/services/details_with_filters/delete.yaml
@@ -1,0 +1,49 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/14.2.0 (+github.com/fastly/go-fastly; go1.25.5)
+    url: https://api.fastly.com/service/DCsx1c14IixEK8PqF0TvqK
+    method: DELETE
+  response:
+    body: '{"status":"ok"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2026 18:11:01 GMT
+      Fastly-Ratelimit-Remaining:
+      - "9998"
+      Fastly-Ratelimit-Reset:
+      - "1778094000"
+      Pragma:
+      - no-cache
+      Server:
+      - fastly
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-kigq8000176-CHI, cache-ewr-kewr1740073-EWR
+      X-Timer:
+      - S1778091061.064018,VS0,VE510
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/services/details_with_filters/multiple.yaml
+++ b/fastly/fixtures/services/details_with_filters/multiple.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/14.2.0 (+github.com/fastly/go-fastly; go1.25.5)
+    url: https://api.fastly.com/service/DCsx1c14IixEK8PqF0TvqK/details?filter%5Bversions.active%5D=true&filter%5Bversions.staged%5D=true
+    method: GET
+  response:
+    body: '{"created_at":"2026-05-06T18:10:59Z","comment":"test filters","deleted_at":null,"updated_at":"2026-05-06T18:10:59Z","versions":[{"service_id":"DCsx1c14IixEK8PqF0TvqK","comment":"","locked":false,"active":false,"staging":false,"updated_at":"2026-05-06T18:10:59Z","deployed":false,"deleted_at":null,"testing":false,"number":1,"environments":[],"created_at":"2026-05-06T18:10:59Z"}],"environments":[],"name":"test-service-filters","type":"vcl","customer_id":"4dOhK7xEkULiabovMyhRBu","id":"DCsx1c14IixEK8PqF0TvqK","version":{"number":1,"deleted_at":null,"comment":"","service_id":"DCsx1c14IixEK8PqF0TvqK","staging":false,"active":false,"updated_at":"2026-05-06T18:10:59Z","testing":false,"deployed":false,"environments":[],"locked":false,"created_at":"2026-05-06T18:10:59Z","acls":[],"backends":[],"cache_settings":[],"conditions":[],"dictionaries":[],"directors":[],"domains":[],"gzips":[],"headers":[],"healthchecks":[],"request_settings":[],"response_objects":[],"snippets":[],"vcls":[],"wordpress":[],"settings":{"general.stale_if_error":false,"general.default_pci":0,"general.default_ttl":3600,"general.stale_if_error_ttl":43200,"general.default_host":""}},"active_version":null}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2026 18:11:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-klot8100063-CHI, cache-ewr-kewr1740073-EWR
+      X-Timer:
+      - S1778091060.280655,VS0,VE246
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/services/details_with_filters/version.yaml
+++ b/fastly/fixtures/services/details_with_filters/version.yaml
@@ -1,0 +1,46 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/14.2.0 (+github.com/fastly/go-fastly; go1.25.5)
+    url: https://api.fastly.com/service/DCsx1c14IixEK8PqF0TvqK/details?version=1
+    method: GET
+  response:
+    body: '{"created_at":"2026-05-06T18:10:59Z","type":"vcl","updated_at":"2026-05-06T18:10:59Z","id":"DCsx1c14IixEK8PqF0TvqK","environments":[],"customer_id":"4dOhK7xEkULiabovMyhRBu","versions":[{"service_id":"DCsx1c14IixEK8PqF0TvqK","comment":"","locked":false,"active":false,"staging":false,"updated_at":"2026-05-06T18:10:59Z","deployed":false,"deleted_at":null,"testing":false,"number":1,"environments":[],"created_at":"2026-05-06T18:10:59Z"}],"name":"test-service-filters","deleted_at":null,"comment":"test
+      filters","version":{"updated_at":"2026-05-06T18:10:59Z","locked":false,"number":1,"staging":false,"deployed":false,"environments":[],"created_at":"2026-05-06T18:10:59Z","testing":false,"service_id":"DCsx1c14IixEK8PqF0TvqK","comment":"","active":false,"deleted_at":null,"acls":[],"backends":[],"cache_settings":[],"conditions":[],"dictionaries":[],"directors":[],"domains":[],"gzips":[],"headers":[],"healthchecks":[],"request_settings":[],"response_objects":[],"snippets":[],"vcls":[],"wordpress":[],"settings":{"general.default_host":"","general.stale_if_error":false,"general.default_ttl":3600,"general.stale_if_error_ttl":43200,"general.default_pci":0}},"active_version":null}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 06 May 2026 18:11:01 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-kigq8000135-CHI, cache-ewr-kewr1740073-EWR
+      X-Timer:
+      - S1778091061.644428,VS0,VE399
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/service_details.go
+++ b/fastly/service_details.go
@@ -174,17 +174,47 @@ func (c *Client) GetService(ctx context.Context, i *GetServiceInput) (*Service, 
 	return s, nil
 }
 
+// ServiceDetailsFilter represents a filter parameter for GetServiceDetails.
+type ServiceDetailsFilter struct {
+	// Key is the filter key (e.g., "versions.active").
+	Key string
+	// Value is the boolean value for the filter.
+	Value bool
+}
+
+// GetServiceDetailsInput is used as input to the GetServiceDetails function.
+type GetServiceDetailsInput struct {
+	// ServiceID is an alphanumeric string identifying the service (required).
+	ServiceID string
+	// Filters is an array of filter key-value pairs.
+	// Each filter (e.g., {Key: "versions.active", Value: true}) will be sent as filter[versions.active]=true.
+	// Available filter keys are versions.active, versions.staged, and versions.latest_draft
+	Filters []ServiceDetailsFilter
+	// Version is the number identifying a version of the service.
+	Version *int
+}
+
 // GetServiceDetails retrieves the specified resource.
 //
 // If no service exists for the given id, the API returns a 400 response not 404.
-func (c *Client) GetServiceDetails(ctx context.Context, i *GetServiceInput) (*ServiceDetail, error) {
+func (c *Client) GetServiceDetails(ctx context.Context, i *GetServiceDetailsInput) (*ServiceDetail, error) {
 	if i.ServiceID == "" {
 		return nil, ErrMissingServiceID
 	}
 
 	path := ToSafeURL("service", i.ServiceID, "details")
 
-	resp, err := c.Get(ctx, path, CreateRequestOptions())
+	requestOptions := CreateRequestOptions()
+	if len(i.Filters) > 0 {
+		for _, filter := range i.Filters {
+			requestOptions.Params["filter["+filter.Key+"]"] = fmt.Sprintf("%t", filter.Value)
+		}
+	}
+	if i.Version != nil {
+		requestOptions.Params["version"] = fmt.Sprintf("%d", *i.Version)
+	}
+
+	resp, err := c.Get(ctx, path, requestOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/fastly/service_details_test.go
+++ b/fastly/service_details_test.go
@@ -113,7 +113,7 @@ func TestClient_Services(t *testing.T) {
 	// Get Details
 	var nsd *ServiceDetail
 	Record(t, "services/details", func(c *Client) {
-		nsd, err = c.GetServiceDetails(context.TODO(), &GetServiceInput{
+		nsd, err = c.GetServiceDetails(context.TODO(), &GetServiceDetailsInput{
 			ServiceID: *s.ServiceID,
 		})
 	})
@@ -299,7 +299,7 @@ func TestClient_Services_Compute(t *testing.T) {
 	// Get Details
 	var nsd *ServiceDetail
 	Record(t, "services/compute/details", func(c *Client) {
-		nsd, err = c.GetServiceDetails(context.TODO(), &GetServiceInput{
+		nsd, err = c.GetServiceDetails(context.TODO(), &GetServiceDetailsInput{
 			ServiceID: *s.ServiceID,
 		})
 	})
@@ -390,6 +390,112 @@ func TestClient_UpdateService_validation(t *testing.T) {
 
 func TestClient_DeleteService_validation(t *testing.T) {
 	err := TestClient.DeleteService(context.TODO(), &DeleteServiceInput{})
+	if !errors.Is(err, ErrMissingServiceID) {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_GetServiceDetails_WithFilters(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	// Create
+	var s *Service
+	Record(t, "services/details_with_filters/create", func(c *Client) {
+		s, err = c.CreateService(context.TODO(), &CreateServiceInput{
+			Name:    ToPointer("test-service-filters"),
+			Comment: ToPointer("test filters"),
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure deleted
+	defer func() {
+		Record(t, "services/details_with_filters/cleanup", func(c *Client) {
+			_ = c.DeleteService(context.TODO(), &DeleteServiceInput{
+				ServiceID: *s.ServiceID,
+			})
+		})
+	}()
+
+	// Get Details with versions.active filter
+	var nsd *ServiceDetail
+	Record(t, "services/details_with_filters/active", func(c *Client) {
+		nsd, err = c.GetServiceDetails(context.TODO(), &GetServiceDetailsInput{
+			ServiceID: *s.ServiceID,
+			Filters: []ServiceDetailsFilter{
+				{Key: "versions.active", Value: true},
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *s.Name != *nsd.Name {
+		t.Errorf("bad name: %q (%q)", *s.Name, *nsd.Name)
+	}
+	if *s.Comment != *nsd.Comment {
+		t.Errorf("bad comment: %q (%q)", *s.Comment, *nsd.Comment)
+	}
+	if nsd.Version == nil {
+		t.Fatal("Service Detail Version is nil")
+	}
+	if *nsd.Version.Number == 0 {
+		t.Errorf("Service Detail Version is empty: (%#v)", nsd)
+	}
+
+	// Get Details with multiple filters
+	var nsd2 *ServiceDetail
+	Record(t, "services/details_with_filters/multiple", func(c *Client) {
+		nsd2, err = c.GetServiceDetails(context.TODO(), &GetServiceDetailsInput{
+			ServiceID: *s.ServiceID,
+			Filters: []ServiceDetailsFilter{
+				{Key: "versions.active", Value: true},
+				{Key: "versions.staged", Value: true},
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *s.Name != *nsd2.Name {
+		t.Errorf("bad name: %q (%q)", *s.Name, *nsd2.Name)
+	}
+
+	// Get Details with version parameter
+	var nsd3 *ServiceDetail
+	Record(t, "services/details_with_filters/version", func(c *Client) {
+		nsd3, err = c.GetServiceDetails(context.TODO(), &GetServiceDetailsInput{
+			ServiceID: *s.ServiceID,
+			Version:   ToPointer(1),
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *s.Name != *nsd3.Name {
+		t.Errorf("bad name: %q (%q)", *s.Name, *nsd3.Name)
+	}
+
+	// Delete
+	Record(t, "services/details_with_filters/delete", func(c *Client) {
+		err = c.DeleteService(context.TODO(), &DeleteServiceInput{
+			ServiceID: *s.ServiceID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClient_GetServiceDetails_validation(t *testing.T) {
+	_, err := TestClient.GetServiceDetails(context.TODO(), &GetServiceDetailsInput{})
 	if !errors.Is(err, ErrMissingServiceID) {
 		t.Errorf("bad error: %s", err)
 	}


### PR DESCRIPTION
BREAKING CHANGE: changes the input struct for the get service details endpoint

### Change summary

The implementation handles the filter parameters by prefixing them with filter to match the API's expected format (e.g., filter[versions.active]=true).         

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
