### PR TITLE
[CDTOOL-1689] Add typed helpers for new integration types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Enhancements:
 
+- feat(notifications): add typed constants and config helpers for the Datadog, Jira Issue, Jira Service Management, OpsGenie, and Splunk On-Call integration types ([#842](https://github.com/fastly/go-fastly/pull/842))
+
 ### Dependencies:
 
 ### Bug fixes:

--- a/fastly/fixtures/notifications/cleanup_integration.yaml
+++ b/fastly/fixtures/notifications/cleanup_integration.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.1 (+github.com/fastly/go-fastly; go1.22.0)
-    url: https://api.fastly.com/notifications/integrations/2KYt9p4Y1KPhSjwThWG08E
+      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
     method: DELETE
   response:
     body: |
@@ -22,11 +22,11 @@ interactions:
       Content-Type:
       - application/problem+json
       Date:
-      - Tue, 16 Apr 2024 15:52:44 GMT
+      - Tue, 28 Jul 2026 21:20:43 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly istio-envoy
       Status:
       - 404 Not Found
       Strict-Transport-Security:
@@ -34,15 +34,17 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - "0"
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "21"
       X-Served-By:
-      - cache-pao-kpao1770026-PAO
+      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1713282764.911079,VS0,VE212
+      - S1785273644.768990,VS0,VE50
     status: 404 Not Found
     code: 404
     duration: ""

--- a/fastly/fixtures/notifications/create_datadog_integration.yaml
+++ b/fastly/fixtures/notifications/create_datadog_integration.yaml
@@ -2,27 +2,32 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"Config":{"apikey":"abc123def456","site":"datadoghq.eu"},"Description":"test
+      datadog description","Name":"test datadog name","Type":"datadog"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations
+    method: POST
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"integration_id":"1rno9PjY2gML151lMmISgH"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "44"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:40 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +45,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "184"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kigq8000109-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273641.602591,VS0,VE214
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/create_integration.yaml
+++ b/fastly/fixtures/notifications/create_integration.yaml
@@ -11,12 +11,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/9.2.1 (+github.com/fastly/go-fastly; go1.22.0)
+      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
     url: https://api.fastly.com/notifications/integrations
     method: POST
   response:
     body: |
-      {"integration_id":"2KYt9p4Y1KPhSjwThWG08E"}
+      {"integration_id":"1oThZkDLabGDYitZ7ecfBh"}
     headers:
       Accept-Ranges:
       - bytes
@@ -27,11 +27,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 15:52:40 GMT
+      - Tue, 28 Jul 2026 21:20:38 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly istio-envoy
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -39,15 +39,17 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - "0"
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "238"
       X-Served-By:
-      - cache-pao-kpao1770026-PAO
+      - cache-chi-kigq8000109-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1713282760.713037,VS0,VE365
+      - S1785273638.338999,VS0,VE269
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/create_jiraissue_integration.yaml
+++ b/fastly/fixtures/notifications/create_jiraissue_integration.yaml
@@ -2,27 +2,32 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"Config":{"baseurl":"https://your-org.atlassian.net","issuetype":"Bug","projectkey":"PROJ","token":"AbCdEfGhIjKlMnOpQrStUvWx","username":"user@example.com"},"Description":"test
+      jiraissue description","Name":"test jiraissue name","Type":"jiraissue"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations
+    method: POST
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"integration_id":"1sa0xb5OlebwIbCZ0YIQpB"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "44"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:41 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +45,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "212"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kigq8000109-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273641.270672,VS0,VE243
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/create_jsm_integration.yaml
+++ b/fastly/fixtures/notifications/create_jsm_integration.yaml
@@ -2,27 +2,32 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"Config":{"apikey":"g4ff854d-a14c-46a8-b8f0-0960774319dd"},"Description":"test
+      jsm description","Name":"test jsm name","Type":"jsm"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations
+    method: POST
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"integration_id":"1sZoqRMehJcs3JSuSjuSZ5"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "44"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:42 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +45,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "250"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kigq8000109-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273642.974416,VS0,VE281
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/create_mailinglist_confirmation.yaml
+++ b/fastly/fixtures/notifications/create_mailinglist_confirmation.yaml
@@ -10,7 +10,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/9.2.1 (+github.com/fastly/go-fastly; go1.22.0)
+      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
     url: https://api.fastly.com/notifications/mailinglist-confirmations
     method: POST
   response:
@@ -23,11 +23,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 15:52:41 GMT
+      - Tue, 28 Jul 2026 21:20:39 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly istio-envoy
       Status:
       - 204 No Content
       Strict-Transport-Security:
@@ -35,15 +35,17 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - "0"
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "269"
       X-Served-By:
-      - cache-pao-kpao1770026-PAO
+      - cache-chi-kmdw8640058-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1713282761.125854,VS0,VE535
+      - S1785273639.030240,VS0,VE319
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/fixtures/notifications/create_opsgenie_integration.yaml
+++ b/fastly/fixtures/notifications/create_opsgenie_integration.yaml
@@ -2,27 +2,32 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"Config":{"apikey":"a1bb854d-b24c-46a8-c9f0-1960774319ee"},"Description":"test
+      opsgenie description","Name":"test opsgenie name","Type":"opsgenie"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations
+    method: POST
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"integration_id":"1tCOKPaspcCdEPFoiDjLV1"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "44"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:42 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +45,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "214"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kigq8000109-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273643.576250,VS0,VE245
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/create_splunkoncall_integration.yaml
+++ b/fastly/fixtures/notifications/create_splunkoncall_integration.yaml
@@ -2,27 +2,32 @@
 version: 1
 interactions:
 - request:
-    body: ""
+    body: '{"Config":{"url":"https://alert.victorops.com/integrations/generic/20131114/alert/XXXX"},"Description":"test
+      splunkoncall description","Name":"test splunkoncall name","Type":"splunkoncall"}'
     form: {}
     headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations
+    method: POST
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"integration_id":"1uk4flt3WMVQU2xi9Z7j7J"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "44"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:43 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +45,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "189"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kigq8000109-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273643.216141,VS0,VE224
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/delete_datadog_integration.yaml
+++ b/fastly/fixtures/notifications/delete_datadog_integration.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations/1rno9PjY2gML151lMmISgH
+    method: DELETE
   response:
-    body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "251"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:41 GMT
       Pragma:
       - no-cache
       Server:
       - fastly istio-envoy
       Status:
-      - 200 OK
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,11 +37,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "166"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kmdw8640079-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
-    status: 200 OK
-    code: 200
+      - S1785273641.055172,VS0,VE194
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/notifications/delete_integration.yaml
+++ b/fastly/fixtures/notifications/delete_integration.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.1 (+github.com/fastly/go-fastly; go1.22.0)
-    url: https://api.fastly.com/notifications/integrations/2KYt9p4Y1KPhSjwThWG08E
+      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
     method: DELETE
   response:
     body: ""
@@ -19,11 +19,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 15:52:43 GMT
+      - Tue, 28 Jul 2026 21:20:40 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly istio-envoy
       Status:
       - 204 No Content
       Strict-Transport-Security:
@@ -31,15 +31,17 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - "0"
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "202"
       X-Served-By:
-      - cache-pao-kpao1770026-PAO
+      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1713282764.587111,VS0,VE283
+      - S1785273640.351936,VS0,VE232
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/fixtures/notifications/delete_jiraissue_integration.yaml
+++ b/fastly/fixtures/notifications/delete_jiraissue_integration.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations/1sa0xb5OlebwIbCZ0YIQpB
+    method: DELETE
   response:
-    body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "251"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:41 GMT
       Pragma:
       - no-cache
       Server:
       - fastly istio-envoy
       Status:
-      - 200 OK
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,11 +37,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "182"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kigq8000114-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
-    status: 200 OK
-    code: 200
+      - S1785273642.742490,VS0,VE214
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/notifications/delete_jsm_integration.yaml
+++ b/fastly/fixtures/notifications/delete_jsm_integration.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations/1sZoqRMehJcs3JSuSjuSZ5
+    method: DELETE
   response:
-    body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "251"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:42 GMT
       Pragma:
       - no-cache
       Server:
       - fastly istio-envoy
       Status:
-      - 200 OK
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,11 +37,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "174"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kmdw8640081-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
-    status: 200 OK
-    code: 200
+      - S1785273642.355869,VS0,VE203
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/notifications/delete_opsgenie_integration.yaml
+++ b/fastly/fixtures/notifications/delete_opsgenie_integration.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations/1tCOKPaspcCdEPFoiDjLV1
+    method: DELETE
   response:
-    body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "251"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:43 GMT
       Pragma:
       - no-cache
       Server:
       - fastly istio-envoy
       Status:
-      - 200 OK
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,11 +37,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "202"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-klot8100125-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
-    status: 200 OK
-    code: 200
+      - S1785273643.952606,VS0,VE241
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/notifications/delete_splunkoncall_integration.yaml
+++ b/fastly/fixtures/notifications/delete_splunkoncall_integration.yaml
@@ -7,28 +7,25 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
-    method: GET
+    url: https://api.fastly.com/notifications/integrations/1uk4flt3WMVQU2xi9Z7j7J
+    method: DELETE
   response:
-    body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+    body: ""
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "251"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:43 GMT
       Pragma:
       - no-cache
       Server:
       - fastly istio-envoy
       Status:
-      - 200 OK
+      - 204 No Content
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -40,11 +37,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "176"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kigq8000103-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
-    status: 200 OK
-    code: 200
+      - S1785273644.542471,VS0,VE208
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/fastly/fixtures/notifications/get_datadog_integration.yaml
+++ b/fastly/fixtures/notifications/get_datadog_integration.yaml
@@ -7,22 +7,22 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
+    url: https://api.fastly.com/notifications/integrations/1rno9PjY2gML151lMmISgH
     method: GET
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"id":"1rno9PjY2gML151lMmISgH","name":"test datadog name","description":"test datadog description","type":"datadog","created_at":"2026-07-28T21:20:41Z","updated_at":"2026-07-28T21:20:41Z","config":{"site":"datadoghq.eu"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "222"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:41 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "162"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kmdw8640079-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273641.845098,VS0,VE192
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/get_integration_types.yaml
+++ b/fastly/fixtures/notifications/get_integration_types.yaml
@@ -6,27 +6,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.1 (+github.com/fastly/go-fastly; go1.22.0)
+      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
     url: https://api.fastly.com/notifications/integration-types
     method: GET
   response:
     body: |
-      [{"type":"mailinglist","display_name":"Mailing List","custom_fields":[{"name":"address","display_name":"Address","format":"email"}]},{"type":"microsoftteams","display_name":"Microsoft Teams","custom_fields":[{"name":"webhook","display_name":"Webhook URL","format":"url"}]},{"type":"newrelic","display_name":"New Relic","custom_fields":[{"name":"key","display_name":"Key","format":""},{"name":"account","display_name":"Account","format":""}]},{"type":"pagerduty","display_name":"PagerDuty","custom_fields":[{"name":"key","display_name":"Key","format":""}]},{"type":"slack","display_name":"Slack Webhook","custom_fields":[{"name":"webhook","display_name":"Webhook URL","format":"url"}]},{"type":"webhook","display_name":"Generic Webhook","custom_fields":[{"name":"webhook","display_name":"Webhook URL","format":"url"}]}]
+      [{"type":"mailinglist","display_name":"Mailing List","custom_fields":[{"name":"address","display_name":"Address","format":"email"}]},{"type":"microsoftteams","display_name":"Microsoft Teams","custom_fields":[{"name":"webhook","display_name":"Webhook URL","format":"url"}]},{"type":"newrelic","display_name":"New Relic","custom_fields":[{"name":"key","display_name":"Key","format":""},{"name":"account","display_name":"Account","format":""}]},{"type":"pagerduty","display_name":"PagerDuty","custom_fields":[{"name":"key","display_name":"Key","format":""}]},{"type":"slack","display_name":"Slack Webhook","custom_fields":[{"name":"webhook","display_name":"Webhook URL","format":"url"}]},{"type":"webhook","display_name":"Generic Webhook","custom_fields":[{"name":"webhook","display_name":"Webhook URL","format":"url"}]},{"type":"jiraissue","display_name":"JIRA Issue","custom_fields":[{"name":"baseurl","display_name":"JIRA Base URL","format":"url"},{"name":"username","display_name":"Username","format":""},{"name":"token","display_name":"API Token","format":""},{"name":"projectkey","display_name":"Project Key","format":""},{"name":"issuetype","display_name":"Issue Type","format":""}]},{"type":"opsgenie","display_name":"OpsGenie","custom_fields":[{"name":"apikey","display_name":"API Key","format":""}]},{"type":"datadog","display_name":"Datadog","custom_fields":[{"name":"apikey","display_name":"API Key","format":""},{"name":"site","display_name":"Site","format":""}]},{"type":"jsm","display_name":"Jira Service Management","custom_fields":[{"name":"apikey","display_name":"API Key","format":""}]},{"type":"splunkoncall","display_name":"Splunk On-Call","custom_fields":[{"name":"url","display_name":"Webhook URL","format":"url"}]}]
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "819"
+      - "1737"
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 15:52:39 GMT
+      - Tue, 28 Jul 2026 21:20:38 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly istio-envoy
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -34,15 +34,17 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - "0"
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "76"
       X-Served-By:
-      - cache-pao-kpao1770026-PAO
+      - cache-chi-kmdw8640020-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1713282759.197906,VS0,VE481
+      - S1785273638.204905,VS0,VE109
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/get_jiraissue_integration.yaml
+++ b/fastly/fixtures/notifications/get_jiraissue_integration.yaml
@@ -7,22 +7,22 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
+    url: https://api.fastly.com/notifications/integrations/1sa0xb5OlebwIbCZ0YIQpB
     method: GET
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"id":"1sa0xb5OlebwIbCZ0YIQpB","name":"test jiraissue name","description":"test jiraissue description","type":"jiraissue","created_at":"2026-07-28T21:20:41Z","updated_at":"2026-07-28T21:20:41Z","config":{"baseurl":"https://your-org.atlassian.net","issuetype":"Bug","projectkey":"PROJ","username":"user@example.com"}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "317"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:41 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "149"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kigq8000114-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273642.535450,VS0,VE184
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/get_jsm_integration.yaml
+++ b/fastly/fixtures/notifications/get_jsm_integration.yaml
@@ -7,22 +7,22 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
+    url: https://api.fastly.com/notifications/integrations/1sZoqRMehJcs3JSuSjuSZ5
     method: GET
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"id":"1sZoqRMehJcs3JSuSjuSZ5","name":"test jsm name","description":"test jsm description","type":"jsm","created_at":"2026-07-28T21:20:42Z","updated_at":"2026-07-28T21:20:42Z"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "177"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:42 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "28"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kmdw8640081-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273642.277512,VS0,VE58
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/get_opsgenie_integration.yaml
+++ b/fastly/fixtures/notifications/get_opsgenie_integration.yaml
@@ -7,22 +7,22 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
+    url: https://api.fastly.com/notifications/integrations/1tCOKPaspcCdEPFoiDjLV1
     method: GET
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"id":"1tCOKPaspcCdEPFoiDjLV1","name":"test opsgenie name","description":"test opsgenie description","type":"opsgenie","created_at":"2026-07-28T21:20:43Z","updated_at":"2026-07-28T21:20:43Z"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "192"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:42 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "30"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-klot8100125-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273643.839877,VS0,VE93
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/get_splunkoncall_integration.yaml
+++ b/fastly/fixtures/notifications/get_splunkoncall_integration.yaml
@@ -7,22 +7,22 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
+    url: https://api.fastly.com/notifications/integrations/1uk4flt3WMVQU2xi9Z7j7J
     method: GET
   response:
     body: |
-      {"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}
+      {"id":"1uk4flt3WMVQU2xi9Z7j7J","name":"test splunkoncall name","description":"test splunkoncall description","type":"splunkoncall","created_at":"2026-07-28T21:20:43Z","updated_at":"2026-07-28T21:20:43Z"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "251"
+      - "204"
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jul 2026 21:20:39 GMT
+      - Tue, 28 Jul 2026 21:20:43 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "97"
+      - "25"
       X-Served-By:
-      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
+      - cache-chi-kigq8000103-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1785273639.878468,VS0,VE131
+      - S1785273643.469031,VS0,VE55
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/get_webhook_signing_key.yaml
+++ b/fastly/fixtures/notifications/get_webhook_signing_key.yaml
@@ -6,12 +6,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.1 (+github.com/fastly/go-fastly; go1.22.0)
-    url: https://api.fastly.com/notifications/integrations/2KYt9p4Y1KPhSjwThWG08E/signingKey
+      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh/signingKey
     method: GET
   response:
     body: |
-      {"signingKey":"372f476c-d02b-41fd-a275-c06a17c44f81"}
+      {"signingKey":"da18e0d5-0c6a-41e7-806e-8826560a242d"}
     headers:
       Accept-Ranges:
       - bytes
@@ -22,11 +22,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 15:52:43 GMT
+      - Tue, 28 Jul 2026 21:20:40 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly istio-envoy
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -34,15 +34,17 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - "0"
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "208"
       X-Served-By:
-      - cache-pao-kpao1770026-PAO
+      - cache-chi-klot8100145-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1713282763.170686,VS0,VE355
+      - S1785273640.090764,VS0,VE243
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/rotate_webhook_signing_key.yaml
+++ b/fastly/fixtures/notifications/rotate_webhook_signing_key.yaml
@@ -6,12 +6,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.1 (+github.com/fastly/go-fastly; go1.22.0)
-    url: https://api.fastly.com/notifications/integrations/2KYt9p4Y1KPhSjwThWG08E/rotateSigningKey
+      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh/rotateSigningKey
     method: POST
   response:
     body: |
-      {"signingKey":"372f476c-d02b-41fd-a275-c06a17c44f81"}
+      {"signingKey":"da18e0d5-0c6a-41e7-806e-8826560a242d"}
     headers:
       Accept-Ranges:
       - bytes
@@ -22,11 +22,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 15:52:43 GMT
+      - Tue, 28 Jul 2026 21:20:40 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly istio-envoy
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -34,15 +34,17 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - "0"
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "370"
       X-Served-By:
-      - cache-pao-kpao1770026-PAO
+      - cache-chi-kmdw8640094-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1713282762.185656,VS0,VE907
+      - S1785273640.652629,VS0,VE400
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/search_integrations.yaml
+++ b/fastly/fixtures/notifications/search_integrations.yaml
@@ -6,27 +6,27 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/9.2.1 (+github.com/fastly/go-fastly; go1.22.0)
+      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
     url: https://api.fastly.com/notifications/integrations?cursor=&limit=3&sort=-created_at&type=mailinglist
     method: GET
   response:
     body: |
-      {"meta":{"type":"mailinglist","total":1,"limit":3,"sort":"-created_at"},"data":[{"id":"2KYt9p4Y1KPhSjwThWG08E","name":"test name","description":"test description","type":"mailinglist","created_at":"2024-04-16T15:52:40Z","updated_at":"2024-04-16T15:52:40Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}}]}
+      {"meta":{"type":"mailinglist","total":2,"limit":3,"sort":"-created_at"},"data":[{"id":"1oThZkDLabGDYitZ7ecfBh","name":"test name","description":"test description","type":"mailinglist","created_at":"2026-07-28T21:20:39Z","updated_at":"2026-07-28T21:20:39Z","status":"confirmation_pending","config":{"address":"noreply@fastly.com"}},{"id":"7zKS2PO4WYGDbBlZc7jvio","name":"Email: email@address.com","description":"","type":"mailinglist","created_at":"2026-05-22T02:14:33Z","updated_at":"2026-05-22T02:14:33Z","status":"needs_confirmation","config":{"address":"email@address.com"}}]}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "333"
+      - "580"
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 15:52:40 GMT
+      - Tue, 28 Jul 2026 21:20:38 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly istio-envoy
       Status:
       - 200 OK
       Strict-Transport-Security:
@@ -34,15 +34,17 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - "0"
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "181"
       X-Served-By:
-      - cache-pao-kpao1770026-PAO
+      - cache-chi-kigq8000052-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1713282760.108315,VS0,VE510
+      - S1785273639.625627,VS0,VE213
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/fixtures/notifications/update_integration.yaml
+++ b/fastly/fixtures/notifications/update_integration.yaml
@@ -2,8 +2,8 @@
 version: 1
 interactions:
 - request:
-    body: '{"Config":{"url":"https://foo.com/bar"},"Description":"test description
-      updated","ID":"2KYt9p4Y1KPhSjwThWG08E","Name":"test name updated","Type":"webhook"}'
+    body: '{"Config":{"webhook":"https://foo.com/bar"},"Description":"test description
+      updated","ID":"1oThZkDLabGDYitZ7ecfBh","Name":"test name updated","Type":"webhook"}'
     form: {}
     headers:
       Accept:
@@ -11,8 +11,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/9.2.1 (+github.com/fastly/go-fastly; go1.22.0)
-    url: https://api.fastly.com/notifications/integrations/2KYt9p4Y1KPhSjwThWG08E
+      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+    url: https://api.fastly.com/notifications/integrations/1oThZkDLabGDYitZ7ecfBh
     method: PATCH
   response:
     body: ""
@@ -24,11 +24,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Apr 2024 15:52:42 GMT
+      - Tue, 28 Jul 2026 21:20:39 GMT
       Pragma:
       - no-cache
       Server:
-      - control-gateway
+      - fastly istio-envoy
       Status:
       - 204 No Content
       Strict-Transport-Security:
@@ -36,15 +36,17 @@ interactions:
       Vary:
       - Accept-Encoding
       Via:
-      - 1.1 varnish
+      - 1.1 varnish, 1.1 varnish
       X-Cache:
-      - MISS
+      - MISS, MISS
       X-Cache-Hits:
-      - "0"
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "232"
       X-Served-By:
-      - cache-pao-kpao1770026-PAO
+      - cache-chi-kmdw8640067-CHI, cache-ewr-kewr1740020-EWR
       X-Timer:
-      - S1713282762.687833,VS0,VE473
+      - S1785273639.372652,VS0,VE262
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/notifications.go
+++ b/fastly/notifications.go
@@ -8,6 +8,20 @@ import (
 	"time"
 )
 
+// Integration type values for the "type" field of an Integration.
+const (
+	// IntegrationTypeDatadog is the type value for a Datadog integration.
+	IntegrationTypeDatadog = "datadog"
+	// IntegrationTypeJiraIssue is the type value for a Jira Issue integration.
+	IntegrationTypeJiraIssue = "jiraissue"
+	// IntegrationTypeJSM is the type value for a Jira Service Management integration.
+	IntegrationTypeJSM = "jsm"
+	// IntegrationTypeOpsGenie is the type value for an OpsGenie integration.
+	IntegrationTypeOpsGenie = "opsgenie"
+	// IntegrationTypeSplunkOnCall is the type value for a Splunk On-Call integration.
+	IntegrationTypeSplunkOnCall = "splunkoncall"
+)
+
 // Integration holds the configuration for one integration.
 type Integration struct {
 	CreatedAt   *time.Time        `json:"created_at"`
@@ -311,4 +325,89 @@ func (c *Client) CreateMailinglistConfirmation(ctx context.Context, i *CreateMai
 	}
 
 	return nil
+}
+
+// DatadogConfig holds the configuration fields for an integration of type
+// IntegrationTypeDatadog.
+type DatadogConfig struct {
+	// APIKey is the Datadog API key (required).
+	APIKey string
+	// Site is the Datadog site, e.g. "datadoghq.eu" (optional, defaults to the US site).
+	Site string
+}
+
+// ToMap converts c into the map[string]string expected by the Config field of
+// CreateIntegrationInput and UpdateIntegrationInput.
+func (c DatadogConfig) ToMap() map[string]string {
+	m := map[string]string{"apikey": c.APIKey}
+	if c.Site != "" {
+		m["site"] = c.Site
+	}
+	return m
+}
+
+// JiraIssueConfig holds the configuration fields for an integration of type
+// IntegrationTypeJiraIssue.
+type JiraIssueConfig struct {
+	// BaseURL is the base URL of the Jira instance (required).
+	BaseURL string
+	// Username is the Jira username (email address) used to authenticate (required).
+	Username string
+	// Token is the Jira API token (required).
+	Token string
+	// ProjectKey is the key of the Jira project where issues will be created (required).
+	ProjectKey string
+	// IssueType is the type of Jira issue to create (required).
+	IssueType string
+}
+
+// ToMap converts c into the map[string]string expected by the Config field of
+// CreateIntegrationInput and UpdateIntegrationInput.
+func (c JiraIssueConfig) ToMap() map[string]string {
+	return map[string]string{
+		"baseurl":    c.BaseURL,
+		"username":   c.Username,
+		"token":      c.Token,
+		"projectkey": c.ProjectKey,
+		"issuetype":  c.IssueType,
+	}
+}
+
+// JSMConfig holds the configuration fields for an integration of type
+// IntegrationTypeJSM.
+type JSMConfig struct {
+	// APIKey is the Jira Service Management API key (required).
+	APIKey string
+}
+
+// ToMap converts c into the map[string]string expected by the Config field of
+// CreateIntegrationInput and UpdateIntegrationInput.
+func (c JSMConfig) ToMap() map[string]string {
+	return map[string]string{"apikey": c.APIKey}
+}
+
+// OpsGenieConfig holds the configuration fields for an integration of type
+// IntegrationTypeOpsGenie.
+type OpsGenieConfig struct {
+	// APIKey is the OpsGenie API key (required).
+	APIKey string
+}
+
+// ToMap converts c into the map[string]string expected by the Config field of
+// CreateIntegrationInput and UpdateIntegrationInput.
+func (c OpsGenieConfig) ToMap() map[string]string {
+	return map[string]string{"apikey": c.APIKey}
+}
+
+// SplunkOnCallConfig holds the configuration fields for an integration of type
+// IntegrationTypeSplunkOnCall.
+type SplunkOnCallConfig struct {
+	// URL is the Splunk On-Call webhook URL (required).
+	URL string
+}
+
+// ToMap converts c into the map[string]string expected by the Config field of
+// CreateIntegrationInput and UpdateIntegrationInput.
+func (c SplunkOnCallConfig) ToMap() map[string]string {
+	return map[string]string{"url": c.URL}
 }

--- a/fastly/notifications_test.go
+++ b/fastly/notifications_test.go
@@ -225,8 +225,8 @@ func TestClient_Notifications(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if newCir.ID == nil {
-			t.Errorf("missing id for %s integration", nti.fixture)
+		if newCir == nil || newCir.ID == nil {
+			t.Fatalf("missing response or integration id for %s integration", nti.fixture)
 		}
 
 		// Get integration

--- a/fastly/notifications_test.go
+++ b/fastly/notifications_test.go
@@ -3,6 +3,7 @@ package fastly
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 )
 
@@ -120,7 +121,7 @@ func TestClient_Notifications(t *testing.T) {
 	Record(t, "notifications/update_integration", func(c *Client) {
 		err = c.UpdateIntegration(context.TODO(), &UpdateIntegrationInput{
 			Config: map[string]string{
-				"url": "https://foo.com/bar",
+				"webhook": "https://foo.com/bar",
 			},
 			Description: ToPointer("test description updated"),
 			ID:          *gi.ID,
@@ -169,6 +170,92 @@ func TestClient_Notifications(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Create, get, and delete an integration for each of the newer
+	// integration types, using their typed config helpers.
+	newTypeIntegrations := []struct {
+		fixture string
+		typ     string
+		config  map[string]string
+	}{
+		{
+			fixture: "datadog",
+			typ:     IntegrationTypeDatadog,
+			config:  DatadogConfig{APIKey: "abc123def456", Site: "datadoghq.eu"}.ToMap(),
+		},
+		{
+			fixture: "jiraissue",
+			typ:     IntegrationTypeJiraIssue,
+			config: JiraIssueConfig{ //nolint: gosec
+				BaseURL:    "https://your-org.atlassian.net",
+				Username:   "user@example.com",
+				Token:      "AbCdEfGhIjKlMnOpQrStUvWx",
+				ProjectKey: "PROJ",
+				IssueType:  "Bug",
+			}.ToMap(),
+		},
+		{
+			fixture: "jsm",
+			typ:     IntegrationTypeJSM,
+			config:  JSMConfig{APIKey: "g4ff854d-a14c-46a8-b8f0-0960774319dd"}.ToMap(), //nolint: gosec
+		},
+		{
+			fixture: "opsgenie",
+			typ:     IntegrationTypeOpsGenie,
+			config:  OpsGenieConfig{APIKey: "a1bb854d-b24c-46a8-c9f0-1960774319ee"}.ToMap(), //nolint: gosec
+		},
+		{
+			fixture: "splunkoncall",
+			typ:     IntegrationTypeSplunkOnCall,
+			config:  SplunkOnCallConfig{URL: "https://alert.victorops.com/integrations/generic/20131114/alert/XXXX"}.ToMap(),
+		},
+	}
+
+	for _, nti := range newTypeIntegrations {
+		// Create integration
+		var newCir *CreateIntegrationResponse
+		Record(t, "notifications/create_"+nti.fixture+"_integration", func(c *Client) {
+			newCir, err = c.CreateIntegration(context.TODO(), &CreateIntegrationInput{
+				Config:      nti.config,
+				Description: ToPointer("test " + nti.fixture + " description"),
+				Name:        ToPointer("test " + nti.fixture + " name"),
+				Type:        ToPointer(nti.typ),
+			})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if newCir.ID == nil {
+			t.Errorf("missing id for %s integration", nti.fixture)
+		}
+
+		// Get integration
+		var newGi *Integration
+		Record(t, "notifications/get_"+nti.fixture+"_integration", func(c *Client) {
+			newGi, err = c.GetIntegration(context.TODO(), &GetIntegrationInput{
+				ID: *newCir.ID,
+			})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if *newGi.Type != nti.typ {
+			t.Errorf("bad type for %s integration: %q", nti.fixture, *newGi.Type)
+		}
+		if *newGi.ID != *newCir.ID {
+			t.Errorf("bad id for %s integration: %q (%q)", nti.fixture, *newGi.ID, *newCir.ID)
+		}
+
+		// Delete integration
+		Record(t, "notifications/delete_"+nti.fixture+"_integration", func(c *Client) {
+			err = c.DeleteIntegration(context.TODO(), &DeleteIntegrationInput{
+				ID: *newCir.ID,
+			})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 }
 
 func TestClient_GetIntegration_validation(t *testing.T) {
@@ -189,6 +276,65 @@ func TestClient_DeleteIntegration_validation(t *testing.T) {
 	err := TestClient.DeleteIntegration(context.TODO(), &DeleteIntegrationInput{})
 	if !errors.Is(err, ErrMissingID) {
 		t.Errorf("bad error: %s", err)
+	}
+}
+
+func TestDatadogConfig_ToMap(t *testing.T) {
+	got := DatadogConfig{APIKey: "abc123", Site: "datadoghq.eu"}.ToMap()
+	want := map[string]string{"apikey": "abc123", "site": "datadoghq.eu"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bad map: got %v, want %v", got, want)
+	}
+
+	// Site is optional and should be omitted when empty.
+	got = DatadogConfig{APIKey: "abc123"}.ToMap()
+	want = map[string]string{"apikey": "abc123"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bad map: got %v, want %v", got, want)
+	}
+}
+
+func TestJiraIssueConfig_ToMap(t *testing.T) {
+	got := JiraIssueConfig{ //nolint: gosec
+		BaseURL:    "https://your-org.atlassian.net",
+		Username:   "user@example.com",
+		Token:      "AbCdEfGhIjKlMnOpQrStUvWx",
+		ProjectKey: "PROJ",
+		IssueType:  "Bug",
+	}.ToMap()
+	want := map[string]string{ //nolint: gosec
+		"baseurl":    "https://your-org.atlassian.net",
+		"username":   "user@example.com",
+		"token":      "AbCdEfGhIjKlMnOpQrStUvWx",
+		"projectkey": "PROJ",
+		"issuetype":  "Bug",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bad map: got %v, want %v", got, want)
+	}
+}
+
+func TestJSMConfig_ToMap(t *testing.T) {
+	got := JSMConfig{APIKey: "g4ff854d-a14c-46a8-b8f0-0960774319dd"}.ToMap()    //nolint: gosec
+	want := map[string]string{"apikey": "g4ff854d-a14c-46a8-b8f0-0960774319dd"} //nolint: gosec
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bad map: got %v, want %v", got, want)
+	}
+}
+
+func TestOpsGenieConfig_ToMap(t *testing.T) {
+	got := OpsGenieConfig{APIKey: "a1bb854d-b24c-46a8-c9f0-1960774319ee"}.ToMap() //nolint: gosec
+	want := map[string]string{"apikey": "a1bb854d-b24c-46a8-c9f0-1960774319ee"}   //nolint: gosec
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bad map: got %v, want %v", got, want)
+	}
+}
+
+func TestSplunkOnCallConfig_ToMap(t *testing.T) {
+	got := SplunkOnCallConfig{URL: "https://alert.victorops.com/integrations/generic/20131114/alert/XXXX"}.ToMap()
+	want := map[string]string{"url": "https://alert.victorops.com/integrations/generic/20131114/alert/XXXX"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bad map: got %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
### Change summary

Add IntegrationType* constants and per-vendor *Config helper structs (with ToMap()) for the Datadog, Jira Issue, Jira Service Management, OpsGenie, and Splunk On-Call integration types now supported by the Notification Service API.

[API Docs](https://www.fastly.com/documentation/reference/api/observability/notifications/)

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?
