### PR TITLE
[CDTOOL-1086] Add support for listing Time Series metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Enhancements:
 
-- feat(ngwaf/timeseries): add support for list time series metrics ([#827](https://github.com/fastly/go-fastly/pull/827))
+- feat(ngwaf/timeseries): add support for listing time series metrics ([#827](https://github.com/fastly/go-fastly/pull/827))
 
 ### Dependencies:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Enhancements:
 
+- feat(ngwaf/timeseries): add support for list time series metrics ([#827](https://github.com/fastly/go-fastly/pull/827))
+
 ### Dependencies:
 
 ### Bug fixes:

--- a/fastly/ngwaf/v1/timeseries/api_list.go
+++ b/fastly/ngwaf/v1/timeseries/api_list.go
@@ -9,48 +9,45 @@ import (
 	"github.com/fastly/go-fastly/v15/fastly"
 )
 
-// GetInput specifies the information needed for the Get() function to
+// ListInput specifies the information needed for the List() function to
 // perform the operation.
-type GetInput struct {
-	// End is the end of a date-time range, expressed in RFC 3339 format.
-	End *string
+type ListInput struct {
+	// Dimensions is a comma-separated list of grouping dimensions to be
+	// included in the timeseries. Allowed values are workspaces and time.
+	// Default is time.
+	Dimensions *string
+	// From is the start of a date-time range, expressed in RFC 3339 format (required).
+	From *string
 	// Granularity is the level of detail of the sample size in seconds.
 	Granularity *int
 	// Metrics is a comma-separated list of metrics to be included in the
 	// timeseries. Metrics can be XSS, SQLI, HTTP404, requests_total,
 	// requests_attack, requests_total_blocked, or any custom metric (required).
 	Metrics *string
-	// Start is the start of a date-time range, expressed in RFC 3339 format (required).
-	Start *string
-	// WorkspaceID is the workspace identifier (required).
-	WorkspaceID *string
+	// To is the end of a date-time range, expressed in RFC 3339 format.
+	To *string
 }
 
-// Get retrieves the specified timeseries.
-func Get(ctx context.Context, c *fastly.Client, i *GetInput) (*TimeSeries, error) {
-	if i.WorkspaceID == nil {
-		return nil, fastly.ErrMissingWorkspaceID
-	}
-
+// List retrieves timeseries metrics for Next-Gen WAF.
+func List(ctx context.Context, c *fastly.Client, i *ListInput) (*Timeseries, error) {
 	if i.Metrics == nil {
 		return nil, fastly.ErrMissingMetrics
 	}
 
-	if i.Start == nil {
-		return nil, fastly.ErrMissingStart
+	if i.From == nil {
+		return nil, fastly.ErrMissingFrom
 	}
 
-	path := fastly.ToSafeURL("ngwaf", "v1", "workspaces", *i.WorkspaceID, "timeseries")
+	path := fastly.ToSafeURL("ngwaf", "v1", "timeseries")
 
 	requestOptions := fastly.CreateRequestOptions()
-	if i.Start != nil {
-		requestOptions.Params["start"] = *i.Start
+	requestOptions.Params["metrics"] = *i.Metrics
+	requestOptions.Params["from"] = *i.From
+	if i.To != nil {
+		requestOptions.Params["to"] = *i.To
 	}
-	if i.End != nil {
-		requestOptions.Params["end"] = *i.End
-	}
-	if i.Metrics != nil {
-		requestOptions.Params["metrics"] = *i.Metrics
+	if i.Dimensions != nil {
+		requestOptions.Params["dimensions"] = *i.Dimensions
 	}
 	if i.Granularity != nil {
 		requestOptions.Params["granularity"] = strconv.Itoa(*i.Granularity)
@@ -62,7 +59,7 @@ func Get(ctx context.Context, c *fastly.Client, i *GetInput) (*TimeSeries, error
 	}
 	defer resp.Body.Close()
 
-	var ts *TimeSeries
+	var ts *Timeseries
 	if err := json.NewDecoder(resp.Body).Decode(&ts); err != nil {
 		return nil, fmt.Errorf("failed to decode json response: %w", err)
 	}

--- a/fastly/ngwaf/v1/timeseries/api_list.go
+++ b/fastly/ngwaf/v1/timeseries/api_list.go
@@ -30,11 +30,11 @@ type ListInput struct {
 
 // List retrieves timeseries metrics for Next-Gen WAF.
 func List(ctx context.Context, c *fastly.Client, i *ListInput) (*Timeseries, error) {
-	if i.Metrics == nil {
+	if i.Metrics == nil || *i.Metrics == "" {
 		return nil, fastly.ErrMissingMetrics
 	}
 
-	if i.From == nil {
+	if i.From == nil || *i.From == "" {
 		return nil, fastly.ErrMissingFrom
 	}
 

--- a/fastly/ngwaf/v1/timeseries/api_response.go
+++ b/fastly/ngwaf/v1/timeseries/api_response.go
@@ -1,0 +1,31 @@
+package timeseries
+
+// TimeseriesDataPoint is a single data point in the timeseries.
+type TimeseriesDataPoint struct {
+	// Dimensions are the dimension values for this data point.
+	Dimensions TimeseriesDimensions `json:"dimensions"`
+	// Values are the metric values for this data point.
+	Values []map[string]any `json:"values"`
+}
+
+// TimeseriesDimensions holds the grouping dimensions for a data point.
+type TimeseriesDimensions struct {
+	// Time is the timestamp for this data point.
+	Time string `json:"time"`
+	// Workspace is the workspace identifier.
+	Workspace string `json:"workspace"`
+}
+
+// Timeseries is the API response structure for the list timeseries operation.
+type Timeseries struct {
+	// Data is the list of returned timeseries data points.
+	Data []TimeseriesDataPoint `json:"data"`
+	// Meta is the information for total timeseries.
+	Meta MetaTimeseries `json:"meta"`
+}
+
+// MetaTimeseries is a subset of the Timeseries response structure.
+type MetaTimeseries struct {
+	// Total is the count of data points returned.
+	Total int `json:"total"`
+}

--- a/fastly/ngwaf/v1/timeseries/api_response.go
+++ b/fastly/ngwaf/v1/timeseries/api_response.go
@@ -1,15 +1,15 @@
 package timeseries
 
-// TimeseriesDataPoint is a single data point in the timeseries.
-type TimeseriesDataPoint struct {
+// DataPoint is a single data point in the timeseries.
+type DataPoint struct {
 	// Dimensions are the dimension values for this data point.
-	Dimensions TimeseriesDimensions `json:"dimensions"`
+	Dimensions Dimensions `json:"dimensions"`
 	// Values are the metric values for this data point.
 	Values []map[string]any `json:"values"`
 }
 
-// TimeseriesDimensions holds the grouping dimensions for a data point.
-type TimeseriesDimensions struct {
+// Dimensions holds the grouping dimensions for a data point.
+type Dimensions struct {
 	// Time is the timestamp for this data point.
 	Time string `json:"time"`
 	// Workspace is the workspace identifier.
@@ -19,7 +19,7 @@ type TimeseriesDimensions struct {
 // Timeseries is the API response structure for the list timeseries operation.
 type Timeseries struct {
 	// Data is the list of returned timeseries data points.
-	Data []TimeseriesDataPoint `json:"data"`
+	Data []DataPoint `json:"data"`
 	// Meta is the information for total timeseries.
 	Meta MetaTimeseries `json:"meta"`
 }

--- a/fastly/ngwaf/v1/timeseries/api_test.go
+++ b/fastly/ngwaf/v1/timeseries/api_test.go
@@ -43,7 +43,9 @@ func TestTimeSeries_List(t *testing.T) {
 }
 
 func TestClient_List_Timeseries_validation(t *testing.T) {
+	empty := ""
 	var err error
+
 	_, err = List(context.TODO(), fastly.TestClient, &ListInput{
 		From:    nil,
 		Metrics: fastly.ToPointer(tsMetrics),
@@ -53,8 +55,24 @@ func TestClient_List_Timeseries_validation(t *testing.T) {
 	}
 
 	_, err = List(context.TODO(), fastly.TestClient, &ListInput{
+		From:    &empty,
+		Metrics: fastly.ToPointer(tsMetrics),
+	})
+	if !errors.Is(err, fastly.ErrMissingFrom) {
+		t.Errorf("expected ErrMissingFrom: got %s", err)
+	}
+
+	_, err = List(context.TODO(), fastly.TestClient, &ListInput{
 		From:    &tsFrom,
 		Metrics: nil,
+	})
+	if !errors.Is(err, fastly.ErrMissingMetrics) {
+		t.Errorf("expected ErrMissingMetrics: got %s", err)
+	}
+
+	_, err = List(context.TODO(), fastly.TestClient, &ListInput{
+		From:    &tsFrom,
+		Metrics: &empty,
 	})
 	if !errors.Is(err, fastly.ErrMissingMetrics) {
 		t.Errorf("expected ErrMissingMetrics: got %s", err)

--- a/fastly/ngwaf/v1/timeseries/api_test.go
+++ b/fastly/ngwaf/v1/timeseries/api_test.go
@@ -1,0 +1,62 @@
+package timeseries
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/fastly/go-fastly/v15/fastly"
+)
+
+const tsMetrics = "XSS,SQLI,HTTP404"
+
+var (
+	// NOTE: Update this to a recent timestamp when regenerating the test fixtures,
+	// otherwise the data may be outside of retention and an error will be
+	// returned.
+	tsTo   = time.Date(2026, 6, 15, 12, 10, 0, 0, time.UTC).Format(time.RFC3339)
+	tsFrom = time.Date(2026, 6, 15, 11, 58, 0, 0, time.UTC).Format(time.RFC3339)
+
+	// Set to 60 seconds of granularity.
+	tsGranularity = 60
+)
+
+func TestTimeSeries_List(t *testing.T) {
+	var err error
+	var ts *Timeseries
+
+	fastly.Record(t, "list_timeseries", func(c *fastly.Client) {
+		ts, err = List(context.TODO(), c, &ListInput{
+			From:        &tsFrom,
+			Granularity: &tsGranularity,
+			Metrics:     fastly.ToPointer(tsMetrics),
+			To:          &tsTo,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts == nil {
+		t.Fatal("expected timeseries response, got nil")
+	}
+}
+
+func TestClient_List_Timeseries_validation(t *testing.T) {
+	var err error
+	_, err = List(context.TODO(), fastly.TestClient, &ListInput{
+		From:    nil,
+		Metrics: fastly.ToPointer(tsMetrics),
+	})
+	if !errors.Is(err, fastly.ErrMissingFrom) {
+		t.Errorf("expected ErrMissingFrom: got %s", err)
+	}
+
+	_, err = List(context.TODO(), fastly.TestClient, &ListInput{
+		From:    &tsFrom,
+		Metrics: nil,
+	})
+	if !errors.Is(err, fastly.ErrMissingMetrics) {
+		t.Errorf("expected ErrMissingMetrics: got %s", err)
+	}
+}

--- a/fastly/ngwaf/v1/timeseries/doc.go
+++ b/fastly/ngwaf/v1/timeseries/doc.go
@@ -1,0 +1,3 @@
+// Package timeseries contains API operations to list
+// Fastly Next-Gen WAF time series metrics
+package timeseries

--- a/fastly/ngwaf/v1/timeseries/fixtures/list_timeseries.yaml
+++ b/fastly/ngwaf/v1/timeseries/fixtures/list_timeseries.yaml
@@ -1,0 +1,46 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - FastlyGo/15.0.3 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/ngwaf/v1/timeseries?from=2026-06-15T11%3A58%3A00Z&granularity=60&metrics=XSS%2CSQLI%2CHTTP404&to=2026-06-15T12%3A10%3A00Z
+    method: GET
+  response:
+    body: |
+      {"data":[{"dimensions":{"time":"2026-06-15T11:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T12:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T13:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T14:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T15:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T16:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T17:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T18:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T19:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T20:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T21:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T22:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-15T23:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T00:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T01:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T02:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T03:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T04:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T05:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T06:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T07:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T08:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T09:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T10:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]},{"dimensions":{"time":"2026-06-16T11:00:00Z"},"values":[{"HTTP404":0,"SQLI":0,"XSS":0}]}],"meta":{"total":25}}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 15 Jun 2026 14:47:56 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Served-By:
+      - cache-chi-kmdw8640056-CHI, cache-ewr-kewr1740041-EWR
+      X-Timer:
+      - S1781534875.526977,VS0,VE1503
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
### Change summary

This PR adds support for the `GET` `/ngwaf/v1/timeseries` [endpoint](https://www.fastly.com/documentation/reference/api/ngwaf/timeseries/#ngwafListTimeseries). 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Help docs for the existing workspace `GET` Time Series endpoint have also been updated to reflect the latest API docs. 
