### PR TITLE
[CDTOOL-1497] Add Nullable Helper for Int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking:
 
 ### Enhancements:
+- feat(helpers): add NullInt helper to return nil when an int value is zero
 
 ### Dependencies:
 - build(deps): `actions/checkout` from 6.0.2 to 6.0.3 ([#821](https://github.com/fastly/go-fastly/pull/821))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking:
 
 ### Enhancements:
-- feat(helpers): add NullInt helper to return nil when an int value is zero
+- feat(helpers): add NullInt helper to return nil when an int value is zero ([#824](https://github.com/fastly/go-fastly/pull/824))
 
 ### Dependencies:
 - build(deps): `actions/checkout` from 6.0.2 to 6.0.3 ([#821](https://github.com/fastly/go-fastly/pull/821))

--- a/fastly/helpers.go
+++ b/fastly/helpers.go
@@ -38,6 +38,15 @@ func NullString(v string) *string {
 	return &v
 }
 
+// NullInt is a helper that returns a pointer to the int value passed in
+// or nil if the int is zero.
+func NullInt(v int) *int {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}
+
 // -- Nullable helpers --
 
 // Nullable represents a value that can be explicitly set to null in JSON output.

--- a/fastly/helpers_test.go
+++ b/fastly/helpers_test.go
@@ -4,6 +4,50 @@ import (
 	"testing"
 )
 
+func TestNullString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-empty string returns pointer", func(t *testing.T) {
+		v := "hello"
+		result := NullString(v)
+		if result == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *result != v {
+			t.Errorf("expected %q, got %q", v, *result)
+		}
+	})
+
+	t.Run("empty string returns nil", func(t *testing.T) {
+		result := NullString("")
+		if result != nil {
+			t.Errorf("expected nil, got %q", *result)
+		}
+	})
+}
+
+func TestNullInt(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-zero int returns pointer", func(t *testing.T) {
+		v := 42
+		result := NullInt(v)
+		if result == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		if *result != v {
+			t.Errorf("expected %d, got %d", v, *result)
+		}
+	})
+
+	t.Run("zero returns nil", func(t *testing.T) {
+		result := NullInt(0)
+		if result != nil {
+			t.Errorf("expected nil, got %d", *result)
+		}
+	})
+}
+
 func TestToSafeURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Change summary

This PR adds the `NullInt` func helper to provide the ability to return `nil` when a int is zero. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

```
=== RUN   TestNullInt
=== PAUSE TestNullInt
=== CONT  TestNullString
=== RUN   TestNullString/non-empty_string_returns_pointer
=== RUN   TestNullString/empty_string_returns_nil
--- PASS: TestNullString (0.00s)
    --- PASS: TestNullString/non-empty_string_returns_pointer (0.00s)
    --- PASS: TestNullString/empty_string_returns_nil (0.00s)
=== CONT  TestNullInt
=== RUN   TestNullInt/non-zero_int_returns_pointer
=== RUN   TestNullInt/zero_returns_nil
--- PASS: TestNullInt (0.00s)
    --- PASS: TestNullInt/non-zero_int_returns_pointer (0.00s)
    --- PASS: TestNullInt/zero_returns_nil (0.00s)
PASS
```