### PR TITLE
Bump 'go-fastly' References to v15

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -17,7 +17,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ fixes available.
 ## Usage
 
 ```go
-import "github.com/fastly/go-fastly/v14/fastly"
+import "github.com/fastly/go-fastly/v15/fastly"
 ```
 
 ## Reference
@@ -42,4 +42,4 @@ import "github.com/fastly/go-fastly/v14/fastly"
 - [EXAMPLES.md](./EXAMPLES.md)
 - [TESTING.md](./TESTING.md)
 
-[latest]: https://pkg.go.dev/github.com/fastly/go-fastly/v14/fastly
+[latest]: https://pkg.go.dev/github.com/fastly/go-fastly/v15/fastly

--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -34,7 +34,7 @@ service with SID `1234abcd` might look like this:
 ```go
   import (
 	"context"
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
   )
 
   client := fastly.DefaultClient()

--- a/fastly/apisecurity/operations/api_add_tags_bulk.go
+++ b/fastly/apisecurity/operations/api_add_tags_bulk.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // BulkAddTagsInput specifies the information needed for the BulkAddTags() function

--- a/fastly/apisecurity/operations/api_create.go
+++ b/fastly/apisecurity/operations/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateInput specifies the information needed for the Create() function to

--- a/fastly/apisecurity/operations/api_create_operations_bulk.go
+++ b/fastly/apisecurity/operations/api_create_operations_bulk.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // BulkCreateOperationsInput specifies the information needed for the

--- a/fastly/apisecurity/operations/api_create_tag.go
+++ b/fastly/apisecurity/operations/api_create_tag.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateTagInput specifies the information needed for the CreateTag() function

--- a/fastly/apisecurity/operations/api_delete.go
+++ b/fastly/apisecurity/operations/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to

--- a/fastly/apisecurity/operations/api_delete_tag.go
+++ b/fastly/apisecurity/operations/api_delete_tag.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteTagInput specifies the information needed for the DeleteTag() function

--- a/fastly/apisecurity/operations/api_describe.go
+++ b/fastly/apisecurity/operations/api_describe.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DescribeInput specifies the information needed for the Describe() function to

--- a/fastly/apisecurity/operations/api_describe_tag.go
+++ b/fastly/apisecurity/operations/api_describe_tag.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DescribeTagInput specifies the information needed for the DescribeTag()

--- a/fastly/apisecurity/operations/api_list_discovered_operations.go
+++ b/fastly/apisecurity/operations/api_list_discovered_operations.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListDiscoveredInput specifies the information needed for the ListDiscovered()

--- a/fastly/apisecurity/operations/api_list_operations.go
+++ b/fastly/apisecurity/operations/api_list_operations.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListOperationsInput specifies the information needed for the ListOperations()

--- a/fastly/apisecurity/operations/api_list_tags.go
+++ b/fastly/apisecurity/operations/api_list_tags.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListTagsInput specifies the information needed for the ListTags() function to

--- a/fastly/apisecurity/operations/api_operations_test.go
+++ b/fastly/apisecurity/operations/api_operations_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_Operations(t *testing.T) {

--- a/fastly/apisecurity/operations/api_tags_test.go
+++ b/fastly/apisecurity/operations/api_tags_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_Tags(t *testing.T) {

--- a/fastly/apisecurity/operations/api_update.go
+++ b/fastly/apisecurity/operations/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateInput specifies the information needed for the Update() function to

--- a/fastly/apisecurity/operations/api_update_discovered_operation.go
+++ b/fastly/apisecurity/operations/api_update_discovered_operation.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateDiscoveredStatusInput specifies the information needed for the

--- a/fastly/apisecurity/operations/api_update_discovered_operations_bulk.go
+++ b/fastly/apisecurity/operations/api_update_discovered_operations_bulk.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // BulkUpdateDiscoveredStatusInput specifies the information needed for the

--- a/fastly/apisecurity/operations/api_update_tag.go
+++ b/fastly/apisecurity/operations/api_update_tag.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateTagInput specifies the information needed for the UpdateTag() function

--- a/fastly/apisecurity/operations/api_validation_test.go
+++ b/fastly/apisecurity/operations/api_validation_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_Create_validation(t *testing.T) {

--- a/fastly/apisecurity/operations/pagination.go
+++ b/fastly/apisecurity/operations/pagination.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 const defaultPageLimit = 100

--- a/fastly/client.go
+++ b/fastly/client.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/fastly/go-fastly/v14/fastly/impersonation"
+	"github.com/fastly/go-fastly/v15/fastly/impersonation"
 )
 
 // APIKeyEnvVar is the name of the environment variable where the Fastly API

--- a/fastly/client_test.go
+++ b/fastly/client_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly/impersonation"
+	"github.com/fastly/go-fastly/v15/fastly/impersonation"
 )
 
 func TestClient_RawRequest(t *testing.T) {

--- a/fastly/computeacls/api_create.go
+++ b/fastly/computeacls/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateInput specifies the information needed for the Create() function to

--- a/fastly/computeacls/api_delete.go
+++ b/fastly/computeacls/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to

--- a/fastly/computeacls/api_describe.go
+++ b/fastly/computeacls/api_describe.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DescribeInput specifies the information needed for the Describe() function to perform

--- a/fastly/computeacls/api_list_acls.go
+++ b/fastly/computeacls/api_list_acls.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListACLs retrieves all compute ACLs.

--- a/fastly/computeacls/api_list_entries.go
+++ b/fastly/computeacls/api_list_entries.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListEntriesInput specifies the information needed for the ListEntries() function to perform

--- a/fastly/computeacls/api_lookup.go
+++ b/fastly/computeacls/api_lookup.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // LookupInput specifies the information needed for the Lookup() function to perform

--- a/fastly/computeacls/api_test.go
+++ b/fastly/computeacls/api_test.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_ComputeACL(t *testing.T) {

--- a/fastly/computeacls/api_update.go
+++ b/fastly/computeacls/api_update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateInput specifies the information needed for the Update() function to

--- a/fastly/dns/v1/dnszones/api_create.go
+++ b/fastly/dns/v1/dnszones/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateInput specifies the information needed to create a zone.

--- a/fastly/dns/v1/dnszones/api_delete.go
+++ b/fastly/dns/v1/dnszones/api_delete.go
@@ -3,7 +3,7 @@ package dnszones
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to

--- a/fastly/dns/v1/dnszones/api_get.go
+++ b/fastly/dns/v1/dnszones/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed to get a zone.

--- a/fastly/dns/v1/dnszones/api_list.go
+++ b/fastly/dns/v1/dnszones/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed to list zones.

--- a/fastly/dns/v1/dnszones/api_response.go
+++ b/fastly/dns/v1/dnszones/api_response.go
@@ -1,6 +1,6 @@
 package dnszones
 
-import "github.com/fastly/go-fastly/v14/fastly"
+import "github.com/fastly/go-fastly/v15/fastly"
 
 // Zone is the API response structure for the create, update and get operations.
 type Zone struct {

--- a/fastly/dns/v1/dnszones/api_test.go
+++ b/fastly/dns/v1/dnszones/api_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/dns/v1/tsigkeys"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/dns/v1/tsigkeys"
 )
 
 func TestZones(t *testing.T) {

--- a/fastly/dns/v1/dnszones/api_update.go
+++ b/fastly/dns/v1/dnszones/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateInput specifies the information needed to update a zone.

--- a/fastly/dns/v1/tsigkeys/api_create.go
+++ b/fastly/dns/v1/tsigkeys/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateInput specifies the information needed to create a TSIG key.

--- a/fastly/dns/v1/tsigkeys/api_delete.go
+++ b/fastly/dns/v1/tsigkeys/api_delete.go
@@ -3,7 +3,7 @@ package tsigkeys
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to

--- a/fastly/dns/v1/tsigkeys/api_get.go
+++ b/fastly/dns/v1/tsigkeys/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed to get a TSIG key.

--- a/fastly/dns/v1/tsigkeys/api_list.go
+++ b/fastly/dns/v1/tsigkeys/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed to list TSIG keys.

--- a/fastly/dns/v1/tsigkeys/api_test.go
+++ b/fastly/dns/v1/tsigkeys/api_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestTSIGKeys(t *testing.T) {

--- a/fastly/dns/v1/tsigkeys/api_update.go
+++ b/fastly/dns/v1/tsigkeys/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateInput specifies the information needed to update a TSIG key.

--- a/fastly/domainmanagement/v1/domains/api_create.go
+++ b/fastly/domainmanagement/v1/domains/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateInput specifies the information needed for the Create() function to

--- a/fastly/domainmanagement/v1/domains/api_delete.go
+++ b/fastly/domainmanagement/v1/domains/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to

--- a/fastly/domainmanagement/v1/domains/api_get.go
+++ b/fastly/domainmanagement/v1/domains/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/domainmanagement/v1/domains/api_list.go
+++ b/fastly/domainmanagement/v1/domains/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/domainmanagement/v1/domains/api_test.go
+++ b/fastly/domainmanagement/v1/domains/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_Domain(t *testing.T) {

--- a/fastly/domainmanagement/v1/domains/api_update.go
+++ b/fastly/domainmanagement/v1/domains/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateInput specifies the information needed for the Update() function to

--- a/fastly/domainmanagement/v1/tools/status/api_get.go
+++ b/fastly/domainmanagement/v1/tools/status/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Scope determines the depth of availability checking.

--- a/fastly/domainmanagement/v1/tools/status/api_test.go
+++ b/fastly/domainmanagement/v1/tools/status/api_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_DomainToolsStatus(t *testing.T) {

--- a/fastly/domainmanagement/v1/tools/suggest/api_get.go
+++ b/fastly/domainmanagement/v1/tools/suggest/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the various parameters for performing real-time queries against the known zones database.

--- a/fastly/domainmanagement/v1/tools/suggest/api_test.go
+++ b/fastly/domainmanagement/v1/tools/suggest/api_test.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_DomainToolsSuggestion(t *testing.T) {

--- a/fastly/example_ratelimit_test.go
+++ b/fastly/example_ratelimit_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func ExampleClient_RateLimitRemaining() {

--- a/fastly/imageoptimizerdefaultsettings/image_optimizer_default_settings_test.go
+++ b/fastly/imageoptimizerdefaultsettings/image_optimizer_default_settings_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products/imageoptimizer"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products/imageoptimizer"
 )
 
 // TestClient_ImageOptimizerDefaultSettings tests the Image Optimizer Default Settings API

--- a/fastly/ngwaf/v1/lists/api_create.go
+++ b/fastly/ngwaf/v1/lists/api_create.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // CreateInput specifies the information needed for the Create()

--- a/fastly/ngwaf/v1/lists/api_delete.go
+++ b/fastly/ngwaf/v1/lists/api_delete.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // DeleteInput specifies the information needed for the Delete()

--- a/fastly/ngwaf/v1/lists/api_get.go
+++ b/fastly/ngwaf/v1/lists/api_get.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // GetInput specifies the information needed for the Get() function to

--- a/fastly/ngwaf/v1/lists/api_list.go
+++ b/fastly/ngwaf/v1/lists/api_list.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/ngwaf/v1/lists/api_test.go
+++ b/fastly/ngwaf/v1/lists/api_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 const (

--- a/fastly/ngwaf/v1/lists/api_update.go
+++ b/fastly/ngwaf/v1/lists/api_update.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // UpdateInput specifies the information needed for the Update()

--- a/fastly/ngwaf/v1/rules/api_create.go
+++ b/fastly/ngwaf/v1/rules/api_create.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // CreateInput specifies the information needed for the Create()

--- a/fastly/ngwaf/v1/rules/api_delete.go
+++ b/fastly/ngwaf/v1/rules/api_delete.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // DeleteInput specifies the information needed for the Delete()

--- a/fastly/ngwaf/v1/rules/api_get.go
+++ b/fastly/ngwaf/v1/rules/api_get.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // GetInput specifies the information needed for the Get() function

--- a/fastly/ngwaf/v1/rules/api_list.go
+++ b/fastly/ngwaf/v1/rules/api_list.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // ListInput specifies the information needed for the List() function

--- a/fastly/ngwaf/v1/rules/api_nested_multival_test.go
+++ b/fastly/ngwaf/v1/rules/api_nested_multival_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 func TestClient_Rule_NestedMultivalConditions_WorkspaceScope(t *testing.T) {

--- a/fastly/ngwaf/v1/rules/api_test.go
+++ b/fastly/ngwaf/v1/rules/api_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/signals"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/signals"
 )
 
 func TestClient_Rule_WorkspaceScope(t *testing.T) {

--- a/fastly/ngwaf/v1/rules/api_update.go
+++ b/fastly/ngwaf/v1/rules/api_update.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // UpdateInput specifies the information needed for the Update()

--- a/fastly/ngwaf/v1/scope/pathbuilder.go
+++ b/fastly/ngwaf/v1/scope/pathbuilder.go
@@ -3,7 +3,7 @@ package scope
 import (
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // BuildPath generates the appropriate API path based on the given scope,

--- a/fastly/ngwaf/v1/signals/api_create.go
+++ b/fastly/ngwaf/v1/signals/api_create.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // CreateInput specifies the information needed for the Create()

--- a/fastly/ngwaf/v1/signals/api_delete.go
+++ b/fastly/ngwaf/v1/signals/api_delete.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // DeleteInput specifies the information needed for the Delete()

--- a/fastly/ngwaf/v1/signals/api_get.go
+++ b/fastly/ngwaf/v1/signals/api_get.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // GetInput specifies the information needed for the Get() function to

--- a/fastly/ngwaf/v1/signals/api_list.go
+++ b/fastly/ngwaf/v1/signals/api_list.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // ListInput specifies the information needed for the List() function

--- a/fastly/ngwaf/v1/signals/api_test.go
+++ b/fastly/ngwaf/v1/signals/api_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 const (

--- a/fastly/ngwaf/v1/signals/api_update.go
+++ b/fastly/ngwaf/v1/signals/api_update.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/scope"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/scope"
 )
 
 // UpdateInput specifies the information needed for the Update()

--- a/fastly/ngwaf/v1/workspaces/alerts/datadog/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/datadog/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Config is the config object for integration type datadog.

--- a/fastly/ngwaf/v1/workspaces/alerts/datadog/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/datadog/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/datadog/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/datadog/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/datadog/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/datadog/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/datadog/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/datadog/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global workspace value for the tests.

--- a/fastly/ngwaf/v1/workspaces/alerts/datadog/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/datadog/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Config is the config object for integration type datadog.

--- a/fastly/ngwaf/v1/workspaces/alerts/jira/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/jira/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateConfig is the config object for integration type jira.

--- a/fastly/ngwaf/v1/workspaces/alerts/jira/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/jira/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/jira/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/jira/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/jira/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/jira/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/jira/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/jira/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global workspace value for the tests.

--- a/fastly/ngwaf/v1/workspaces/alerts/jira/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/jira/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateConfig is the config object for integration type jira.

--- a/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateConfig is the config object for integration type mailinglist.

--- a/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global workspace value for the tests.

--- a/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/mailinglist/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateConfig is the config object for integration type mailinglist.

--- a/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateConfig is the config object for integration type microsoftteams.

--- a/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global workspace value for the tests.

--- a/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/microsoftteams/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateConfig is the config object for integration type microsoftteams.

--- a/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateConfig is the config object for integration type opsgenie.

--- a/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global workspace value for the tests.

--- a/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/opsgenie/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateConfig is the config object for integration type opsgenie.

--- a/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateConfig is the config object for integration type pagerduty.

--- a/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global workspace value for the tests.

--- a/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/pagerduty/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateConfig is the config object for integration type pagerduty.

--- a/fastly/ngwaf/v1/workspaces/alerts/slack/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/slack/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateConfig is the config object for integration type slack.

--- a/fastly/ngwaf/v1/workspaces/alerts/slack/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/slack/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/slack/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/slack/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/slack/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/slack/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/slack/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/slack/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global workspace value for the tests.

--- a/fastly/ngwaf/v1/workspaces/alerts/slack/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/slack/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateConfig is the config object for integration type slack.

--- a/fastly/ngwaf/v1/workspaces/alerts/webhook/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/webhook/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateConfig is the config object for integration type webhook.

--- a/fastly/ngwaf/v1/workspaces/alerts/webhook/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/webhook/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/webhook/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/webhook/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/webhook/api_get_sign_key.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/webhook/api_get_sign_key.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetKeyInput specifies the information needed for the get signing key

--- a/fastly/ngwaf/v1/workspaces/alerts/webhook/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/webhook/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function to perform

--- a/fastly/ngwaf/v1/workspaces/alerts/webhook/api_rotate_sign_key.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/webhook/api_rotate_sign_key.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // RotateKeyInput specifies the information needed for the rotate signing key

--- a/fastly/ngwaf/v1/workspaces/alerts/webhook/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/webhook/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global workspace value for the tests.

--- a/fastly/ngwaf/v1/workspaces/alerts/webhook/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/alerts/webhook/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateConfig is the config object for integration type webhook.

--- a/fastly/ngwaf/v1/workspaces/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // AttackSignalThresholdsCreateInput are the parameters for system

--- a/fastly/ngwaf/v1/workspaces/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete()

--- a/fastly/ngwaf/v1/workspaces/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to

--- a/fastly/ngwaf/v1/workspaces/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function

--- a/fastly/ngwaf/v1/workspaces/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_Workspace(t *testing.T) {

--- a/fastly/ngwaf/v1/workspaces/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // AttackSignalThresholdsUpdateInput are the parameters for system

--- a/fastly/ngwaf/v1/workspaces/events/api_expire.go
+++ b/fastly/ngwaf/v1/workspaces/events/api_expire.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ExpireInput specifies the information needed for the Expire()

--- a/fastly/ngwaf/v1/workspaces/events/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/events/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to

--- a/fastly/ngwaf/v1/workspaces/events/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/events/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function

--- a/fastly/ngwaf/v1/workspaces/events/api_response.go
+++ b/fastly/ngwaf/v1/workspaces/events/api_response.go
@@ -3,7 +3,7 @@ package events
 import (
 	"time"
 
-	"github.com/fastly/go-fastly/v14/fastly/ngwaf/v1/workspaces/requests"
+	"github.com/fastly/go-fastly/v15/fastly/ngwaf/v1/workspaces/requests"
 )
 
 // Event is the API response structure for the get, list, and expire

--- a/fastly/ngwaf/v1/workspaces/events/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/events/api_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 const (

--- a/fastly/ngwaf/v1/workspaces/redactions/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/redactions/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateInput specifies the information needed for the Create()

--- a/fastly/ngwaf/v1/workspaces/redactions/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/redactions/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete()

--- a/fastly/ngwaf/v1/workspaces/redactions/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/redactions/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to

--- a/fastly/ngwaf/v1/workspaces/redactions/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/redactions/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function

--- a/fastly/ngwaf/v1/workspaces/redactions/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/redactions/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_Redactions(t *testing.T) {

--- a/fastly/ngwaf/v1/workspaces/redactions/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/redactions/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateInput specifies the information needed for the Update()

--- a/fastly/ngwaf/v1/workspaces/requests/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/requests/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to

--- a/fastly/ngwaf/v1/workspaces/requests/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/requests/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function

--- a/fastly/ngwaf/v1/workspaces/requests/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/requests/api_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 const (

--- a/fastly/ngwaf/v1/workspaces/thresholds/api_create.go
+++ b/fastly/ngwaf/v1/workspaces/thresholds/api_create.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // CreateInput specifies the information needed for the Create()

--- a/fastly/ngwaf/v1/workspaces/thresholds/api_delete.go
+++ b/fastly/ngwaf/v1/workspaces/thresholds/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete()

--- a/fastly/ngwaf/v1/workspaces/thresholds/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/thresholds/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to

--- a/fastly/ngwaf/v1/workspaces/thresholds/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/thresholds/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function

--- a/fastly/ngwaf/v1/workspaces/thresholds/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/thresholds/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 const (

--- a/fastly/ngwaf/v1/workspaces/thresholds/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/thresholds/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateInput specifies the information needed for the Update()

--- a/fastly/ngwaf/v1/workspaces/timeseries/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/timeseries/api_get.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to

--- a/fastly/ngwaf/v1/workspaces/timeseries/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/timeseries/api_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global value for the tests.

--- a/fastly/ngwaf/v1/workspaces/virtualpatches/api_get.go
+++ b/fastly/ngwaf/v1/workspaces/virtualpatches/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to

--- a/fastly/ngwaf/v1/workspaces/virtualpatches/api_list.go
+++ b/fastly/ngwaf/v1/workspaces/virtualpatches/api_list.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListInput specifies the information needed for the List() function

--- a/fastly/ngwaf/v1/workspaces/virtualpatches/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/virtualpatches/api_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Global value for the test workspace ID.

--- a/fastly/ngwaf/v1/workspaces/virtualpatches/api_update.go
+++ b/fastly/ngwaf/v1/workspaces/virtualpatches/api_update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // UpdateInput specifies the information needed for the Update function

--- a/fastly/objectstorage/accesskeys/api_create.go
+++ b/fastly/objectstorage/accesskeys/api_create.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // Permissions can be one of these values only.

--- a/fastly/objectstorage/accesskeys/api_delete.go
+++ b/fastly/objectstorage/accesskeys/api_delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete() function to

--- a/fastly/objectstorage/accesskeys/api_get.go
+++ b/fastly/objectstorage/accesskeys/api_get.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // GetInput specifies the information needed for the Get() function to perform

--- a/fastly/objectstorage/accesskeys/api_list_access_keys.go
+++ b/fastly/objectstorage/accesskeys/api_list_access_keys.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // ListAccessKeys retrieves all access keys within object storage.

--- a/fastly/objectstorage/accesskeys/api_test.go
+++ b/fastly/objectstorage/accesskeys/api_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 func TestClient_AccessKey(t *testing.T) {

--- a/fastly/products/apidiscovery/api.go
+++ b/fastly/products/apidiscovery/api.go
@@ -3,9 +3,9 @@ package apidiscovery
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/apidiscovery/api_test.go
+++ b/fastly/products/apidiscovery/api_test.go
@@ -3,11 +3,11 @@ package apidiscovery_test
 import (
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/fastly/products/apidiscovery"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly/products/apidiscovery"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 var functionalTests = []*test_utils.FunctionalTest{

--- a/fastly/products/botmanagement/api.go
+++ b/fastly/products/botmanagement/api.go
@@ -3,9 +3,9 @@ package botmanagement
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/botmanagement/api_test.go
+++ b/fastly/products/botmanagement/api_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/fastly/products/botmanagement"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly/products/botmanagement"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 
 	"github.com/stretchr/testify/require"
 )

--- a/fastly/products/brotlicompression/api.go
+++ b/fastly/products/brotlicompression/api.go
@@ -3,9 +3,9 @@ package brotlicompression
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/brotlicompression/api_test.go
+++ b/fastly/products/brotlicompression/api_test.go
@@ -3,11 +3,11 @@ package brotlicompression_test
 import (
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/fastly/products/brotlicompression"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly/products/brotlicompression"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 var functionalTests = []*test_utils.FunctionalTest{

--- a/fastly/products/ddosprotection/api.go
+++ b/fastly/products/ddosprotection/api.go
@@ -3,9 +3,9 @@ package ddosprotection
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/ddosprotection/api_test.go
+++ b/fastly/products/ddosprotection/api_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products/ddosprotection"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products/ddosprotection"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 
 	"github.com/stretchr/testify/require"
 )

--- a/fastly/products/domaininspector/api.go
+++ b/fastly/products/domaininspector/api.go
@@ -3,9 +3,9 @@ package domaininspector
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/domaininspector/api_test.go
+++ b/fastly/products/domaininspector/api_test.go
@@ -3,11 +3,11 @@ package domaininspector_test
 import (
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/fastly/products/domaininspector"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly/products/domaininspector"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 var functionalTests = []*test_utils.FunctionalTest{

--- a/fastly/products/fanout/api.go
+++ b/fastly/products/fanout/api.go
@@ -3,9 +3,9 @@ package fanout
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/fanout/api_test.go
+++ b/fastly/products/fanout/api_test.go
@@ -3,11 +3,11 @@ package fanout_test
 import (
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/fastly/products/fanout"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly/products/fanout"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 var functionalTests = []*test_utils.FunctionalTest{

--- a/fastly/products/imageoptimizer/api.go
+++ b/fastly/products/imageoptimizer/api.go
@@ -3,9 +3,9 @@ package imageoptimizer
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/imageoptimizer/api_test.go
+++ b/fastly/products/imageoptimizer/api_test.go
@@ -3,11 +3,11 @@ package imageoptimizer_test
 import (
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/fastly/products/imageoptimizer"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly/products/imageoptimizer"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 var functionalTests = []*test_utils.FunctionalTest{

--- a/fastly/products/logexplorerinsights/api.go
+++ b/fastly/products/logexplorerinsights/api.go
@@ -3,9 +3,9 @@ package logexplorerinsights
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/logexplorerinsights/api_test.go
+++ b/fastly/products/logexplorerinsights/api_test.go
@@ -3,11 +3,11 @@ package logexplorerinsights_test
 import (
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/fastly/products/logexplorerinsights"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly/products/logexplorerinsights"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 var functionalTests = []*test_utils.FunctionalTest{

--- a/fastly/products/ngwaf/api.go
+++ b/fastly/products/ngwaf/api.go
@@ -3,9 +3,9 @@ package ngwaf
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/ngwaf/api_test.go
+++ b/fastly/products/ngwaf/api_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products/ngwaf"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products/ngwaf"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 
 	"github.com/stretchr/testify/require"
 )

--- a/fastly/products/origininspector/api.go
+++ b/fastly/products/origininspector/api.go
@@ -3,9 +3,9 @@ package origininspector
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/origininspector/api_test.go
+++ b/fastly/products/origininspector/api_test.go
@@ -3,11 +3,11 @@ package origininspector_test
 import (
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/fastly/products/origininspector"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly/products/origininspector"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 var functionalTests = []*test_utils.FunctionalTest{

--- a/fastly/products/types.go
+++ b/fastly/products/types.go
@@ -1,6 +1,6 @@
 package products
 
-import "github.com/fastly/go-fastly/v14/fastly"
+import "github.com/fastly/go-fastly/v15/fastly"
 
 // ProductOutput is an interface used to constrain the 'O' type
 // parameters of API operation functions. Use of this interface allows

--- a/fastly/products/websockets/api.go
+++ b/fastly/products/websockets/api.go
@@ -3,9 +3,9 @@ package websockets
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 const (

--- a/fastly/products/websockets/api_test.go
+++ b/fastly/products/websockets/api_test.go
@@ -3,11 +3,11 @@ package websockets_test
 import (
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/fastly/products/websockets"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly/products/websockets"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 var functionalTests = []*test_utils.FunctionalTest{

--- a/fastly/purge.go
+++ b/fastly/purge.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/fastly/go-fastly/v14/fastly/impersonation"
+	"github.com/fastly/go-fastly/v15/fastly/impersonation"
 )
 
 // Purge is a response from a purge request.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fastly/go-fastly/v14
+module github.com/fastly/go-fastly/v15
 
 go 1.25.0
 

--- a/internal/productcore/api_delete.go
+++ b/internal/productcore/api_delete.go
@@ -3,7 +3,7 @@ package productcore
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 // DeleteInput specifies the information needed for the Delete

--- a/internal/productcore/api_get.go
+++ b/internal/productcore/api_get.go
@@ -3,8 +3,8 @@ package productcore
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
 )
 
 // GetInput specifies the information needed for the Get()

--- a/internal/productcore/api_patch.go
+++ b/internal/productcore/api_patch.go
@@ -3,8 +3,8 @@ package productcore
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
 )
 
 // PatchInput specifies the information needed for the Patch()

--- a/internal/productcore/api_put.go
+++ b/internal/productcore/api_put.go
@@ -3,8 +3,8 @@ package productcore
 import (
 	"context"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
 )
 
 // PutInput specifies the information needed for the Put()

--- a/internal/productcore/functional_test_disable.go
+++ b/internal/productcore/functional_test_disable.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 // DisableTestInput specifies the information needed for the

--- a/internal/productcore/functional_test_enable.go
+++ b/internal/productcore/functional_test_enable.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 // EnableTestInput specifies the information needed for the

--- a/internal/productcore/functional_test_get.go
+++ b/internal/productcore/functional_test_get.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 // GetTestInput specifies the information needed for the NewGetTest

--- a/internal/productcore/functional_test_get_configuration.go
+++ b/internal/productcore/functional_test_get_configuration.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 // GetConfigurationTestInput specifies the information needed for the

--- a/internal/productcore/functional_test_update_configuration.go
+++ b/internal/productcore/functional_test_update_configuration.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 // UpdateConfigurationTestInput specifies the information needed for

--- a/internal/productcore/functional_test_utils.go
+++ b/internal/productcore/functional_test_utils.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/test_utils"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/test_utils"
 )
 
 // validateOutput provides common validation for all responses to

--- a/internal/productcore/productcore_test.go
+++ b/internal/productcore/productcore_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
-	"github.com/fastly/go-fastly/v14/fastly/products"
-	"github.com/fastly/go-fastly/v14/internal/productcore"
+	"github.com/fastly/go-fastly/v15/fastly"
+	"github.com/fastly/go-fastly/v15/fastly/products"
+	"github.com/fastly/go-fastly/v15/internal/productcore"
 )
 
 func TestDeleteMissingServiceID(t *testing.T) {

--- a/internal/productcore/utils.go
+++ b/internal/productcore/utils.go
@@ -1,6 +1,6 @@
 package productcore
 
-import "github.com/fastly/go-fastly/v14/fastly"
+import "github.com/fastly/go-fastly/v15/fastly"
 
 func makeURL(productID, serviceID string, subComponents []string) string {
 	path := []string{"enabled-products", "v1", productID}

--- a/internal/test_utils/functional.go
+++ b/internal/test_utils/functional.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/fastly/go-fastly/v14/fastly"
+	"github.com/fastly/go-fastly/v15/fastly"
 )
 
 type FunctionalTest struct {


### PR DESCRIPTION
### Change summary

This PR bumps the `go.mod` and other references of `go-fastly` to ` v15` that were missed in #808. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?
