### PR TITLE
Rename Deprecated 'app-id' to 'client-id'

### DIFF
--- a/.github/workflows/dependabot_changelog_update.yml
+++ b/.github/workflows/dependabot_changelog_update.yml
@@ -23,7 +23,7 @@ jobs:
         id: github-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: "go-fastly"


### PR DESCRIPTION
### Change summary

`actions/create-github-app-token v3.2.0` (pinned in #815) deprecated the `app-id` input in favour of `client-id`. This was causing the Dependabot changelog update workflow to fail with an error on `private-key` validation. This PR renames `app-id` to `client-id` to resolve the deprecation warning and restore the workflow.

Example of failure being addressed: https://github.com/fastly/go-fastly/actions/runs/26897614727/job/79343355442 

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
