### PR TITLE
[CDTOOL-1316] Add Support for Backend Connection-Reuse Limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Enhancements:
 - feat(dns): add support for DNS Zones and TSIG Keys ([#805](https://github.com/fastly/go-fastly/pull/805))
+- feat(backend): add support for the 'max_use' and 'max_lifetime' fields ([#807](https://github.com/fastly/go-fastly/pull/807))
 
 ### Dependencies:
 - build(deps): `golang.org/x/crypto` from 0.49.0 to 0.50.0 ([#804](https://github.com/fastly/go-fastly/pull/804))

--- a/fastly/backend.go
+++ b/fastly/backend.go
@@ -22,6 +22,8 @@ type Backend struct {
 	Hostname            *string    `mapstructure:"hostname"`
 	KeepAliveTime       *int       `mapstructure:"keepalive_time"`
 	MaxConn             *int       `mapstructure:"max_conn"`
+	MaxUse              *int       `mapstructure:"max_use"`
+	MaxLifetime         *int       `mapstructure:"max_lifetime"`
 	MaxTLSVersion       *string    `mapstructure:"max_tls_version"`
 	MinTLSVersion       *string    `mapstructure:"min_tls_version"`
 	Name                *string    `mapstructure:"name"`
@@ -103,6 +105,10 @@ type CreateBackendInput struct {
 	KeepAliveTime *int `url:"keepalive_time,omitempty"`
 	// MaxConn is the maximum number of concurrent connections this backend will accept.
 	MaxConn *int `url:"max_conn,omitempty"`
+	// MaxUse is the maximum number of times an HTTP keepalive connection can be used. `0` is unlimited.
+	MaxUse *int `url:"max_use,omitempty"`
+	// MaxLifetime is the upper bound in milliseconds for how long an HTTP keepalive connection can be open before it is no longer used. `0` is unlimited.
+	MaxLifetime *int `url:"max_lifetime,omitempty"`
 	// MaxTLSVersion is the maximum allowed TLS version on SSL connections to this backend.
 	MaxTLSVersion *string `url:"max_tls_version,omitempty"`
 	// MinTLSVersion is the minimum allowed TLS version on SSL connections to this backend.
@@ -236,6 +242,10 @@ type UpdateBackendInput struct {
 	KeepAliveTime *int `url:"keepalive_time,omitempty"`
 	// MaxConn is the maximum number of concurrent connections this backend will accept.
 	MaxConn *int `url:"max_conn,omitempty"`
+	// MaxUse is the maximum number of times an HTTP keepalive connection can be used. `0` is unlimited.
+	MaxUse *int `url:"max_use,omitempty"`
+	// MaxLifetime is the upper bound in milliseconds for how long an HTTP keepalive connection can be open before it is no longer used. `0` is unlimited.
+	MaxLifetime *int `url:"max_lifetime,omitempty"`
 	// MaxTLSVersion is the maximum allowed TLS version on SSL connections to this backend.
 	MaxTLSVersion *string `url:"max_tls_version,omitempty"`
 	// MinTLSVersion is the minimum allowed TLS version on SSL connections to this backend.

--- a/fastly/backend_test.go
+++ b/fastly/backend_test.go
@@ -24,6 +24,8 @@ func TestClient_Backends_Compute(t *testing.T) {
 			Name:           ToPointer("test-backend-compute"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
 			ConnectTimeout: ToPointer(1500),
+			MaxUse:         ToPointer(100),
+			MaxLifetime:    ToPointer(60000),
 			OverrideHost:   ToPointer("origin.example.com"),
 			SSLCheckCert:   ToPointer(Compatibool(false)),
 			SSLCiphers:     ToPointer("DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384"),
@@ -62,6 +64,12 @@ func TestClient_Backends_Compute(t *testing.T) {
 	}
 	if *b.ConnectTimeout != 1500 {
 		t.Errorf("bad connect_timeout: %d", *b.ConnectTimeout)
+	}
+	if *b.MaxUse != 100 {
+		t.Errorf("bad max_use: %d", *b.MaxUse)
+	}
+	if *b.MaxLifetime != 60000 {
+		t.Errorf("bad max_lifetime: %d", *b.MaxLifetime)
 	}
 	if *b.OverrideHost != "origin.example.com" {
 		t.Errorf("bad override_host: %q", *b.OverrideHost)
@@ -127,6 +135,8 @@ func TestClient_Backends_Compute(t *testing.T) {
 			ServiceVersion: *tv.Number,
 			Name:           "test-backend-compute",
 			NewName:        ToPointer("new-test-backend-compute"),
+			MaxUse:         ToPointer(200),
+			MaxLifetime:    ToPointer(120000),
 			OverrideHost:   ToPointer("www.example.com"),
 			Port:           ToPointer(1234),
 			PreferIPv6:     ToPointer(Compatibool(true)),
@@ -141,6 +151,12 @@ func TestClient_Backends_Compute(t *testing.T) {
 	}
 	if *ub.Name != "new-test-backend-compute" {
 		t.Errorf("bad name: %q", *ub.Name)
+	}
+	if *ub.MaxUse != 200 {
+		t.Errorf("bad max_use: %d", *ub.MaxUse)
+	}
+	if *ub.MaxLifetime != 120000 {
+		t.Errorf("bad max_lifetime: %d", *ub.MaxLifetime)
 	}
 	if *ub.OverrideHost != "www.example.com" {
 		t.Errorf("bad override_host: %q", *ub.OverrideHost)
@@ -234,6 +250,8 @@ func TestClient_Backends(t *testing.T) {
 			Name:           ToPointer("test-backend"),
 			Address:        ToPointer("integ-test.go-fastly.com"),
 			ConnectTimeout: ToPointer(1500),
+			MaxUse:         ToPointer(100),
+			MaxLifetime:    ToPointer(60000),
 			OverrideHost:   ToPointer("origin.example.com"),
 			SSLCheckCert:   ToPointer(Compatibool(false)),
 			SSLCiphers:     ToPointer("DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384"),
@@ -272,6 +290,12 @@ func TestClient_Backends(t *testing.T) {
 	}
 	if *b.ConnectTimeout != 1500 {
 		t.Errorf("bad connect_timeout: %d", *b.ConnectTimeout)
+	}
+	if *b.MaxUse != 100 {
+		t.Errorf("bad max_use: %d", *b.MaxUse)
+	}
+	if *b.MaxLifetime != 60000 {
+		t.Errorf("bad max_lifetime: %d", *b.MaxLifetime)
 	}
 	if *b.OverrideHost != "origin.example.com" {
 		t.Errorf("bad override_host: %q", *b.OverrideHost)
@@ -337,6 +361,8 @@ func TestClient_Backends(t *testing.T) {
 			ServiceVersion: *tv.Number,
 			Name:           "test-backend",
 			NewName:        ToPointer("new-test-backend"),
+			MaxUse:         ToPointer(200),
+			MaxLifetime:    ToPointer(120000),
 			OverrideHost:   ToPointer("www.example.com"),
 			Port:           ToPointer(1234),
 			PreferIPv6:     ToPointer(Compatibool(true)),
@@ -351,6 +377,12 @@ func TestClient_Backends(t *testing.T) {
 	}
 	if *ub.Name != "new-test-backend" {
 		t.Errorf("bad name: %q", *ub.Name)
+	}
+	if *ub.MaxUse != 200 {
+		t.Errorf("bad max_use: %d", *ub.MaxUse)
+	}
+	if *ub.MaxLifetime != 120000 {
+		t.Errorf("bad max_lifetime: %d", *ub.MaxLifetime)
 	}
 	if *ub.OverrideHost != "www.example.com" {
 		t.Errorf("bad override_host: %q", *ub.OverrideHost)

--- a/fastly/fixtures/backends/cleanup.yaml
+++ b/fastly/fixtures/backends/cleanup.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/102/backend/test-backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/145/backend/test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e test-backend, service =\u003e kKJb5bOFI47uHeBVluGfX1,
-      version =\u003e 102 }''"}'
+      version =\u003e 145 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,15 +21,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:14 GMT
+      - Wed, 06 May 2026 18:11:13 GMT
       Fastly-Ratelimit-Remaining:
-      - "9988"
+      - "9986"
       Fastly-Ratelimit-Reset:
-      - "1746633600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100020-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-kigq8000157-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630195.678194,VS0,VE110
+      - S1778091074.852671,VS0,VE138
     status: 404 Not Found
     code: 404
     duration: ""
@@ -54,13 +54,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/102/backend/new-test-backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/145/backend/new-test-backend
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e new-test-backend, service =\u003e
-      kKJb5bOFI47uHeBVluGfX1, version =\u003e 102 }''"}'
+      kKJb5bOFI47uHeBVluGfX1, version =\u003e 145 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -69,15 +69,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:14 GMT
+      - Wed, 06 May 2026 18:11:14 GMT
       Fastly-Ratelimit-Remaining:
-      - "9987"
+      - "9984"
       Fastly-Ratelimit-Reset:
-      - "1746633600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -91,9 +91,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100159-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-kigq8000049-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630195.795885,VS0,VE117
+      - S1778091074.170498,VS0,VE147
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/backends/compute/cleanup.yaml
+++ b/fastly/fixtures/backends/compute/cleanup.yaml
@@ -6,13 +6,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/7/backend/test-backend-compute
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/62/backend/test-backend-compute
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e test-backend-compute, service =\u003e
-      XsjdElScZGjmfCcTwsYRC1, version =\u003e 7 }''"}'
+      XsjdElScZGjmfCcTwsYRC1, version =\u003e 62 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:10 GMT
+      - Wed, 06 May 2026 18:11:13 GMT
       Fastly-Ratelimit-Remaining:
-      - "9965"
+      - "9987"
       Fastly-Ratelimit-Reset:
-      - "1756497600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100133-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-klot8100098-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496290.992615,VS0,VE123
+      - S1778091074.650555,VS0,VE190
     status: 404 Not Found
     code: 404
     duration: ""
@@ -54,13 +54,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/7/backend/new-test-backend-compute
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/62/backend/new-test-backend-compute
     method: DELETE
   response:
     body: '{"msg":"Record not found","detail":"Couldn''t find Backend ''{ deleted
       =\u003e 0000-00-00 00:00:00, name =\u003e new-test-backend-compute, service
-      =\u003e XsjdElScZGjmfCcTwsYRC1, version =\u003e 7 }''"}'
+      =\u003e XsjdElScZGjmfCcTwsYRC1, version =\u003e 62 }''"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -69,11 +69,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:10 GMT
+      - Wed, 06 May 2026 18:11:14 GMT
       Fastly-Ratelimit-Remaining:
-      - "9964"
+      - "9985"
       Fastly-Ratelimit-Reset:
-      - "1756497600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
@@ -91,9 +91,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000151-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-kigq8000108-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496290.137013,VS0,VE138
+      - S1778091074.002443,VS0,VE150
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/backends/compute/create.yaml
+++ b/fastly/fixtures/backends/compute/create.yaml
@@ -2,12 +2,16 @@
 version: 1
 interactions:
 - request:
-    body: address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend-compute&override_host=origin.example.com&ssl_check_cert=0&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384&ssl_sni_hostname=ssl-hostname.com
+    body: address=integ-test.go-fastly.com&connect_timeout=1500&max_lifetime=60000&max_use=100&name=test-backend-compute&override_host=origin.example.com&ssl_check_cert=0&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384&ssl_sni_hostname=ssl-hostname.com
     form:
       address:
       - integ-test.go-fastly.com
       connect_timeout:
       - "1500"
+      max_lifetime:
+      - "60000"
+      max_use:
+      - "100"
       name:
       - test-backend-compute
       override_host:
@@ -22,11 +26,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/7/backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/62/backend
     method: POST
   response:
-    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend-compute","override_host":"origin.example.com","ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_sni_hostname":"ssl-hostname.com","service_id":"XsjdElScZGjmfCcTwsYRC1","version":7,"tcp_keepalive_enable":null,"updated_at":"2025-08-29T19:38:08Z","client_cert":null,"created_at":"2025-08-29T19:38:08Z","max_conn":200,"ssl_cert_hostname":null,"prefer_ipv6":true,"ssl_ca_cert":null,"first_byte_timeout":15000,"ssl_client_key":null,"comment":"","hostname":"integ-test.go-fastly.com","error_threshold":0,"request_condition":"","shield":null,"min_tls_version":null,"share_key":null,"between_bytes_timeout":10000,"tcp_keepalive_probes":null,"ipv6":null,"use_ssl":false,"auto_loadbalance":false,"weight":100,"ssl_client_cert":null,"ssl_hostname":null,"healthcheck":null,"tcp_keepalive_interval":null,"keepalive_time":null,"tcp_keepalive_time":null,"deleted_at":null,"ipv4":null,"port":80,"max_tls_version":null}'
+    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"max_lifetime":60000,"max_use":100,"name":"test-backend-compute","override_host":"origin.example.com","ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_sni_hostname":"ssl-hostname.com","service_id":"XsjdElScZGjmfCcTwsYRC1","version":62,"ssl_client_cert":null,"ipv4":null,"weight":100,"ssl_ca_cert":null,"tcp_keepalive_enable":null,"deleted_at":null,"updated_at":"2026-05-06T18:11:08Z","share_key":null,"tcp_keepalive_probes":null,"shield":null,"use_ssl":false,"ssl_cert_hostname":null,"between_bytes_timeout":10000,"prefer_ipv6":true,"ipv6":null,"created_at":"2026-05-06T18:11:08Z","port":80,"ssl_client_key":null,"auto_loadbalance":false,"min_tls_version":null,"max_conn":200,"client_cert":null,"request_condition":"","healthcheck":null,"hostname":"integ-test.go-fastly.com","ssl_hostname":null,"comment":"","first_byte_timeout":15000,"keepalive_time":null,"tcp_keepalive_interval":null,"error_threshold":0,"tcp_keepalive_time":null,"max_tls_version":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,11 +39,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:08 GMT
+      - Wed, 06 May 2026 18:11:08 GMT
       Fastly-Ratelimit-Remaining:
-      - "9970"
+      - "9996"
       Fastly-Ratelimit-Reset:
-      - "1756497600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
@@ -57,9 +61,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100059-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-kigq8000110-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496288.115978,VS0,VE299
+      - S1778091068.634298,VS0,VE1031
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/compute/delete.yaml
+++ b/fastly/fixtures/backends/compute/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/7/backend/new-test-backend-compute
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/62/backend/new-test-backend-compute
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:09 GMT
+      - Wed, 06 May 2026 18:11:13 GMT
       Fastly-Ratelimit-Remaining:
-      - "9966"
+      - "9988"
       Fastly-Ratelimit-Reset:
-      - "1756497600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000151-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-kigq8000108-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496290.676820,VS0,VE295
+      - S1778091073.096477,VS0,VE540
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/compute/get.yaml
+++ b/fastly/fixtures/backends/compute/get.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/7/backend/test-backend-compute
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/62/backend/test-backend-compute
     method: GET
   response:
-    body: '{"max_conn":200,"ssl_ca_cert":null,"share_key":null,"error_threshold":0,"comment":"","name":"test-backend-compute","between_bytes_timeout":10000,"shield":null,"keepalive_time":null,"tcp_keepalive_time":null,"ipv6":null,"deleted_at":null,"hostname":"integ-test.go-fastly.com","weight":100,"ssl_cert_hostname":null,"port":80,"created_at":"2025-08-29T19:38:08Z","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","client_cert":null,"max_tls_version":null,"connect_timeout":1500,"ssl_hostname":null,"ssl_sni_hostname":"ssl-hostname.com","ssl_client_cert":null,"ipv4":null,"request_condition":"","first_byte_timeout":15000,"service_id":"XsjdElScZGjmfCcTwsYRC1","updated_at":"2025-08-29T19:38:08Z","auto_loadbalance":false,"override_host":"origin.example.com","healthcheck":null,"tcp_keepalive_interval":null,"tcp_keepalive_enable":null,"version":7,"ssl_client_key":null,"address":"integ-test.go-fastly.com","min_tls_version":null,"tcp_keepalive_probes":null,"ssl_check_cert":false,"prefer_ipv6":true,"use_ssl":false}'
+    body: '{"min_tls_version":null,"comment":"","address":"integ-test.go-fastly.com","client_cert":null,"first_byte_timeout":15000,"prefer_ipv6":true,"ssl_cert_hostname":null,"hostname":"integ-test.go-fastly.com","shield":null,"ssl_client_cert":null,"use_ssl":false,"share_key":null,"created_at":"2026-05-06T18:11:08Z","name":"test-backend-compute","ssl_hostname":null,"max_lifetime":60000,"ssl_check_cert":false,"ssl_client_key":null,"port":80,"healthcheck":null,"between_bytes_timeout":10000,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","tcp_keepalive_interval":null,"service_id":"XsjdElScZGjmfCcTwsYRC1","version":62,"tcp_keepalive_enable":null,"ipv4":null,"ssl_sni_hostname":"ssl-hostname.com","tcp_keepalive_time":null,"deleted_at":null,"override_host":"origin.example.com","max_use":100,"connect_timeout":1500,"request_condition":"","ipv6":null,"tcp_keepalive_probes":null,"ssl_ca_cert":null,"max_conn":200,"error_threshold":0,"weight":100,"updated_at":"2026-05-06T18:11:08Z","auto_loadbalance":false,"keepalive_time":null,"max_tls_version":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:08 GMT
+      - Wed, 06 May 2026 18:11:09 GMT
       Pragma:
       - no-cache
       Server:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100133-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-klot8100098-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496289.627567,VS0,VE172
+      - S1778091069.920812,VS0,VE171
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/compute/list.yaml
+++ b/fastly/fixtures/backends/compute/list.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/7/backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/62/backend
     method: GET
   response:
-    body: '[{"name":"test-backend-compute","tcp_keepalive_interval":null,"use_ssl":false,"first_byte_timeout":15000,"ssl_client_cert":null,"share_key":null,"ssl_ca_cert":null,"max_conn":200,"keepalive_time":null,"version":7,"tcp_keepalive_time":null,"address":"integ-test.go-fastly.com","created_at":"2025-08-29T19:38:08Z","service_id":"XsjdElScZGjmfCcTwsYRC1","ssl_client_key":null,"auto_loadbalance":false,"prefer_ipv6":true,"hostname":"integ-test.go-fastly.com","ssl_hostname":null,"connect_timeout":1500,"shield":null,"tcp_keepalive_probes":null,"deleted_at":null,"between_bytes_timeout":10000,"min_tls_version":null,"updated_at":"2025-08-29T19:38:08Z","ipv4":null,"client_cert":null,"max_tls_version":null,"override_host":"origin.example.com","tcp_keepalive_enable":null,"port":80,"weight":100,"error_threshold":0,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","healthcheck":null,"request_condition":"","ssl_sni_hostname":"ssl-hostname.com","ssl_check_cert":false,"comment":"","ssl_cert_hostname":null,"ipv6":null}]'
+    body: '[{"ssl_cert_hostname":null,"tcp_keepalive_interval":null,"hostname":"integ-test.go-fastly.com","ipv4":null,"share_key":null,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","weight":100,"client_cert":null,"max_conn":200,"keepalive_time":null,"ssl_ca_cert":null,"max_lifetime":60000,"tcp_keepalive_probes":null,"address":"integ-test.go-fastly.com","min_tls_version":null,"between_bytes_timeout":10000,"ssl_client_key":null,"healthcheck":null,"max_tls_version":null,"tcp_keepalive_time":null,"ssl_hostname":null,"first_byte_timeout":15000,"ssl_client_cert":null,"use_ssl":false,"comment":"","error_threshold":0,"deleted_at":null,"auto_loadbalance":false,"name":"test-backend-compute","override_host":"origin.example.com","connect_timeout":1500,"tcp_keepalive_enable":null,"updated_at":"2026-05-06T18:11:08Z","ipv6":null,"created_at":"2026-05-06T18:11:08Z","service_id":"XsjdElScZGjmfCcTwsYRC1","ssl_check_cert":false,"shield":null,"max_use":100,"port":80,"ssl_sni_hostname":"ssl-hostname.com","version":62,"request_condition":"","prefer_ipv6":true}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,7 +19,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:08 GMT
+      - Wed, 06 May 2026 18:11:08 GMT
       Pragma:
       - no-cache
       Server:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100059-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-kigq8000110-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496288.439412,VS0,VE167
+      - S1778091069.680499,VS0,VE227
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/compute/update.yaml
+++ b/fastly/fixtures/backends/compute/update.yaml
@@ -2,8 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: name=new-test-backend-compute&override_host=www.example.com&port=1234&prefer_ipv6=1&share_key=sharedkey&ssl_check_cert=0&ssl_ciphers=HIGH&ssl_sni_hostname=ssl-hostname-updated.com
+    body: max_lifetime=120000&max_use=200&name=new-test-backend-compute&override_host=www.example.com&port=1234&prefer_ipv6=1&share_key=sharedkey&ssl_check_cert=0&ssl_ciphers=HIGH&ssl_sni_hostname=ssl-hostname-updated.com
     form:
+      max_lifetime:
+      - "120000"
+      max_use:
+      - "200"
       name:
       - new-test-backend-compute
       override_host:
@@ -24,11 +28,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/7/backend/test-backend-compute
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/62/backend/test-backend-compute
     method: PUT
   response:
-    body: '{"ssl_client_key":null,"name":"new-test-backend-compute","ssl_hostname":null,"ssl_client_cert":null,"ipv4":null,"ssl_ca_cert":null,"share_key":"sharedkey","ssl_sni_hostname":"ssl-hostname-updated.com","tcp_keepalive_time":null,"client_cert":null,"override_host":"www.example.com","max_tls_version":null,"address":"integ-test.go-fastly.com","use_ssl":false,"healthcheck":null,"deleted_at":null,"ssl_ciphers":"HIGH","connect_timeout":1500,"prefer_ipv6":true,"request_condition":"","auto_loadbalance":false,"version":7,"first_byte_timeout":15000,"ssl_check_cert":false,"weight":100,"updated_at":"2025-08-29T19:38:08Z","comment":"","keepalive_time":null,"created_at":"2025-08-29T19:38:08Z","tcp_keepalive_interval":null,"tcp_keepalive_enable":null,"service_id":"XsjdElScZGjmfCcTwsYRC1","min_tls_version":null,"max_conn":200,"shield":null,"hostname":"integ-test.go-fastly.com","tcp_keepalive_probes":null,"error_threshold":0,"ipv6":null,"ssl_cert_hostname":null,"between_bytes_timeout":10000,"port":1234}'
+    body: '{"tcp_keepalive_enable":null,"tcp_keepalive_probes":null,"service_id":"XsjdElScZGjmfCcTwsYRC1","comment":"","deleted_at":null,"ssl_client_cert":null,"tcp_keepalive_time":null,"port":1234,"ipv6":null,"created_at":"2026-05-06T18:11:08Z","first_byte_timeout":15000,"max_conn":200,"ssl_check_cert":false,"ssl_client_key":null,"request_condition":"","ssl_sni_hostname":"ssl-hostname-updated.com","prefer_ipv6":true,"version":62,"hostname":"integ-test.go-fastly.com","name":"new-test-backend-compute","min_tls_version":null,"override_host":"www.example.com","max_use":200,"auto_loadbalance":false,"ssl_ciphers":"HIGH","max_lifetime":120000,"client_cert":null,"share_key":"sharedkey","ssl_cert_hostname":null,"connect_timeout":1500,"address":"integ-test.go-fastly.com","use_ssl":false,"tcp_keepalive_interval":null,"keepalive_time":null,"weight":100,"between_bytes_timeout":10000,"ipv4":null,"updated_at":"2026-05-06T18:11:08Z","ssl_ca_cert":null,"ssl_hostname":null,"shield":null,"healthcheck":null,"error_threshold":0,"max_tls_version":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -37,11 +41,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:09 GMT
+      - Wed, 06 May 2026 18:11:10 GMT
       Fastly-Ratelimit-Remaining:
-      - "9969"
+      - "9994"
       Fastly-Ratelimit-Reset:
-      - "1756497600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
@@ -59,9 +63,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100133-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-klot8100098-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496289.819217,VS0,VE279
+      - S1778091069.470946,VS0,VE537
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/compute/update_allow_empty_values.yaml
+++ b/fastly/fixtures/backends/compute/update_allow_empty_values.yaml
@@ -12,11 +12,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/7/backend/new-test-backend-compute
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/62/backend/new-test-backend-compute
     method: PUT
   response:
-    body: '{"error_threshold":0,"ipv6":null,"between_bytes_timeout":10000,"ssl_cert_hostname":null,"port":0,"min_tls_version":null,"service_id":"XsjdElScZGjmfCcTwsYRC1","max_conn":200,"hostname":"integ-test.go-fastly.com","shield":null,"tcp_keepalive_probes":null,"weight":100,"updated_at":"2025-08-29T19:38:08Z","created_at":"2025-08-29T19:38:08Z","tcp_keepalive_interval":null,"keepalive_time":null,"comment":"","tcp_keepalive_enable":null,"first_byte_timeout":15000,"ssl_check_cert":false,"connect_timeout":1500,"healthcheck":null,"deleted_at":null,"ssl_ciphers":"HIGH","prefer_ipv6":true,"auto_loadbalance":false,"request_condition":"","version":7,"client_cert":null,"address":"integ-test.go-fastly.com","override_host":null,"max_tls_version":null,"use_ssl":false,"ssl_client_cert":null,"ssl_hostname":null,"share_key":"sharedkey","ssl_ca_cert":null,"ssl_sni_hostname":"ssl-hostname-updated.com","ipv4":null,"tcp_keepalive_time":null,"ssl_client_key":null,"name":"new-test-backend-compute"}'
+    body: '{"first_byte_timeout":15000,"comment":"","max_use":200,"tcp_keepalive_time":null,"ssl_hostname":null,"share_key":"sharedkey","ipv6":null,"client_cert":null,"version":62,"shield":null,"ssl_cert_hostname":null,"between_bytes_timeout":10000,"tcp_keepalive_probes":null,"updated_at":"2026-05-06T18:11:09Z","error_threshold":0,"min_tls_version":null,"use_ssl":false,"connect_timeout":1500,"ssl_ca_cert":null,"deleted_at":null,"healthcheck":null,"ssl_sni_hostname":"ssl-hostname-updated.com","request_condition":"","tcp_keepalive_enable":null,"prefer_ipv6":true,"ssl_client_key":null,"override_host":null,"max_tls_version":null,"tcp_keepalive_interval":null,"ssl_ciphers":"HIGH","name":"new-test-backend-compute","service_id":"XsjdElScZGjmfCcTwsYRC1","address":"integ-test.go-fastly.com","hostname":"integ-test.go-fastly.com","ssl_client_cert":null,"port":0,"max_lifetime":120000,"keepalive_time":null,"ssl_check_cert":false,"auto_loadbalance":false,"max_conn":200,"weight":100,"created_at":"2026-05-06T18:11:08Z","ipv4":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -25,11 +25,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:09 GMT
+      - Wed, 06 May 2026 18:11:12 GMT
       Fastly-Ratelimit-Remaining:
-      - "9967"
+      - "9990"
       Fastly-Ratelimit-Reset:
-      - "1756497600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
@@ -47,9 +47,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000151-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-kigq8000108-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496289.383749,VS0,VE273
+      - S1778091072.066288,VS0,VE544
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/compute/update_ignore_empty_values.yaml
+++ b/fastly/fixtures/backends/compute/update_ignore_empty_values.yaml
@@ -8,11 +8,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/7/backend/new-test-backend-compute
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version/62/backend/new-test-backend-compute
     method: PUT
   response:
-    body: '{"comment":"","tcp_keepalive_enable":null,"weight":100,"ssl_client_cert":null,"error_threshold":0,"service_id":"XsjdElScZGjmfCcTwsYRC1","ipv6":null,"min_tls_version":null,"ipv4":null,"ssl_ca_cert":null,"keepalive_time":null,"share_key":"sharedkey","tcp_keepalive_time":null,"override_host":"www.example.com","healthcheck":null,"request_condition":"","ssl_hostname":null,"ssl_check_cert":false,"shield":null,"prefer_ipv6":true,"first_byte_timeout":15000,"client_cert":null,"use_ssl":false,"max_tls_version":null,"version":7,"max_conn":200,"name":"new-test-backend-compute","tcp_keepalive_probes":null,"deleted_at":null,"port":1234,"created_at":"2025-08-29T19:38:08Z","ssl_ciphers":"HIGH","between_bytes_timeout":10000,"auto_loadbalance":false,"ssl_sni_hostname":"ssl-hostname-updated.com","connect_timeout":1500,"ssl_cert_hostname":null,"address":"integ-test.go-fastly.com","ssl_client_key":null,"hostname":"integ-test.go-fastly.com","updated_at":"2025-08-29T19:38:08Z","tcp_keepalive_interval":null}'
+    body: '{"tcp_keepalive_probes":null,"ipv6":null,"request_condition":"","weight":100,"ssl_ca_cert":null,"error_threshold":0,"max_conn":200,"keepalive_time":null,"updated_at":"2026-05-06T18:11:09Z","auto_loadbalance":false,"max_tls_version":null,"override_host":"www.example.com","max_use":200,"connect_timeout":1500,"ssl_ciphers":"HIGH","between_bytes_timeout":10000,"version":62,"service_id":"XsjdElScZGjmfCcTwsYRC1","tcp_keepalive_interval":null,"ssl_sni_hostname":"ssl-hostname-updated.com","ipv4":null,"tcp_keepalive_enable":null,"deleted_at":null,"tcp_keepalive_time":null,"max_lifetime":120000,"ssl_hostname":null,"ssl_client_key":null,"ssl_check_cert":false,"port":1234,"healthcheck":null,"ssl_client_cert":null,"shield":null,"name":"new-test-backend-compute","share_key":"sharedkey","use_ssl":false,"created_at":"2026-05-06T18:11:08Z","prefer_ipv6":true,"hostname":"integ-test.go-fastly.com","ssl_cert_hostname":null,"first_byte_timeout":15000,"comment":"","min_tls_version":null,"address":"integ-test.go-fastly.com","client_cert":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:09 GMT
+      - Wed, 06 May 2026 18:11:11 GMT
       Fastly-Ratelimit-Remaining:
-      - "9968"
+      - "9992"
       Fastly-Ratelimit-Reset:
-      - "1756497600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000151-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-kigq8000108-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496289.118517,VS0,VE243
+      - S1778091071.755167,VS0,VE571
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/compute/version.yaml
+++ b/fastly/fixtures/backends/compute/version.yaml
@@ -8,11 +8,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/11.3.0 (+github.com/fastly/go-fastly; go1.24.2)
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
     url: https://api.fastly.com/service/XsjdElScZGjmfCcTwsYRC1/version
     method: POST
   response:
-    body: '{"service_id":"XsjdElScZGjmfCcTwsYRC1","number":7}'
+    body: '{"service_id":"XsjdElScZGjmfCcTwsYRC1","number":62}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,11 +21,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Aug 2025 19:38:07 GMT
+      - Wed, 06 May 2026 18:11:07 GMT
       Fastly-Ratelimit-Remaining:
-      - "9971"
+      - "9997"
       Fastly-Ratelimit-Reset:
-      - "1756497600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000128-CHI, cache-ewr-kewr1740076-EWR
+      - cache-chi-klot8100121-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1756496288.545961,VS0,VE374
+      - S1778091067.094904,VS0,VE526
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/create.yaml
+++ b/fastly/fixtures/backends/create.yaml
@@ -2,12 +2,16 @@
 version: 1
 interactions:
 - request:
-    body: address=integ-test.go-fastly.com&connect_timeout=1500&name=test-backend&override_host=origin.example.com&ssl_check_cert=0&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384&ssl_sni_hostname=ssl-hostname.com
+    body: address=integ-test.go-fastly.com&connect_timeout=1500&max_lifetime=60000&max_use=100&name=test-backend&override_host=origin.example.com&ssl_check_cert=0&ssl_ciphers=DHE-RSA-AES256-SHA%3ADHE-RSA-CAMELLIA256-SHA%3AAES256-GCM-SHA384&ssl_sni_hostname=ssl-hostname.com
     form:
       address:
       - integ-test.go-fastly.com
       connect_timeout:
       - "1500"
+      max_lifetime:
+      - "60000"
+      max_use:
+      - "100"
       name:
       - test-backend
       override_host:
@@ -22,11 +26,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/102/backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/145/backend
     method: POST
   response:
-    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"name":"test-backend","override_host":"origin.example.com","ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_sni_hostname":"ssl-hostname.com","service_id":"kKJb5bOFI47uHeBVluGfX1","version":102,"ssl_hostname":null,"deleted_at":null,"ssl_client_key":null,"between_bytes_timeout":10000,"healthcheck":null,"client_cert":null,"ssl_cert_hostname":null,"ssl_ca_cert":null,"error_threshold":0,"comment":"","keepalive_time":null,"prefer_ipv6":null,"hostname":"integ-test.go-fastly.com","shield":null,"weight":100,"use_ssl":false,"tcp_keepalive_time":null,"tcp_keepalive_probes":null,"created_at":"2025-05-07T15:03:13Z","ssl_client_cert":null,"tcp_keepalive_interval":null,"max_tls_version":null,"share_key":null,"request_condition":"","ipv4":null,"max_conn":200,"min_tls_version":null,"ipv6":null,"auto_loadbalance":false,"updated_at":"2025-05-07T15:03:13Z","tcp_keepalive_enable":null,"port":80,"first_byte_timeout":15000}'
+    body: '{"address":"integ-test.go-fastly.com","connect_timeout":1500,"max_lifetime":60000,"max_use":100,"name":"test-backend","override_host":"origin.example.com","ssl_check_cert":false,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_sni_hostname":"ssl-hostname.com","service_id":"kKJb5bOFI47uHeBVluGfX1","version":145,"ssl_ca_cert":null,"updated_at":"2026-05-06T18:11:06Z","shield":null,"ssl_hostname":null,"error_threshold":0,"healthcheck":null,"max_tls_version":null,"ipv4":null,"between_bytes_timeout":10000,"keepalive_time":null,"tcp_keepalive_interval":null,"weight":100,"ssl_cert_hostname":null,"use_ssl":false,"min_tls_version":null,"auto_loadbalance":false,"share_key":null,"client_cert":null,"prefer_ipv6":false,"request_condition":"","hostname":"integ-test.go-fastly.com","port":80,"created_at":"2026-05-06T18:11:06Z","ipv6":null,"first_byte_timeout":15000,"max_conn":200,"ssl_client_key":null,"tcp_keepalive_enable":null,"tcp_keepalive_probes":null,"comment":"","tcp_keepalive_time":null,"ssl_client_cert":null,"deleted_at":null}'
     headers:
       Accept-Ranges:
       - bytes
@@ -35,15 +39,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:13 GMT
+      - Wed, 06 May 2026 18:11:07 GMT
       Fastly-Ratelimit-Remaining:
-      - "9993"
+      - "9998"
       Fastly-Ratelimit-Reset:
-      - "1746633600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -57,9 +61,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000133-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-kigq8000094-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630193.043190,VS0,VE255
+      - S1778091066.402562,VS0,VE674
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/delete.yaml
+++ b/fastly/fixtures/backends/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/102/backend/new-test-backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/145/backend/new-test-backend
     method: DELETE
   response:
     body: '{"status":"ok"}'
@@ -19,15 +19,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:14 GMT
+      - Wed, 06 May 2026 18:11:13 GMT
       Fastly-Ratelimit-Remaining:
       - "9989"
       Fastly-Ratelimit-Reset:
-      - "1746633600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -41,9 +41,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100159-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-kigq8000049-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630194.403773,VS0,VE266
+      - S1778091073.622239,VS0,VE460
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/get.yaml
+++ b/fastly/fixtures/backends/get.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/102/backend/test-backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/145/backend/test-backend
     method: GET
   response:
-    body: '{"ipv4":null,"ssl_sni_hostname":"ssl-hostname.com","keepalive_time":null,"override_host":"origin.example.com","comment":"","updated_at":"2025-05-07T15:03:13Z","request_condition":"","max_tls_version":null,"client_cert":null,"use_ssl":false,"prefer_ipv6":null,"shield":null,"ssl_check_cert":false,"name":"test-backend","tcp_keepalive_time":null,"ssl_cert_hostname":null,"healthcheck":null,"ssl_client_key":null,"min_tls_version":null,"weight":100,"tcp_keepalive_enable":null,"ssl_ca_cert":null,"tcp_keepalive_probes":null,"auto_loadbalance":false,"version":102,"hostname":"integ-test.go-fastly.com","ipv6":null,"ssl_hostname":null,"between_bytes_timeout":10000,"share_key":null,"error_threshold":0,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ssl_client_cert":null,"connect_timeout":1500,"tcp_keepalive_interval":null,"created_at":"2025-05-07T15:03:13Z","max_conn":200,"address":"integ-test.go-fastly.com","deleted_at":null,"service_id":"kKJb5bOFI47uHeBVluGfX1","port":80,"first_byte_timeout":15000}'
+    body: '{"ipv6":null,"use_ssl":false,"created_at":"2026-05-06T18:11:06Z","ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","ipv4":null,"weight":100,"prefer_ipv6":false,"max_use":100,"hostname":"integ-test.go-fastly.com","deleted_at":null,"tcp_keepalive_probes":null,"error_threshold":0,"name":"test-backend","version":145,"between_bytes_timeout":10000,"shield":null,"healthcheck":null,"connect_timeout":1500,"updated_at":"2026-05-06T18:11:06Z","ssl_cert_hostname":null,"ssl_check_cert":false,"client_cert":null,"ssl_ca_cert":null,"ssl_sni_hostname":"ssl-hostname.com","address":"integ-test.go-fastly.com","auto_loadbalance":false,"max_conn":200,"comment":"","override_host":"origin.example.com","ssl_hostname":null,"tcp_keepalive_interval":null,"share_key":null,"ssl_client_key":null,"service_id":"kKJb5bOFI47uHeBVluGfX1","tcp_keepalive_time":null,"port":80,"keepalive_time":null,"tcp_keepalive_enable":null,"max_tls_version":null,"min_tls_version":null,"ssl_client_cert":null,"first_byte_timeout":15000,"request_condition":"","max_lifetime":60000}'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:13 GMT
+      - Wed, 06 May 2026 18:11:07 GMT
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100020-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-kigq8000157-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630193.449162,VS0,VE113
+      - S1778091068.644165,VS0,VE172
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/list.yaml
+++ b/fastly/fixtures/backends/list.yaml
@@ -6,11 +6,11 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/102/backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/145/backend
     method: GET
   response:
-    body: '[{"weight":100,"address":"integ-test.go-fastly.com","ssl_client_cert":null,"request_condition":"","ssl_hostname":null,"override_host":"origin.example.com","share_key":null,"updated_at":"2025-05-07T15:03:13Z","use_ssl":false,"ipv4":null,"ipv6":null,"client_cert":null,"port":80,"first_byte_timeout":15000,"version":102,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","connect_timeout":1500,"hostname":"integ-test.go-fastly.com","tcp_keepalive_probes":null,"auto_loadbalance":false,"error_threshold":0,"ssl_cert_hostname":null,"ssl_ca_cert":null,"comment":"","tcp_keepalive_time":null,"ssl_sni_hostname":"ssl-hostname.com","tcp_keepalive_interval":null,"max_conn":200,"prefer_ipv6":null,"max_tls_version":null,"healthcheck":null,"keepalive_time":null,"name":"test-backend","service_id":"kKJb5bOFI47uHeBVluGfX1","created_at":"2025-05-07T15:03:13Z","ssl_check_cert":false,"min_tls_version":null,"deleted_at":null,"between_bytes_timeout":10000,"tcp_keepalive_enable":null,"ssl_client_key":null,"shield":null}]'
+    body: '[{"port":80,"updated_at":"2026-05-06T18:11:06Z","weight":100,"error_threshold":0,"client_cert":null,"tcp_keepalive_interval":null,"name":"test-backend","connect_timeout":1500,"first_byte_timeout":15000,"between_bytes_timeout":10000,"created_at":"2026-05-06T18:11:06Z","healthcheck":null,"ssl_check_cert":false,"use_ssl":false,"ssl_cert_hostname":null,"ssl_sni_hostname":"ssl-hostname.com","hostname":"integ-test.go-fastly.com","address":"integ-test.go-fastly.com","min_tls_version":null,"ipv6":null,"request_condition":"","service_id":"kKJb5bOFI47uHeBVluGfX1","keepalive_time":null,"max_use":100,"ssl_client_key":null,"ssl_ciphers":"DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:AES256-GCM-SHA384","tcp_keepalive_time":null,"tcp_keepalive_enable":null,"override_host":"origin.example.com","ssl_hostname":null,"deleted_at":null,"auto_loadbalance":false,"prefer_ipv6":false,"shield":null,"ssl_ca_cert":null,"share_key":null,"comment":"","tcp_keepalive_probes":null,"max_conn":200,"ipv4":null,"max_lifetime":60000,"ssl_client_cert":null,"version":145,"max_tls_version":null}]'
     headers:
       Accept-Ranges:
       - bytes
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:13 GMT
+      - Wed, 06 May 2026 18:11:07 GMT
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000133-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-kigq8000094-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630193.304605,VS0,VE139
+      - S1778091067.089092,VS0,VE544
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update.yaml
+++ b/fastly/fixtures/backends/update.yaml
@@ -2,8 +2,12 @@
 version: 1
 interactions:
 - request:
-    body: name=new-test-backend&override_host=www.example.com&port=1234&prefer_ipv6=1&share_key=sharedkey&ssl_check_cert=0&ssl_ciphers=HIGH&ssl_sni_hostname=ssl-hostname-updated.com
+    body: max_lifetime=120000&max_use=200&name=new-test-backend&override_host=www.example.com&port=1234&prefer_ipv6=1&share_key=sharedkey&ssl_check_cert=0&ssl_ciphers=HIGH&ssl_sni_hostname=ssl-hostname-updated.com
     form:
+      max_lifetime:
+      - "120000"
+      max_use:
+      - "200"
       name:
       - new-test-backend
       override_host:
@@ -24,11 +28,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/102/backend/test-backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/145/backend/test-backend
     method: PUT
   response:
-    body: '{"tcp_keepalive_time":null,"prefer_ipv6":true,"first_byte_timeout":15000,"ssl_ciphers":"HIGH","updated_at":"2025-05-07T15:03:13Z","ssl_hostname":null,"service_id":"kKJb5bOFI47uHeBVluGfX1","tcp_keepalive_interval":null,"version":102,"use_ssl":false,"ipv4":null,"port":1234,"name":"new-test-backend","ssl_sni_hostname":"ssl-hostname-updated.com","between_bytes_timeout":10000,"deleted_at":null,"ssl_check_cert":false,"hostname":"integ-test.go-fastly.com","client_cert":null,"healthcheck":null,"override_host":"www.example.com","error_threshold":0,"ssl_cert_hostname":null,"tcp_keepalive_enable":null,"max_tls_version":null,"weight":100,"request_condition":"","comment":"","ssl_client_cert":null,"share_key":"sharedkey","connect_timeout":1500,"ipv6":null,"ssl_client_key":null,"address":"integ-test.go-fastly.com","auto_loadbalance":false,"keepalive_time":null,"tcp_keepalive_probes":null,"shield":null,"min_tls_version":null,"max_conn":200,"ssl_ca_cert":null,"created_at":"2025-05-07T15:03:13Z"}'
+    body: '{"max_tls_version":null,"healthcheck":null,"ssl_client_key":null,"between_bytes_timeout":10000,"min_tls_version":null,"tcp_keepalive_time":null,"ssl_hostname":null,"first_byte_timeout":15000,"tcp_keepalive_interval":null,"ssl_cert_hostname":null,"weight":100,"ssl_ciphers":"HIGH","share_key":"sharedkey","ipv4":null,"hostname":"integ-test.go-fastly.com","max_conn":200,"client_cert":null,"max_lifetime":120000,"tcp_keepalive_probes":null,"address":"integ-test.go-fastly.com","ssl_ca_cert":null,"keepalive_time":null,"service_id":"kKJb5bOFI47uHeBVluGfX1","ssl_check_cert":false,"max_use":200,"shield":null,"ssl_sni_hostname":"ssl-hostname-updated.com","port":1234,"prefer_ipv6":true,"request_condition":"","version":145,"ssl_client_cert":null,"use_ssl":false,"deleted_at":null,"error_threshold":0,"comment":"","connect_timeout":1500,"override_host":"www.example.com","name":"new-test-backend","auto_loadbalance":false,"created_at":"2026-05-06T18:11:06Z","ipv6":null,"tcp_keepalive_enable":null,"updated_at":"2026-05-06T18:11:06Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -37,15 +41,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:13 GMT
+      - Wed, 06 May 2026 18:11:09 GMT
       Fastly-Ratelimit-Remaining:
-      - "9992"
+      - "9995"
       Fastly-Ratelimit-Reset:
-      - "1746633600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -59,9 +63,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100020-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-kigq8000157-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630194.577579,VS0,VE290
+      - S1778091069.680609,VS0,VE545
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update_allow_empty_values.yaml
+++ b/fastly/fixtures/backends/update_allow_empty_values.yaml
@@ -12,11 +12,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/102/backend/new-test-backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/145/backend/new-test-backend
     method: PUT
   response:
-    body: '{"ssl_client_key":null,"ssl_sni_hostname":"ssl-hostname-updated.com","ssl_check_cert":false,"ipv6":null,"healthcheck":null,"name":"new-test-backend","request_condition":"","ssl_ca_cert":null,"tcp_keepalive_interval":null,"max_conn":200,"client_cert":null,"hostname":"integ-test.go-fastly.com","share_key":"sharedkey","port":0,"ssl_ciphers":"HIGH","tcp_keepalive_enable":null,"keepalive_time":null,"error_threshold":0,"address":"integ-test.go-fastly.com","auto_loadbalance":false,"tcp_keepalive_probes":null,"service_id":"kKJb5bOFI47uHeBVluGfX1","first_byte_timeout":15000,"min_tls_version":null,"created_at":"2025-05-07T15:03:13Z","tcp_keepalive_time":null,"comment":"","override_host":null,"shield":null,"ssl_hostname":null,"prefer_ipv6":true,"max_tls_version":null,"updated_at":"2025-05-07T15:03:13Z","ipv4":null,"ssl_client_cert":null,"ssl_cert_hostname":null,"deleted_at":null,"weight":100,"connect_timeout":1500,"between_bytes_timeout":10000,"version":102,"use_ssl":false}'
+    body: '{"ssl_hostname":null,"shield":null,"ssl_ca_cert":null,"updated_at":"2026-05-06T18:11:08Z","max_tls_version":null,"healthcheck":null,"error_threshold":0,"ipv4":null,"between_bytes_timeout":10000,"keepalive_time":null,"tcp_keepalive_interval":null,"weight":100,"connect_timeout":1500,"ssl_cert_hostname":null,"use_ssl":false,"address":"integ-test.go-fastly.com","max_use":200,"override_host":null,"min_tls_version":null,"share_key":"sharedkey","max_lifetime":120000,"client_cert":null,"ssl_ciphers":"HIGH","auto_loadbalance":false,"hostname":"integ-test.go-fastly.com","version":145,"prefer_ipv6":true,"ssl_sni_hostname":"ssl-hostname-updated.com","request_condition":"","name":"new-test-backend","created_at":"2026-05-06T18:11:06Z","ipv6":null,"port":0,"ssl_check_cert":false,"ssl_client_key":null,"max_conn":200,"first_byte_timeout":15000,"tcp_keepalive_probes":null,"tcp_keepalive_enable":null,"tcp_keepalive_time":null,"ssl_client_cert":null,"deleted_at":null,"service_id":"kKJb5bOFI47uHeBVluGfX1","comment":""}'
     headers:
       Accept-Ranges:
       - bytes
@@ -25,15 +25,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:14 GMT
+      - Wed, 06 May 2026 18:11:11 GMT
       Fastly-Ratelimit-Remaining:
-      - "9990"
+      - "9991"
       Fastly-Ratelimit-Reset:
-      - "1746633600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -47,9 +47,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100159-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-kigq8000049-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630194.148914,VS0,VE250
+      - S1778091071.354213,VS0,VE522
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/update_ignore_empty_values.yaml
+++ b/fastly/fixtures/backends/update_ignore_empty_values.yaml
@@ -8,11 +8,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
-    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/102/backend/new-test-backend
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version/145/backend/new-test-backend
     method: PUT
   response:
-    body: '{"ssl_client_cert":null,"error_threshold":0,"ssl_ciphers":"HIGH","created_at":"2025-05-07T15:03:13Z","max_conn":200,"connect_timeout":1500,"tcp_keepalive_interval":null,"port":1234,"service_id":"kKJb5bOFI47uHeBVluGfX1","deleted_at":null,"address":"integ-test.go-fastly.com","first_byte_timeout":15000,"hostname":"integ-test.go-fastly.com","version":102,"ipv6":null,"share_key":"sharedkey","between_bytes_timeout":10000,"ssl_hostname":null,"ssl_cert_hostname":null,"tcp_keepalive_time":null,"name":"new-test-backend","ssl_check_cert":false,"prefer_ipv6":true,"shield":null,"min_tls_version":null,"ssl_client_key":null,"healthcheck":null,"tcp_keepalive_enable":null,"weight":100,"auto_loadbalance":false,"ssl_ca_cert":null,"tcp_keepalive_probes":null,"ipv4":null,"ssl_sni_hostname":"ssl-hostname-updated.com","updated_at":"2025-05-07T15:03:13Z","comment":"","override_host":"www.example.com","keepalive_time":null,"client_cert":null,"max_tls_version":null,"request_condition":"","use_ssl":false}'
+    body: '{"max_tls_version":null,"version":145,"tcp_keepalive_probes":null,"max_lifetime":120000,"ssl_client_cert":null,"ipv4":null,"max_conn":200,"share_key":"sharedkey","comment":"","prefer_ipv6":true,"shield":null,"ssl_ca_cert":null,"tcp_keepalive_enable":null,"auto_loadbalance":false,"deleted_at":null,"ssl_hostname":null,"override_host":"www.example.com","service_id":"kKJb5bOFI47uHeBVluGfX1","ssl_client_key":null,"max_use":200,"tcp_keepalive_time":null,"ssl_ciphers":"HIGH","keepalive_time":null,"request_condition":"","address":"integ-test.go-fastly.com","ipv6":null,"min_tls_version":null,"ssl_sni_hostname":"ssl-hostname-updated.com","ssl_cert_hostname":null,"hostname":"integ-test.go-fastly.com","use_ssl":false,"healthcheck":null,"ssl_check_cert":false,"between_bytes_timeout":10000,"first_byte_timeout":15000,"created_at":"2026-05-06T18:11:06Z","connect_timeout":1500,"tcp_keepalive_interval":null,"client_cert":null,"error_threshold":0,"name":"new-test-backend","port":1234,"weight":100,"updated_at":"2026-05-06T18:11:08Z"}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,15 +21,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:14 GMT
+      - Wed, 06 May 2026 18:11:10 GMT
       Fastly-Ratelimit-Remaining:
-      - "9991"
+      - "9993"
       Fastly-Ratelimit-Reset:
-      - "1746633600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-klot8100159-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-kigq8000049-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630194.879213,VS0,VE265
+      - S1778091070.018322,VS0,VE517
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/backends/version.yaml
+++ b/fastly/fixtures/backends/version.yaml
@@ -8,11 +8,11 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - FastlyGo/10.0.1 (+github.com/fastly/go-fastly; go1.24.2)
+      - FastlyGo/12.1.0 (+github.com/fastly/go-fastly; go1.26.2)
     url: https://api.fastly.com/service/kKJb5bOFI47uHeBVluGfX1/version
     method: POST
   response:
-    body: '{"service_id":"kKJb5bOFI47uHeBVluGfX1","number":102}'
+    body: '{"service_id":"kKJb5bOFI47uHeBVluGfX1","number":145}'
     headers:
       Accept-Ranges:
       - bytes
@@ -21,15 +21,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 May 2025 15:03:13 GMT
+      - Wed, 06 May 2026 18:11:06 GMT
       Fastly-Ratelimit-Remaining:
-      - "9994"
+      - "9999"
       Fastly-Ratelimit-Reset:
-      - "1746633600"
+      - "1778094000"
       Pragma:
       - no-cache
       Server:
-      - fastly control-gateway
+      - fastly
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -43,9 +43,9 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Served-By:
-      - cache-chi-kigq8000028-CHI, cache-ewr-kewr1740090-EWR
+      - cache-chi-klot8100171-CHI, cache-ewr-kewr1740088-EWR
       X-Timer:
-      - S1746630193.784923,VS0,VE253
+      - S1778091066.685587,VS0,VE704
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
### Change summary

This is a PR for adding support for two different backend fields: 
- `max_use`, which specifies how many times an HTTP keepalive connection can be used before it's no longer pooled.
- `max_lifetime`, which specifies in milliseconds an upper bound for how long an HTTP keepalive connection can be open before it's no longer used.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Are there any considerations that need to be addressed for release?

I could not push to https://github.com/fastly/go-fastly/pull/764 so I had to create a new PR for this effort. 