### PR TITLE
Add required fields for custom TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Enhancements:
 
 - feat(ngwaf/timeseries): add support for listing time series metrics ([#827](https://github.com/fastly/go-fastly/pull/827))
+- feat(tls/custom-configuration): add `CreateCustomTLSConfiguration` and `DeleteCustomTLSConfiguration`, and surface `default_certificate`, `default_ecdsa_certificate`, `tls_1_2_cipher_suite_profile`, `tls_1_3_cipher_suite_profile`, and `vipspace` on the configuration resource. Create input also accepts `cipher_suites`.
+
+### Bug fixes:
 
 ### Dependencies:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Enhancements:
 
 - feat(ngwaf/timeseries): add support for listing time series metrics ([#827](https://github.com/fastly/go-fastly/pull/827))
-- feat(tls/custom-configuration): add `CreateCustomTLSConfiguration` and `DeleteCustomTLSConfiguration`, and surface `default_certificate`, `default_ecdsa_certificate`, `tls_1_2_cipher_suite_profile`, `tls_1_3_cipher_suite_profile`, and `vipspace` on the configuration resource. Create input also accepts `cipher_suites`.
+- feat(tls/custom-configuration): add `CreateCustomTLSConfiguration`, `DeleteCustomTLSConfiguration`, and additional supported fields. ([#829](https://github.com/fastly/go-fastly/pull/829))
 
 ### Bug fixes:
 

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -486,6 +486,10 @@ var ErrMissingVirtualPatchID = NewFieldError("Virtual Patch")
 // requires a "Mode" key, but one was not set.
 var ErrMissingMode = NewFieldError("Mode")
 
+// ErrMissingHTTPProtocols is an error that is returned when an input struct
+// requires an "HTTPProtocols" key, but one was not set.
+var ErrMissingHTTPProtocols = NewFieldError("HTTPProtocols")
+
 // Ensure HTTPError is, in fact, an error.
 var _ error = (*HTTPError)(nil)
 

--- a/fastly/fixtures/custom_tls_configuration/create.yaml
+++ b/fastly/fixtures/custom_tls_configuration/create.yaml
@@ -1,0 +1,40 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"data":{"type":"tls_configuration","attributes":{"http_protocols":["http/1.1","http/2"],"name":"My configuration","tls_protocols":["1.2","1.3"],"vipspace":"myvipspace"},"relationships":{"default_certificate":{"data":{"id":"1TTgJM5iiNcHi8V5cwCYk0","type":"tls_certificate"}}}}}
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.api+json
+      Content-Type:
+      - application/vnd.api+json
+      User-Agent:
+      - FastlyGo/1.17.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/tls/configurations
+    method: POST
+  response:
+    body: '{"data":{"id":"TLS_CONFIGURATION_ID","type":"tls_configuration","attributes":{"bulk":false,"created_at":"2026-04-13T14:39:59.000Z","default":false,"http_protocols":["http/1.1","http/2"],"name":"My configuration","tls_protocols":["1.2","1.3"],"updated_at":"2026-04-13T14:39:59.000Z","tls_1_2_cipher_suite_profile":["ECDHE-RSA-AES128-GCM-SHA256","ECDHE-RSA-AES128-SHA256","ECDHE-RSA-AES128-SHA","ECDHE-RSA-AES256-GCM-SHA384","ECDHE-RSA-CHACHA20-POLY1305","ECDHE-RSA-AES256-SHA384","ECDHE-RSA-AES256-SHA","AES128-GCM-SHA256","AES256-GCM-SHA384","AES128-SHA256","AES256-SHA","AES128-SHA"],"tls_1_3_cipher_suite_profile":["TLS_AES_128_GCM_SHA256","TLS_AES_256_GCM_SHA384","TLS_CHACHA20_POLY1305_SHA256"],"vipspace":"myvipspace"},"relationships":{"default_certificate":{"data":{"id":"1TTgJM5iiNcHi8V5cwCYk0","type":"tls_certificate"}},"default_ecdsa_certificate":{"data":null}}}}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - application/vnd.api+json
+      Date:
+      - Mon, 13 Apr 2026 14:39:59 GMT
+      Status:
+      - 201 Created
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - "0"
+      X-Content-Type-Options:
+      - nosniff
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/fixtures/custom_tls_configuration/delete.yaml
+++ b/fastly/fixtures/custom_tls_configuration/delete.yaml
@@ -1,0 +1,33 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/1.17.0 (+github.com/fastly/go-fastly; go1.14.2)
+    url: https://api.fastly.com/tls/configurations/TLS_CONFIGURATION_ID
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Mon, 13 Apr 2026 14:40:00 GMT
+      Status:
+      - 204 No Content
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - "0"
+      X-Content-Type-Options:
+      - nosniff
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/fastly/fixtures/custom_tls_configuration/get.yaml
+++ b/fastly/fixtures/custom_tls_configuration/get.yaml
@@ -12,7 +12,7 @@ interactions:
     url: https://api.fastly.com/tls/configurations/TLS_CONFIGURATION_ID
     method: GET
   response:
-    body: '{"data":{"id":"TLS_CONFIGURATION_ID","type":"tls_configuration","attributes":{"bulk":false,"created_at":"2018-09-11T20:59:51.000Z","default":true,"http_protocols":["http/1.1","http/2"],"name":"My configuration","tls_protocols":["1.2"],"updated_at":"2020-10-20T22:16:11.000Z"},"relationships":{"dns_records":{"data":[{"id":"IP_ADDRESS","type":"dns_record"}]}}},"included":[{"id":"IP_ADDRESS","type":"dns_record","attributes":{"record_type":"A","region":"global"}}]}'
+    body: '{"data":{"id":"TLS_CONFIGURATION_ID","type":"tls_configuration","attributes":{"bulk":false,"created_at":"2018-09-11T20:59:51.000Z","default":true,"http_protocols":["http/1.1","http/2"],"name":"My configuration","tls_protocols":["1.2","1.3"],"updated_at":"2020-10-20T22:16:11.000Z","tls_1_2_cipher_suite_profile":["ECDHE-RSA-AES128-GCM-SHA256","ECDHE-RSA-AES128-SHA256","ECDHE-RSA-AES128-SHA","ECDHE-RSA-AES256-GCM-SHA384","ECDHE-RSA-CHACHA20-POLY1305","ECDHE-RSA-AES256-SHA384","ECDHE-RSA-AES256-SHA","AES128-GCM-SHA256","AES256-GCM-SHA384","AES128-SHA256","AES256-SHA","AES128-SHA"],"tls_1_3_cipher_suite_profile":["TLS_AES_128_GCM_SHA256","TLS_AES_256_GCM_SHA384","TLS_CHACHA20_POLY1305_SHA256"],"vipspace":"myvipspace"},"relationships":{"default_certificate":{"data":{"id":"1TTgJM5iiNcHi8V5cwCYk0","type":"tls_certificate"}},"default_ecdsa_certificate":{"data":null},"dns_records":{"data":[{"id":"IP_ADDRESS","type":"dns_record"}]}}}}'
     headers:
       Accept-Ranges:
       - bytes

--- a/fastly/tls_custom_configuration.go
+++ b/fastly/tls_custom_configuration.go
@@ -12,15 +12,20 @@ import (
 
 // CustomTLSConfiguration represents a TLS configuration response from the Fastly API.
 type CustomTLSConfiguration struct {
-	Bulk          bool         `jsonapi:"attr,bulk"`
-	CreatedAt     *time.Time   `jsonapi:"attr,created_at,iso8601"`
-	DNSRecords    []*DNSRecord `jsonapi:"relation,dns_records"`
-	Default       bool         `jsonapi:"attr,default"`
-	HTTPProtocols []string     `jsonapi:"attr,http_protocols"`
-	ID            string       `jsonapi:"primary,tls_configuration"`
-	Name          string       `jsonapi:"attr,name"`
-	TLSProtocols  []string     `jsonapi:"attr,tls_protocols"`
-	UpdatedAt     *time.Time   `jsonapi:"attr,updated_at,iso8601"`
+	ID                      string             `jsonapi:"primary,tls_configuration"`
+	Name                    string             `jsonapi:"attr,name"`
+	Bulk                    bool               `jsonapi:"attr,bulk"`
+	CreatedAt               *time.Time         `jsonapi:"attr,created_at,iso8601"`
+	DefaultCertificate      *TLSCertificateRef `jsonapi:"relation,default_certificate"`
+	DefaultECDSACertificate *TLSCertificateRef `jsonapi:"relation,default_ecdsa_certificate"`
+	DNSRecords              []*DNSRecord       `jsonapi:"relation,dns_records"`
+	Default                 bool               `jsonapi:"attr,default"`
+	HTTPProtocols           []string           `jsonapi:"attr,http_protocols"`
+	TLS12CipherSuiteProfile []string           `jsonapi:"attr,tls_1_2_cipher_suite_profile"`
+	TLS13CipherSuiteProfile []string           `jsonapi:"attr,tls_1_3_cipher_suite_profile"`
+	TLSProtocols            []string           `jsonapi:"attr,tls_protocols"`
+	Vipspace                *string            `jsonapi:"attr,vipspace"`
+	UpdatedAt               *time.Time         `jsonapi:"attr,updated_at,iso8601"`
 }
 
 // DNSRecord is a child of CustomTLSConfiguration.
@@ -135,6 +140,60 @@ func (c *Client) GetCustomTLSConfiguration(ctx context.Context, i *GetCustomTLSC
 	return &con, nil
 }
 
+// CreateCustomTLSConfigurationInput is used as input to the CreateCustomTLSConfiguration function.
+type CreateCustomTLSConfigurationInput struct {
+	// CipherSuites is an ordered collection of OpenSSL-formatted cipher suite names. Note: Setting this field is an advanced feature that requires enablement by Fastly Support.
+	CipherSuites []string `jsonapi:"attr,cipher_suites,omitempty"`
+	// DefaultCertificate is the default TLS certificate.
+	DefaultCertificate *TLSCertificateRef `jsonapi:"relation,default_certificate,omitempty"`
+	// DefaultECDSACertificate is the default ECDSA TLS certificate.
+	DefaultECDSACertificate *TLSCertificateRef `jsonapi:"relation,default_ecdsa_certificate,omitempty"`
+	// DNSRecords is the set of DNS record references for the TLS configuration. Note: Setting this field is an advanced feature that requires enablement by Fastly Support.
+	DNSRecords []*DNSRecordRef `jsonapi:"relation,dns_records,omitempty"`
+	// HTTPProtocols are the HTTP protocols available on your configuration. At least one protocol is required: http/1.1 is always supported and is required in the array. http/2 and http/3 are optionally supported.
+	HTTPProtocols []string `jsonapi:"attr,http_protocols"`
+	// ID is an alphanumeric string identifying a TLS configuration (do not set, will be ignored).
+	ID string `jsonapi:"primary,tls_configuration"`
+	// Name is a custom name for your TLS configuration. Optional, Fastly will assign a value if none is provided.
+	Name string `jsonapi:"attr,name,omitempty"`
+	// Service is the Fastly service to associate with this TLS configuration.
+	Service *SAService `jsonapi:"relation,service,omitempty"`
+	// TLSProtocols are the TLS protocols available on your configuration.
+	TLSProtocols []string `jsonapi:"attr,tls_protocols,omitempty"`
+	// Vipspace is a Fastly assigned name representing a set of network prefixes. Optional; if omitted, Fastly assigns a default vipspace.
+	Vipspace *string `jsonapi:"attr,vipspace,omitempty"`
+}
+
+// TLSCertificateRef is a reference to a TLS certificate used in relationships.
+type TLSCertificateRef struct {
+	ID string `jsonapi:"primary,tls_certificate"`
+}
+
+// DNSRecordRef is a reference to a DNS record used in relationships.
+type DNSRecordRef struct {
+	ID string `jsonapi:"primary,dns_record"`
+}
+
+// CreateCustomTLSConfiguration creates a new TLS configuration.
+func (c *Client) CreateCustomTLSConfiguration(ctx context.Context, i *CreateCustomTLSConfigurationInput) (*CustomTLSConfiguration, error) {
+	if len(i.HTTPProtocols) == 0 {
+		return nil, ErrMissingHTTPProtocols
+	}
+
+	resp, err := c.PostJSONAPI(ctx, "/tls/configurations", i, CreateRequestOptions())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var con CustomTLSConfiguration
+	if err := jsonapi.UnmarshalPayload(resp.Body, &con); err != nil {
+		return nil, err
+	}
+
+	return &con, nil
+}
+
 // UpdateCustomTLSConfigurationInput is used as input to the UpdateCustomTLSConfiguration function.
 type UpdateCustomTLSConfigurationInput struct {
 	// ID is an alphanumeric string identifying a TLS configuration.
@@ -166,4 +225,26 @@ func (c *Client) UpdateCustomTLSConfiguration(ctx context.Context, i *UpdateCust
 		return nil, err
 	}
 	return &con, nil
+}
+
+// DeleteCustomTLSConfigurationInput is used as input to the DeleteCustomTLSConfiguration function.
+type DeleteCustomTLSConfigurationInput struct {
+	// ID is an alphanumeric string identifying a TLS configuration.
+	ID string
+}
+
+// DeleteCustomTLSConfiguration deletes the specified resource.
+func (c *Client) DeleteCustomTLSConfiguration(ctx context.Context, i *DeleteCustomTLSConfigurationInput) error {
+	if i.ID == "" {
+		return ErrMissingID
+	}
+
+	path := ToSafeURL("tls", "configurations", i.ID)
+
+	resp, err := c.Delete(ctx, path, CreateRequestOptions())
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
 }

--- a/fastly/tls_custom_configuration_test.go
+++ b/fastly/tls_custom_configuration_test.go
@@ -14,6 +14,38 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 	var err error
 	conID := "TLS_CONFIGURATION_ID"
 
+	// Create
+	var ccon *CustomTLSConfiguration
+	Record(t, fixtureBase+"create", func(c *Client) {
+		ccon, err = c.CreateCustomTLSConfiguration(context.TODO(), &CreateCustomTLSConfigurationInput{
+			Name:          "My configuration",
+			HTTPProtocols: []string{"http/1.1", "http/2"},
+			TLSProtocols:  []string{"1.2", "1.3"},
+			Vipspace:      ToPointer("myvipspace"),
+			DefaultCertificate: &TLSCertificateRef{
+				ID: "1TTgJM5iiNcHi8V5cwCYk0",
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conID != ccon.ID {
+		t.Errorf("bad ID: %q (%q)", conID, ccon.ID)
+	}
+	if len(ccon.TLS12CipherSuiteProfile) == 0 {
+		t.Errorf("expected TLS12CipherSuiteProfile to be populated")
+	}
+	if len(ccon.TLS13CipherSuiteProfile) == 0 {
+		t.Errorf("expected TLS13CipherSuiteProfile to be populated")
+	}
+	if ccon.DefaultCertificate == nil || ccon.DefaultCertificate.ID != "1TTgJM5iiNcHi8V5cwCYk0" {
+		t.Errorf("bad DefaultCertificate: %+v", ccon.DefaultCertificate)
+	}
+	if ccon.Vipspace == nil || *ccon.Vipspace != "myvipspace" {
+		t.Errorf("bad Vipspace: %+v", ccon.Vipspace)
+	}
+
 	// Get
 	var gcon *CustomTLSConfiguration
 	Record(t, fixtureBase+"get", func(c *Client) {
@@ -26,6 +58,18 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 	}
 	if conID != gcon.ID {
 		t.Errorf("bad ID: %q (%q)", conID, gcon.ID)
+	}
+	if gcon.Vipspace == nil || *gcon.Vipspace != "myvipspace" {
+		t.Errorf("bad Vipspace: %v", gcon.Vipspace)
+	}
+	if len(gcon.TLS12CipherSuiteProfile) == 0 {
+		t.Errorf("expected TLS12CipherSuiteProfile to be populated")
+	}
+	if len(gcon.TLS13CipherSuiteProfile) == 0 {
+		t.Errorf("expected TLS13CipherSuiteProfile to be populated")
+	}
+	if gcon.DefaultCertificate == nil || gcon.DefaultCertificate.ID != "1TTgJM5iiNcHi8V5cwCYk0" {
+		t.Errorf("bad DefaultCertificate: %+v", gcon.DefaultCertificate)
 	}
 
 	// List
@@ -57,6 +101,16 @@ func TestClient_CustomTLSConfiguration(t *testing.T) {
 	}
 	if ucon.Name != newName {
 		t.Errorf("bad Name: %q (%q)", newName, ucon.Name)
+	}
+
+	// Delete
+	Record(t, fixtureBase+"delete", func(c *Client) {
+		err = c.DeleteCustomTLSConfiguration(context.TODO(), &DeleteCustomTLSConfigurationInput{
+			ID: conID,
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -116,6 +170,24 @@ func TestClient_UpdateCustomTLSConfiguration_validation(t *testing.T) {
 		ID: "CONFIGURATION_ID",
 	})
 	if !errors.Is(err, ErrMissingName) {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_CreateCustomTLSConfiguration_validation(t *testing.T) {
+	t.Parallel()
+
+	_, err := TestClient.CreateCustomTLSConfiguration(context.TODO(), &CreateCustomTLSConfigurationInput{})
+	if !errors.Is(err, ErrMissingHTTPProtocols) {
+		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestClient_DeleteCustomTLSConfiguration_validation(t *testing.T) {
+	t.Parallel()
+
+	err := TestClient.DeleteCustomTLSConfiguration(context.TODO(), &DeleteCustomTLSConfigurationInput{})
+	if !errors.Is(err, ErrMissingID) {
 		t.Errorf("bad error: %s", err)
 	}
 }


### PR DESCRIPTION
### Change summary

Add creation and deletion of custom TLS configurations. This is building up changes required to fully support custom TLS configurations in the Fastly Terraform Provider.

 <!--
Briefly describe the changes introduced in this pull request. Include context or
reasoning behind the changes, even if they seem minor. If relevant, link to any
related discussions (e.g. Slack threads, tickets, documents).
-->

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

<!-- What is the user impact of this change? -->

There shouldn't be any impact to existing users.

### Are there any considerations that need to be addressed for release?

<!-- Any breaking changes, etc -->

- [ ] Some of this functionality may require Fastly to enable for account-specific features.
- [ ] Public type structure may not be desired shape.
