### PR TITLE
add cooldown timer to resolve semgrep flag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     allow:
       # Allow both direct and indirect updates for all packages.
       - dependency-type: "all"
@@ -19,6 +21,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - github_actions


### PR DESCRIPTION
### Change summary

<img width="812" height="568" alt="Screenshot 2026-07-30 at 11 25 59 AM" src="https://github.com/user-attachments/assets/3dfd5bf9-2ad4-4e9d-b463-0fd1279f0330" />

Semgrep complained about this, so adding a cooldown time to resolve

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?
