### PR TITLE
[CDTOOL-1669] Allow `templated_signal` Rules to be created without `conditions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug fixes:
 
+- fix(ngwaf/rules): allow `templated_signal` rules to be created without conditions ([#834](https://github.com/fastly/go-fastly/pull/834))
+
 ## [v16.0.0](https://github.com/fastly/go-fastly/releases/tag/v16.0.0) (2026-07-01)
 
 ### Breaking:

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -103,10 +103,6 @@ var ErrMissingCertBlob = NewFieldError("CertBlob")
 // requires a "CertBundle" key, but one was not set.
 var ErrMissingCertBundle = NewFieldError("CertBundle")
 
-// ErrMissingConditions is an error that is returned when an input struct
-// requires a "Conditions" key, but one was not set.
-var ErrMissingConditions = NewFieldError("Conditions")
-
 // ErrMissingComputeACLID is an error that is returned when an input struct
 // requires a "ComputeACLID" key, but one was not set.
 var ErrMissingComputeACLID = NewFieldError("ComputeACLID")

--- a/fastly/ngwaf/v1/rules/api_create.go
+++ b/fastly/ngwaf/v1/rules/api_create.go
@@ -20,7 +20,7 @@ type CreateInput struct {
 	// criteria.
 	Conditions []*CreateCondition
 	// Description provides a human-readable explanation of what
-	// the rule does (required).
+	// the rule does.
 	Description *string
 	// Enabled determines if the rule is active. If false or
 	// omitted, the rule is disabled by default.
@@ -193,14 +193,11 @@ func Create(ctx context.Context, c *fastly.Client, i *CreateInput) (*Rule, error
 	if i.Type == nil {
 		return nil, fastly.ErrMissingType
 	}
-	if i.Description == nil {
-		return nil, fastly.ErrMissingDescription
-	}
 	if i.Scope == nil {
 		return nil, fastly.ErrMissingScope
 	}
 
-	var mergedConditions []any
+	mergedConditions := []any{}
 	for _, c := range i.Conditions {
 		privateCondition := &privateCreateCondition{
 			Type:     fastly.ToPointer("single"),
@@ -264,14 +261,10 @@ func Create(ctx context.Context, c *fastly.Client, i *CreateInput) (*Rule, error
 		}
 		mergedConditions = append(mergedConditions, privateMultivalCondition)
 	}
-	if len(mergedConditions) == 0 {
-		return nil, fastly.ErrMissingConditions
-	}
-
 	v := struct {
 		Actions        []*CreateAction  `json:"actions,omitempty"`
 		Conditions     []any            `json:"conditions"`
-		Description    *string          `json:"description"`
+		Description    *string          `json:"description,omitempty"`
 		Enabled        *bool            `json:"enabled,omitempty"`
 		ExpiresAt      *time.Time       `json:"expires_at,omitempty"`
 		GroupOperator  *string          `json:"group_operator,omitempty"`

--- a/fastly/ngwaf/v1/rules/api_test.go
+++ b/fastly/ngwaf/v1/rules/api_test.go
@@ -2094,6 +2094,58 @@ func runDeceptionRuleTest(t *testing.T, scopeType scope.Type, appliesToID string
 	assert.Contains(updatedMultivalConditions[0].Conditions, ConditionMul{Type: conditionType, Field: updatedField10, Operator: updatedOperator10, Value: updatedValue10})
 }
 
+func TestClient_TemplatedSignalRule_WorkspaceScope(t *testing.T) {
+	assert := require.New(t)
+
+	var err error
+
+	enabled := true
+	ruleType := "templated_signal"
+	groupOperator := "all"
+	actionType := "templated_signal"
+	actionSignal := "AWS-SSRF"
+
+	var rule *Rule
+	fastly.Record(t, "workspace_templated_signal_create_rule", func(c *fastly.Client) {
+		rule, err = Create(context.TODO(), c, &CreateInput{
+			Scope: &scope.Scope{
+				Type:      scope.ScopeTypeWorkspace,
+				AppliesTo: []string{fastly.TestNGWAFWorkspaceID},
+			},
+			Type:          &ruleType,
+			Enabled:       &enabled,
+			GroupOperator: &groupOperator,
+			Actions: []*CreateAction{
+				{
+					Type:   &actionType,
+					Signal: &actionSignal,
+				},
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		fastly.Record(t, "workspace_templated_signal_delete_rule", func(c *fastly.Client) {
+			err = Delete(context.TODO(), c, &DeleteInput{
+				RuleID: fastly.ToPointer(rule.RuleID),
+				Scope: &scope.Scope{
+					Type:      scope.ScopeTypeWorkspace,
+					AppliesTo: []string{fastly.TestNGWAFWorkspaceID},
+				},
+			})
+		})
+		if err != nil {
+			t.Errorf("error during templated_signal rule cleanup: %v", err)
+		}
+	}()
+
+	assert.Equal(ruleType, rule.Type)
+	assert.Empty(rule.Conditions)
+}
+
 func TestClient_CreateRule_validation(t *testing.T) {
 	var err error
 	_, err = Create(context.TODO(), fastly.TestClient, &CreateInput{
@@ -2103,32 +2155,11 @@ func TestClient_CreateRule_validation(t *testing.T) {
 		t.Errorf("expected ErrMissingType: got %s", err)
 	}
 	_, err = Create(context.TODO(), fastly.TestClient, &CreateInput{
-		Type:        fastly.ToPointer("request"),
-		Description: nil,
-	})
-	if !errors.Is(err, fastly.ErrMissingDescription) {
-		t.Errorf("expected ErrMissingDescription: got %s", err)
-	}
-	_, err = Create(context.TODO(), fastly.TestClient, &CreateInput{
-		Type:        fastly.ToPointer("request"),
-		Description: fastly.ToPointer("test"),
-		Scope:       nil,
+		Type:  fastly.ToPointer("request"),
+		Scope: nil,
 	})
 	if !errors.Is(err, fastly.ErrMissingScope) {
 		t.Errorf("expected ErrMissingScope: got %s", err)
-	}
-	_, err = Create(context.TODO(), fastly.TestClient, &CreateInput{
-		Type:        fastly.ToPointer("request"),
-		Description: fastly.ToPointer("test"),
-		Scope: &scope.Scope{
-			Type:      scope.ScopeTypeWorkspace,
-			AppliesTo: []string{"123"},
-		},
-		Conditions:      []*CreateCondition{},
-		GroupConditions: []*CreateGroupCondition{},
-	})
-	if !errors.Is(err, fastly.ErrMissingConditions) {
-		t.Errorf("expected ErrMissingConditions: got %s", err)
 	}
 }
 

--- a/fastly/ngwaf/v1/rules/api_update.go
+++ b/fastly/ngwaf/v1/rules/api_update.go
@@ -20,7 +20,7 @@ type UpdateInput struct {
 	// criteria.
 	Conditions []*UpdateCondition
 	// Description provides a human-readable explanation of what
-	// the rule does (required).
+	// the rule does.
 	Description *string
 	// Enabled determines if the rule is active. If false or
 	// omitted, the rule is disabled by default.

--- a/fastly/ngwaf/v1/rules/fixtures/workspace_templated_signal_create_rule.yaml
+++ b/fastly/ngwaf/v1/rules/fixtures/workspace_templated_signal_create_rule.yaml
@@ -1,0 +1,52 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"actions":[{"signal":"AWS-SSRF","type":"templated_signal"}],"conditions":[],"enabled":true,"group_operator":"all","scope":{"type":"workspace","applies_to":["Am2qjXkgamuYp3u54rQkLD"]},"type":"templated_signal"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/16.0.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/ngwaf/v1/workspaces/Am2qjXkgamuYp3u54rQkLD/rules
+    method: POST
+  response:
+    body: |
+      {"id":"6a4d5d95310e836ab55ce339","type":"templated_signal","scope":{"type":"workspace","applies_to":["Am2qjXkgamuYp3u54rQkLD"]},"enabled":true,"description":"","group_operator":"all","conditions":[],"actions":[{"type":"templated_signal","signal":"AWS-SSRF"}],"created_at":"2026-07-07T20:12:05Z","updated_at":"2026-07-07T20:12:05Z"}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "332"
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Jul 2026 20:12:05 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "3572"
+      X-Served-By:
+      - cache-chi-klot8100060-CHI, cache-ewr-kewr1740078-EWR
+      X-Timer:
+      - S1783455122.907660,VS0,VE3606
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/ngwaf/v1/rules/fixtures/workspace_templated_signal_delete_rule.yaml
+++ b/fastly/ngwaf/v1/rules/fixtures/workspace_templated_signal_delete_rule.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/16.0.0 (+github.com/fastly/go-fastly; go1.26.2)
+    url: https://api.fastly.com/ngwaf/v1/workspaces/Am2qjXkgamuYp3u54rQkLD/rules/6a4d5d95310e836ab55ce339
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 Jul 2026 20:12:06 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "1022"
+      X-Served-By:
+      - cache-chi-kigq8000129-CHI, cache-ewr-kewr1740078-EWR
+      X-Timer:
+      - S1783455126.539393,VS0,VE1074
+    status: 204 No Content
+    code: 204
+    duration: ""


### PR DESCRIPTION
### Change summary

This PR updates the `conditions` and `description` fields for NGWAF Rules to be optional as rules of type `templated_signal` must have this exception. 

Sample payload example:
```
{
    "type": "templated_signal",
    "conditions": [],
    "enabled": true,
    "actions": [
        {
            "type": "templated_signal",
            "signal": "AWS-SSRF"
        }
    ],
    "group_operator": "all"
}
```

This is unique behavior where the `description` field is omitted and `[]` can be passed for the value of `conditions`. 

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

This unblocks downstream functionality in Terraform, where creating a rule of type `templated_signal` is currently not possible due condition enforcement in `go-fastly`. 
