### PR TITLE
Upgrade Golang to 1.26.5

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -35,12 +35,12 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.10.1
+          version: v2.12.2
 
   golangci-latest:
     name: lint-latest (informational)
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: Run golangci-lint@latest
         id: lint
@@ -77,7 +77,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -75,6 +75,7 @@ jobs:
           fi
 
   test:
+    name: Test (${{ matrix.platform }})
     strategy:
       matrix:
         go-version: [1.26.x]

--- a/fastly/backend_test.go
+++ b/fastly/backend_test.go
@@ -118,10 +118,10 @@ func TestClient_Backends_Compute(t *testing.T) {
 		t.Errorf("bad address: %q (%q)", *b.Address, *nb.Address)
 	}
 	if *b.Port != *nb.Port {
-		t.Errorf("bad port: %q (%q)", *b.Port, *nb.Port)
+		t.Errorf("bad port: %d (%d)", *b.Port, *nb.Port)
 	}
 	if *b.ConnectTimeout != *nb.ConnectTimeout {
-		t.Errorf("bad connect_timeout: %q (%q)", *b.ConnectTimeout, *nb.ConnectTimeout)
+		t.Errorf("bad connect_timeout: %d (%d)", *b.ConnectTimeout, *nb.ConnectTimeout)
 	}
 	if *b.OverrideHost != *nb.OverrideHost {
 		t.Errorf("bad override_host: %q (%q)", *b.OverrideHost, *nb.OverrideHost)
@@ -344,10 +344,10 @@ func TestClient_Backends(t *testing.T) {
 		t.Errorf("bad address: %q (%q)", *b.Address, *nb.Address)
 	}
 	if *b.Port != *nb.Port {
-		t.Errorf("bad port: %q (%q)", *b.Port, *nb.Port)
+		t.Errorf("bad port: %d (%d)", *b.Port, *nb.Port)
 	}
 	if *b.ConnectTimeout != *nb.ConnectTimeout {
-		t.Errorf("bad connect_timeout: %q (%q)", *b.ConnectTimeout, *nb.ConnectTimeout)
+		t.Errorf("bad connect_timeout: %d (%d)", *b.ConnectTimeout, *nb.ConnectTimeout)
 	}
 	if *b.OverrideHost != *nb.OverrideHost {
 		t.Errorf("bad override_host: %q (%q)", *b.OverrideHost, *nb.OverrideHost)

--- a/fastly/health_check_test.go
+++ b/fastly/health_check_test.go
@@ -76,22 +76,22 @@ func TestClient_HealthChecks(t *testing.T) {
 		t.Errorf("bad http_version: %q", *hc.HTTPVersion)
 	}
 	if *hc.Timeout != 1500 {
-		t.Errorf("bad timeout: %q", *hc.Timeout)
+		t.Errorf("bad timeout: %d", *hc.Timeout)
 	}
 	if *hc.CheckInterval != 2500 {
-		t.Errorf("bad check_interval: %q", *hc.CheckInterval)
+		t.Errorf("bad check_interval: %d", *hc.CheckInterval)
 	}
 	if *hc.ExpectedResponse != http.StatusOK {
-		t.Errorf("bad timeout: %q", *hc.ExpectedResponse)
+		t.Errorf("bad timeout: %d", *hc.ExpectedResponse)
 	}
 	if *hc.Window != 5000 {
-		t.Errorf("bad window: %q", *hc.Window)
+		t.Errorf("bad window: %d", *hc.Window)
 	}
 	if *hc.Threshold != 10 {
-		t.Errorf("bad threshold: %q", *hc.Threshold)
+		t.Errorf("bad threshold: %d", *hc.Threshold)
 	}
 	if *hc.Initial != 10 {
-		t.Errorf("bad initial: %q", *hc.Initial)
+		t.Errorf("bad initial: %d", *hc.Initial)
 	}
 	if len(hc.Headers) != 2 {
 		t.Errorf("bad headers: %q", hc.Headers)
@@ -140,22 +140,22 @@ func TestClient_HealthChecks(t *testing.T) {
 		t.Errorf("bad http_version: %q", *hc.HTTPVersion)
 	}
 	if *hc.Timeout != *nhc.Timeout {
-		t.Errorf("bad timeout: %q", *hc.Timeout)
+		t.Errorf("bad timeout: %d", *hc.Timeout)
 	}
 	if *hc.CheckInterval != *nhc.CheckInterval {
-		t.Errorf("bad check_interval: %q", *hc.CheckInterval)
+		t.Errorf("bad check_interval: %d", *hc.CheckInterval)
 	}
 	if *hc.ExpectedResponse != *nhc.ExpectedResponse {
-		t.Errorf("bad timeout: %q", *hc.ExpectedResponse)
+		t.Errorf("bad timeout: %d", *hc.ExpectedResponse)
 	}
 	if *hc.Window != *nhc.Window {
-		t.Errorf("bad window: %q", *hc.Window)
+		t.Errorf("bad window: %d", *hc.Window)
 	}
 	if *hc.Threshold != *nhc.Threshold {
-		t.Errorf("bad threshold: %q", *hc.Threshold)
+		t.Errorf("bad threshold: %d", *hc.Threshold)
 	}
 	if *hc.Initial != *nhc.Initial {
-		t.Errorf("bad initial: %q", *hc.Initial)
+		t.Errorf("bad initial: %d", *hc.Initial)
 	}
 	if len(nhc.Headers) != 2 {
 		t.Errorf("bad headers: %q", nhc.Headers)
@@ -266,22 +266,22 @@ func TestClient_HealthChecks_Compute(t *testing.T) {
 		t.Errorf("bad http_version: %q", *hc.HTTPVersion)
 	}
 	if *hc.Timeout != 1500 {
-		t.Errorf("bad timeout: %q", *hc.Timeout)
+		t.Errorf("bad timeout: %d", *hc.Timeout)
 	}
 	if *hc.CheckInterval != 2500 {
-		t.Errorf("bad check_interval: %q", *hc.CheckInterval)
+		t.Errorf("bad check_interval: %d", *hc.CheckInterval)
 	}
 	if *hc.ExpectedResponse != http.StatusOK {
-		t.Errorf("bad timeout: %q", *hc.ExpectedResponse)
+		t.Errorf("bad timeout: %d", *hc.ExpectedResponse)
 	}
 	if *hc.Window != 5000 {
-		t.Errorf("bad window: %q", *hc.Window)
+		t.Errorf("bad window: %d", *hc.Window)
 	}
 	if *hc.Threshold != 10 {
-		t.Errorf("bad threshold: %q", *hc.Threshold)
+		t.Errorf("bad threshold: %d", *hc.Threshold)
 	}
 	if *hc.Initial != 10 {
-		t.Errorf("bad initial: %q", *hc.Initial)
+		t.Errorf("bad initial: %d", *hc.Initial)
 	}
 	if len(hc.Headers) != 2 {
 		t.Errorf("bad headers: %q", hc.Headers)
@@ -330,22 +330,22 @@ func TestClient_HealthChecks_Compute(t *testing.T) {
 		t.Errorf("bad http_version: %q", *hc.HTTPVersion)
 	}
 	if *hc.Timeout != *nhc.Timeout {
-		t.Errorf("bad timeout: %q", *hc.Timeout)
+		t.Errorf("bad timeout: %d", *hc.Timeout)
 	}
 	if *hc.CheckInterval != *nhc.CheckInterval {
-		t.Errorf("bad check_interval: %q", *hc.CheckInterval)
+		t.Errorf("bad check_interval: %d", *hc.CheckInterval)
 	}
 	if *hc.ExpectedResponse != *nhc.ExpectedResponse {
-		t.Errorf("bad timeout: %q", *hc.ExpectedResponse)
+		t.Errorf("bad timeout: %d", *hc.ExpectedResponse)
 	}
 	if *hc.Window != *nhc.Window {
-		t.Errorf("bad window: %q", *hc.Window)
+		t.Errorf("bad window: %d", *hc.Window)
 	}
 	if *hc.Threshold != *nhc.Threshold {
-		t.Errorf("bad threshold: %q", *hc.Threshold)
+		t.Errorf("bad threshold: %d", *hc.Threshold)
 	}
 	if *hc.Initial != *nhc.Initial {
-		t.Errorf("bad initial: %q", *hc.Initial)
+		t.Errorf("bad initial: %d", *hc.Initial)
 	}
 	if len(nhc.Headers) != 2 {
 		t.Errorf("bad headers: %q", nhc.Headers)

--- a/fastly/load_balance_pool_test.go
+++ b/fastly/load_balance_pool_test.go
@@ -54,7 +54,7 @@ func TestClient_Pools(t *testing.T) {
 		t.Errorf("bad name: %q", *p.Name)
 	}
 	if *p.Quorum != 50 {
-		t.Errorf("bad quorum: %q", *p.Quorum)
+		t.Errorf("bad quorum: %d", *p.Quorum)
 	}
 	if !*p.UseTLS {
 		t.Errorf("bad use_tls: %t", *p.UseTLS)
@@ -97,7 +97,7 @@ func TestClient_Pools(t *testing.T) {
 		t.Errorf("bad name: %q (%q)", *p.Name, *np.Name)
 	}
 	if *p.Quorum != *np.Quorum {
-		t.Errorf("bad quorum: %q (%q)", *p.Quorum, *np.Quorum)
+		t.Errorf("bad quorum: %d (%d)", *p.Quorum, *np.Quorum)
 	}
 	if *p.Type != *np.Type {
 		t.Errorf("bad type: %q (%q)", *p.Type, *np.Type)
@@ -122,7 +122,7 @@ func TestClient_Pools(t *testing.T) {
 		t.Errorf("bad name: %q", *up.Name)
 	}
 	if *up.Quorum != 0 {
-		t.Errorf("bad quorum: %q", *up.Quorum)
+		t.Errorf("bad quorum: %d", *up.Quorum)
 	}
 
 	// Delete

--- a/fastly/load_balancer_director_test.go
+++ b/fastly/load_balancer_director_test.go
@@ -92,7 +92,7 @@ func TestClient_Directors(t *testing.T) {
 		t.Errorf("bad name: %q", *d.Name)
 	}
 	if *d.Quorum != 50 {
-		t.Errorf("bad quorum: %q", *d.Quorum)
+		t.Errorf("bad quorum: %d", *d.Quorum)
 	}
 	if *d.Type != DirectorTypeRandom {
 		t.Errorf("bad type: %d", *d.Type)
@@ -135,13 +135,13 @@ func TestClient_Directors(t *testing.T) {
 		t.Errorf("bad name: %q (%q)", *d.Name, *nb.Name)
 	}
 	if *d.Quorum != *nb.Quorum {
-		t.Errorf("bad quorum: %q (%q)", *d.Quorum, *nb.Quorum)
+		t.Errorf("bad quorum: %d (%d)", *d.Quorum, *nb.Quorum)
 	}
 	if *d.Type != *nb.Type {
-		t.Errorf("bad type: %q (%q)", *d.Type, *nb.Type)
+		t.Errorf("bad type: %d (%d)", *d.Type, *nb.Type)
 	}
 	if *d.Retries != *nb.Retries {
-		t.Errorf("bad retries: %q (%q)", *d.Retries, *nb.Retries)
+		t.Errorf("bad retries: %d (%d)", *d.Retries, *nb.Retries)
 	}
 	if len(nb.Backends) == 0 || nb.Backends[0] != *b.Name {
 		t.Error("bad backend: expected a backend")
@@ -162,7 +162,7 @@ func TestClient_Directors(t *testing.T) {
 		t.Fatal(err)
 	}
 	if *ub.Quorum != 100 {
-		t.Errorf("bad quorum: %q", *ub.Quorum)
+		t.Errorf("bad quorum: %d", *ub.Quorum)
 	}
 
 	// Delete

--- a/fastly/load_balancer_server_test.go
+++ b/fastly/load_balancer_server_test.go
@@ -122,7 +122,7 @@ func TestClient_Servers(t *testing.T) {
 		t.Errorf("bad address: %s", *us.Address)
 	}
 	if *us.Weight != 50 {
-		t.Errorf("bad weight: %q", 50)
+		t.Errorf("bad weight: %d", 50)
 	}
 
 	// Delete

--- a/fastly/logging_bigquery_test.go
+++ b/fastly/logging_bigquery_test.go
@@ -92,7 +92,7 @@ func TestClient_Bigqueries_Compute(t *testing.T) {
 		t.Errorf("bad placement: %q", *bq.Placement)
 	}
 	if *bq.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *bq.FormatVersion)
+		t.Errorf("bad format_version: %d", *bq.FormatVersion)
 	}
 
 	// List
@@ -153,7 +153,7 @@ func TestClient_Bigqueries_Compute(t *testing.T) {
 		t.Errorf("bad placement: %q", *bq.Placement)
 	}
 	if *bq.FormatVersion != *nbq.FormatVersion {
-		t.Errorf("bad format_version: %q", *bq.FormatVersion)
+		t.Errorf("bad format_version: %d", *bq.FormatVersion)
 	}
 
 	// Update
@@ -279,7 +279,7 @@ func TestClient_Bigqueries(t *testing.T) {
 		t.Errorf("bad placement: %q", *bq.Placement)
 	}
 	if *bq.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *bq.FormatVersion)
+		t.Errorf("bad format_version: %d", *bq.FormatVersion)
 	}
 
 	// List
@@ -340,7 +340,7 @@ func TestClient_Bigqueries(t *testing.T) {
 		t.Errorf("bad placement: %q", *bq.Placement)
 	}
 	if *bq.FormatVersion != *nbq.FormatVersion {
-		t.Errorf("bad format_version: %q", *bq.FormatVersion)
+		t.Errorf("bad format_version: %d", *bq.FormatVersion)
 	}
 
 	// Update

--- a/fastly/logging_blobstorage_test.go
+++ b/fastly/logging_blobstorage_test.go
@@ -165,7 +165,7 @@ func TestClient_BlobStorages_Compute(t *testing.T) {
 		t.Errorf("bad sas_token: %q", *bsCreateResp1.SASToken)
 	}
 	if *bsCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *bsCreateResp1.Period)
+		t.Errorf("bad period: %d", *bsCreateResp1.Period)
 	}
 	if *bsCreateResp1.TimestampFormat != "%Y-%m-%dT%H:%M:%S.000" {
 		t.Errorf("bad timestamp_format: %q", *bsCreateResp1.TimestampFormat)
@@ -174,7 +174,7 @@ func TestClient_BlobStorages_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *bsCreateResp1.CompressionCodec)
 	}
 	if *bsCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *bsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsCreateResp1.GzipLevel)
 	}
 	if *bsCreateResp1.PublicKey != "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/\nibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4\n8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p\nlDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn\ndwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB\n89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz\ndCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6\nvFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc\n9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9\nOLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX\nSvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq\n7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx\nkATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG\nM1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe\nu6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L\n4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF\nftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K\nUEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu\nYrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi\nkiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb\nDAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml\ndYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L\n3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c\nFaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR\n5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR\nwMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N\n=28dr\n-----END PGP PUBLIC KEY BLOCK-----\n" {
 		t.Errorf("bad public_key: %q", *bsCreateResp1.PublicKey)
@@ -183,7 +183,7 @@ func TestClient_BlobStorages_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *bsCreateResp1.Format)
 	}
 	if *bsCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *bsCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *bsCreateResp1.FormatVersion)
 	}
 	if *bsCreateResp1.MessageType != "classic" {
 		t.Errorf("bad message_type: %q", *bsCreateResp1.MessageType)
@@ -192,25 +192,25 @@ func TestClient_BlobStorages_Compute(t *testing.T) {
 		t.Errorf("bad placement: %q", *bsCreateResp1.Placement)
 	}
 	if *bsCreateResp1.FileMaxBytes != MiB {
-		t.Errorf("bad file_max_bytes: %q", *bsCreateResp1.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *bsCreateResp1.FileMaxBytes)
 	}
 	if bsCreateResp2.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *bsCreateResp2.CompressionCodec)
 	}
 	if *bsCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *bsCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsCreateResp2.GzipLevel)
 	}
 	if *bsCreateResp2.FileMaxBytes != 10*MiB {
-		t.Errorf("bad file_max_bytes: %q", *bsCreateResp2.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *bsCreateResp2.FileMaxBytes)
 	}
 	if *bsCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *bsCreateResp3.CompressionCodec)
 	}
 	if *bsCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *bsCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsCreateResp3.GzipLevel)
 	}
 	if *bsCreateResp3.FileMaxBytes != 0 {
-		t.Errorf("bad file_max_bytes: %q", *bsCreateResp3.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *bsCreateResp3.FileMaxBytes)
 	}
 
 	// List
@@ -256,7 +256,7 @@ func TestClient_BlobStorages_Compute(t *testing.T) {
 		t.Errorf("bad sas_token: %q", *bsCreateResp1.SASToken)
 	}
 	if *bsCreateResp1.Period != *bsGetResp.Period {
-		t.Errorf("bad period: %q", *bsCreateResp1.Period)
+		t.Errorf("bad period: %d", *bsCreateResp1.Period)
 	}
 	if *bsCreateResp1.TimestampFormat != *bsGetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *bsCreateResp1.TimestampFormat)
@@ -265,7 +265,7 @@ func TestClient_BlobStorages_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *bsCreateResp1.CompressionCodec)
 	}
 	if *bsCreateResp1.GzipLevel != *bsGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *bsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsCreateResp1.GzipLevel)
 	}
 	if *bsCreateResp1.PublicKey != *bsGetResp.PublicKey {
 		t.Errorf("bad public_key: %q", *bsCreateResp1.PublicKey)
@@ -274,7 +274,7 @@ func TestClient_BlobStorages_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *bsCreateResp1.Format)
 	}
 	if *bsCreateResp1.FormatVersion != *bsGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *bsCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *bsCreateResp1.FormatVersion)
 	}
 	if *bsCreateResp1.MessageType != *bsGetResp.MessageType {
 		t.Errorf("bad message_type: %q", *bsCreateResp1.MessageType)
@@ -347,7 +347,7 @@ func TestClient_BlobStorages_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *bsUpdateResp1.CompressionCodec)
 	}
 	if *bsUpdateResp1.FileMaxBytes != 5*MiB {
-		t.Errorf("bad file_max_bytes: %q", *bsUpdateResp1.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *bsUpdateResp1.FileMaxBytes)
 	}
 	if *bsUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *bsUpdateResp1.ProcessingRegion)
@@ -356,13 +356,13 @@ func TestClient_BlobStorages_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *bsUpdateResp2.CompressionCodec)
 	}
 	if *bsUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *bsUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsUpdateResp2.GzipLevel)
 	}
 	if bsUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *bsUpdateResp3.CompressionCodec)
 	}
 	if *bsUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *bsUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsUpdateResp3.GzipLevel)
 	}
 
 	// Delete
@@ -532,7 +532,7 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Errorf("bad sas_token: %q", *bsCreateResp1.SASToken)
 	}
 	if *bsCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *bsCreateResp1.Period)
+		t.Errorf("bad period: %d", *bsCreateResp1.Period)
 	}
 	if *bsCreateResp1.TimestampFormat != "%Y-%m-%dT%H:%M:%S.000" {
 		t.Errorf("bad timestamp_format: %q", *bsCreateResp1.TimestampFormat)
@@ -541,7 +541,7 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *bsCreateResp1.CompressionCodec)
 	}
 	if *bsCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *bsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsCreateResp1.GzipLevel)
 	}
 	if *bsCreateResp1.PublicKey != "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBFyUD8sBCACyFnB39AuuTygseek+eA4fo0cgwva6/FSjnWq7riouQee8GgQ/\nibXTRyv4iVlwI12GswvMTIy7zNvs1R54i0qvsLr+IZ4GVGJqs6ZJnvQcqe3xPoR4\n8AnBfw90o32r/LuHf6QCJXi+AEu35koNlNAvLJ2B+KACaNB7N0EeWmqpV/1V2k9p\nlDYk+th7LcCuaFNGqKS/PrMnnMqR6VDLCjHhNx4KR79b0Twm/2qp6an3hyNRu8Gn\ndwxpf1/BUu3JWf+LqkN4Y3mbOmSUL3MaJNvyQguUzTfS0P0uGuBDHrJCVkMZCzDB\n89ag55jCPHyGeHBTd02gHMWzsg3WMBWvCsrzABEBAAG0JXRlcnJhZm9ybSAodGVz\ndCkgPHRlc3RAdGVycmFmb3JtLmNvbT6JAU4EEwEIADgWIQSHYyc6Kj9l6HzQsau6\nvFFc9jxV/wUCXJQPywIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRC6vFFc\n9jxV/815CAClb32OxV7wG01yF97TzlyTl8TnvjMtoG29Mw4nSyg+mjM3b8N7iXm9\nOLX59fbDAWtBSldSZE22RXd3CvlFOG/EnKBXSjBtEqfyxYSnyOPkMPBYWGL/ApkX\nSvPYJ4LKdvipYToKFh3y9kk2gk1DcDBDyaaHvR+3rv1u3aoy7/s2EltAfDS3ZQIq\n7/cWTLJml/lleeB/Y6rPj8xqeCYhE5ahw9gsV/Mdqatl24V9Tks30iijx0Hhw+Gx\nkATUikMGr2GDVqoIRga5kXI7CzYff4rkc0Twn47fMHHHe/KY9M2yVnMHUXmAZwbG\nM1cMI/NH1DjevCKdGBLcRJlhuLPKF/anuQENBFyUD8sBCADIpd7r7GuPd6n/Ikxe\nu6h7umV6IIPoAm88xCYpTbSZiaK30Svh6Ywra9jfE2KlU9o6Y/art8ip0VJ3m07L\n4RSfSpnzqgSwdjSq5hNour2Fo/BzYhK7yaz2AzVSbe33R0+RYhb4b/6N+bKbjwGF\nftCsqVFMH+PyvYkLbvxyQrHlA9woAZaNThI1ztO5rGSnGUR8xt84eup28WIFKg0K\nUEGUcTzz+8QGAwAra+0ewPXo/AkO+8BvZjDidP417u6gpBHOJ9qYIcO9FxHeqFyu\nYrjlrxowEgXn5wO8xuNz6Vu1vhHGDHGDsRbZF8pv1d5O+0F1G7ttZ2GRRgVBZPwi\nkiyRABEBAAGJATYEGAEIACAWIQSHYyc6Kj9l6HzQsau6vFFc9jxV/wUCXJQPywIb\nDAAKCRC6vFFc9jxV/9YOCACe8qmOSnKQpQfW+PqYOqo3dt7JyweTs3FkD6NT8Zml\ndYy/vkstbTjPpX6aTvUZjkb46BVi7AOneVHpD5GBqvRsZ9iVgDYHaehmLCdKiG5L\n3Tp90NN+QY5WDbsGmsyk6+6ZMYejb4qYfweQeduOj27aavCJdLkCYMoRKfcFYI8c\nFaNmEfKKy/r1PO20NXEG6t9t05K/frHy6ZG8bCNYdpagfFVot47r9JaQqWlTNtIR\n5+zkkSq/eG9BEtRij3a6cTdQbktdBzx2KBeI0PYc1vlZR0LpuFKZqY9vlE6vTGLR\nwMfrTEOvx0NxUM3rpaCgEmuWbB1G1Hu371oyr4srrr+N\n=28dr\n-----END PGP PUBLIC KEY BLOCK-----\n" {
 		t.Errorf("bad public_key: %q", *bsCreateResp1.PublicKey)
@@ -550,7 +550,7 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Errorf("bad format: %q", *bsCreateResp1.Format)
 	}
 	if *bsCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *bsCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *bsCreateResp1.FormatVersion)
 	}
 	if *bsCreateResp1.MessageType != "classic" {
 		t.Errorf("bad message_type: %q", *bsCreateResp1.MessageType)
@@ -559,25 +559,25 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Errorf("bad placement: %q", *bsCreateResp1.Placement)
 	}
 	if *bsCreateResp1.FileMaxBytes != MiB {
-		t.Errorf("bad file_max_bytes: %q", *bsCreateResp1.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *bsCreateResp1.FileMaxBytes)
 	}
 	if bsCreateResp2.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *bsCreateResp2.CompressionCodec)
 	}
 	if *bsCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *bsCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsCreateResp2.GzipLevel)
 	}
 	if *bsCreateResp2.FileMaxBytes != 10*MiB {
-		t.Errorf("bad file_max_bytes: %q", *bsCreateResp2.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *bsCreateResp2.FileMaxBytes)
 	}
 	if *bsCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *bsCreateResp3.CompressionCodec)
 	}
 	if *bsCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *bsCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsCreateResp3.GzipLevel)
 	}
 	if *bsCreateResp3.FileMaxBytes != 0 {
-		t.Errorf("bad file_max_bytes: %q", *bsCreateResp3.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *bsCreateResp3.FileMaxBytes)
 	}
 
 	// List
@@ -623,7 +623,7 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Errorf("bad sas_token: %q", *bsCreateResp1.SASToken)
 	}
 	if *bsCreateResp1.Period != *bsGetResp.Period {
-		t.Errorf("bad period: %q", *bsCreateResp1.Period)
+		t.Errorf("bad period: %d", *bsCreateResp1.Period)
 	}
 	if *bsCreateResp1.TimestampFormat != *bsGetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *bsCreateResp1.TimestampFormat)
@@ -632,7 +632,7 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *bsCreateResp1.CompressionCodec)
 	}
 	if *bsCreateResp1.GzipLevel != *bsGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *bsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsCreateResp1.GzipLevel)
 	}
 	if *bsCreateResp1.PublicKey != *bsGetResp.PublicKey {
 		t.Errorf("bad public_key: %q", *bsCreateResp1.PublicKey)
@@ -641,7 +641,7 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Errorf("bad format: %q", *bsCreateResp1.Format)
 	}
 	if *bsCreateResp1.FormatVersion != *bsGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *bsCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *bsCreateResp1.FormatVersion)
 	}
 	if *bsCreateResp1.MessageType != *bsGetResp.MessageType {
 		t.Errorf("bad message_type: %q", *bsCreateResp1.MessageType)
@@ -714,7 +714,7 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *bsUpdateResp1.CompressionCodec)
 	}
 	if *bsUpdateResp1.FileMaxBytes != 5*MiB {
-		t.Errorf("bad file_max_bytes: %q", *bsUpdateResp1.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *bsUpdateResp1.FileMaxBytes)
 	}
 	if *bsUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *bsUpdateResp1.ProcessingRegion)
@@ -723,13 +723,13 @@ func TestClient_BlobStorages(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *bsUpdateResp2.CompressionCodec)
 	}
 	if *bsUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *bsUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsUpdateResp2.GzipLevel)
 	}
 	if bsUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *bsUpdateResp3.CompressionCodec)
 	}
 	if *bsUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *bsUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *bsUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/logging_cloudfiles_test.go
+++ b/fastly/logging_cloudfiles_test.go
@@ -164,16 +164,16 @@ func TestClient_Cloudfiles_Compute(t *testing.T) {
 		t.Errorf("bad region: %q", *cloudfilesCreateResp1.Region)
 	}
 	if *cloudfilesCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *cloudfilesCreateResp1.Period)
+		t.Errorf("bad period: %d", *cloudfilesCreateResp1.Period)
 	}
 	if *cloudfilesCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesCreateResp1.GzipLevel)
 	}
 	if *cloudfilesCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *cloudfilesCreateResp1.Format)
 	}
 	if *cloudfilesCreateResp1.FormatVersion != 1 {
-		t.Errorf("bad format_version: %q", *cloudfilesCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *cloudfilesCreateResp1.FormatVersion)
 	}
 	if *cloudfilesCreateResp1.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", *cloudfilesCreateResp1.TimestampFormat)
@@ -191,13 +191,13 @@ func TestClient_Cloudfiles_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *cloudfilesCreateResp2.CompressionCodec)
 	}
 	if *cloudfilesCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesCreateResp2.GzipLevel)
 	}
 	if *cloudfilesCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *cloudfilesCreateResp3.CompressionCodec)
 	}
 	if *cloudfilesCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -246,16 +246,16 @@ func TestClient_Cloudfiles_Compute(t *testing.T) {
 		t.Errorf("bad region: %q", *cloudfilesCreateResp1.Region)
 	}
 	if *cloudfilesCreateResp1.Period != *cloudfilesGetResp.Period {
-		t.Errorf("bad period: %q", *cloudfilesCreateResp1.Period)
+		t.Errorf("bad period: %d", *cloudfilesCreateResp1.Period)
 	}
 	if *cloudfilesCreateResp1.GzipLevel != *cloudfilesGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *cloudfilesCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesCreateResp1.GzipLevel)
 	}
 	if *cloudfilesCreateResp1.Format != *cloudfilesGetResp.Format {
 		t.Errorf("bad format: %q", *cloudfilesCreateResp1.Format)
 	}
 	if *cloudfilesCreateResp1.FormatVersion != *cloudfilesGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *cloudfilesCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *cloudfilesCreateResp1.FormatVersion)
 	}
 	if *cloudfilesCreateResp1.TimestampFormat != *cloudfilesGetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *cloudfilesCreateResp1.TimestampFormat)
@@ -335,19 +335,19 @@ func TestClient_Cloudfiles_Compute(t *testing.T) {
 		t.Errorf("bad user: %q", *cloudfilesUpdateResp1.User)
 	}
 	if cloudfilesUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *cloudfilesUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesUpdateResp1.GzipLevel)
 	}
 	if *cloudfilesUpdateResp1.Period != 0 {
-		t.Errorf("bad period: %q", *cloudfilesUpdateResp1.Period)
+		t.Errorf("bad period: %d", *cloudfilesUpdateResp1.Period)
 	}
 	if *cloudfilesUpdateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *cloudfilesUpdateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *cloudfilesUpdateResp1.FormatVersion)
 	}
 	if *cloudfilesUpdateResp1.CompressionCodec != "zstd" {
 		t.Errorf("bad compression_codec: %q", *cloudfilesUpdateResp1.CompressionCodec)
 	}
 	if cloudfilesUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *cloudfilesUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesUpdateResp1.GzipLevel)
 	}
 	if *cloudfilesUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *cloudfilesUpdateResp1.ProcessingRegion)
@@ -356,13 +356,13 @@ func TestClient_Cloudfiles_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *cloudfilesUpdateResp2.CompressionCodec)
 	}
 	if *cloudfilesUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesUpdateResp2.GzipLevel)
 	}
 	if cloudfilesUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *cloudfilesUpdateResp3.CompressionCodec)
 	}
 	if *cloudfilesUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesUpdateResp3.GzipLevel)
 	}
 
 	// Delete
@@ -536,16 +536,16 @@ func TestClient_Cloudfiles(t *testing.T) {
 		t.Errorf("bad region: %q", *cloudfilesCreateResp1.Region)
 	}
 	if *cloudfilesCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *cloudfilesCreateResp1.Period)
+		t.Errorf("bad period: %d", *cloudfilesCreateResp1.Period)
 	}
 	if *cloudfilesCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesCreateResp1.GzipLevel)
 	}
 	if *cloudfilesCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *cloudfilesCreateResp1.Format)
 	}
 	if *cloudfilesCreateResp1.FormatVersion != 1 {
-		t.Errorf("bad format_version: %q", *cloudfilesCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *cloudfilesCreateResp1.FormatVersion)
 	}
 	if *cloudfilesCreateResp1.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", *cloudfilesCreateResp1.TimestampFormat)
@@ -563,13 +563,13 @@ func TestClient_Cloudfiles(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *cloudfilesCreateResp2.CompressionCodec)
 	}
 	if *cloudfilesCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesCreateResp2.GzipLevel)
 	}
 	if *cloudfilesCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *cloudfilesCreateResp3.CompressionCodec)
 	}
 	if *cloudfilesCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -618,16 +618,16 @@ func TestClient_Cloudfiles(t *testing.T) {
 		t.Errorf("bad region: %q", *cloudfilesCreateResp1.Region)
 	}
 	if *cloudfilesCreateResp1.Period != *cloudfilesGetResp.Period {
-		t.Errorf("bad period: %q", *cloudfilesCreateResp1.Period)
+		t.Errorf("bad period: %d", *cloudfilesCreateResp1.Period)
 	}
 	if *cloudfilesCreateResp1.GzipLevel != *cloudfilesGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *cloudfilesCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesCreateResp1.GzipLevel)
 	}
 	if *cloudfilesCreateResp1.Format != *cloudfilesGetResp.Format {
 		t.Errorf("bad format: %q", *cloudfilesCreateResp1.Format)
 	}
 	if *cloudfilesCreateResp1.FormatVersion != *cloudfilesGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *cloudfilesCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *cloudfilesCreateResp1.FormatVersion)
 	}
 	if *cloudfilesCreateResp1.TimestampFormat != *cloudfilesGetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *cloudfilesCreateResp1.TimestampFormat)
@@ -707,19 +707,19 @@ func TestClient_Cloudfiles(t *testing.T) {
 		t.Errorf("bad user: %q", *cloudfilesUpdateResp1.User)
 	}
 	if cloudfilesUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *cloudfilesUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesUpdateResp1.GzipLevel)
 	}
 	if *cloudfilesUpdateResp1.Period != 0 {
-		t.Errorf("bad period: %q", *cloudfilesUpdateResp1.Period)
+		t.Errorf("bad period: %d", *cloudfilesUpdateResp1.Period)
 	}
 	if *cloudfilesUpdateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *cloudfilesUpdateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *cloudfilesUpdateResp1.FormatVersion)
 	}
 	if *cloudfilesUpdateResp1.CompressionCodec != "zstd" {
 		t.Errorf("bad compression_codec: %q", *cloudfilesUpdateResp1.CompressionCodec)
 	}
 	if cloudfilesUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *cloudfilesUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesUpdateResp1.GzipLevel)
 	}
 	if *cloudfilesUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *cloudfilesUpdateResp1.ProcessingRegion)
@@ -728,13 +728,13 @@ func TestClient_Cloudfiles(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *cloudfilesUpdateResp2.CompressionCodec)
 	}
 	if *cloudfilesUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesUpdateResp2.GzipLevel)
 	}
 	if cloudfilesUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *cloudfilesUpdateResp3.CompressionCodec)
 	}
 	if *cloudfilesUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *cloudfilesUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *cloudfilesUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/logging_datadog_test.go
+++ b/fastly/logging_datadog_test.go
@@ -62,7 +62,7 @@ func TestClient_Datadog_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *d.Format)
 	}
 	if *d.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *d.FormatVersion)
+		t.Errorf("bad format_version: %d", *d.FormatVersion)
 	}
 	if *d.Placement != "none" {
 		t.Errorf("bad placement: %q", *d.Placement)
@@ -105,7 +105,7 @@ func TestClient_Datadog_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *d.Format)
 	}
 	if *d.FormatVersion != *nd.FormatVersion {
-		t.Errorf("bad format_version: %q", *d.FormatVersion)
+		t.Errorf("bad format_version: %d", *d.FormatVersion)
 	}
 	if *d.Placement != *nd.Placement {
 		t.Errorf("bad placement: %q", *d.Placement)
@@ -135,7 +135,7 @@ func TestClient_Datadog_Compute(t *testing.T) {
 		t.Errorf("bad name: %q", *ud.Name)
 	}
 	if *ud.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ud.FormatVersion)
+		t.Errorf("bad format_version: %d", *ud.FormatVersion)
 	}
 	if *ud.Region != "EU" {
 		t.Errorf("bad region: %q", *ud.Region)
@@ -213,7 +213,7 @@ func TestClient_Datadog(t *testing.T) {
 		t.Errorf("bad format: %q", *d.Format)
 	}
 	if *d.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *d.FormatVersion)
+		t.Errorf("bad format_version: %d", *d.FormatVersion)
 	}
 	if *d.Placement != "none" {
 		t.Errorf("bad placement: %q", *d.Placement)
@@ -256,7 +256,7 @@ func TestClient_Datadog(t *testing.T) {
 		t.Errorf("bad format: %q", *d.Format)
 	}
 	if *d.FormatVersion != *nd.FormatVersion {
-		t.Errorf("bad format_version: %q", *d.FormatVersion)
+		t.Errorf("bad format_version: %d", *d.FormatVersion)
 	}
 	if *d.Placement != *nd.Placement {
 		t.Errorf("bad placement: %q", *d.Placement)
@@ -286,7 +286,7 @@ func TestClient_Datadog(t *testing.T) {
 		t.Errorf("bad name: %q", *ud.Name)
 	}
 	if *ud.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ud.FormatVersion)
+		t.Errorf("bad format_version: %d", *ud.FormatVersion)
 	}
 	if *ud.Region != "EU" {
 		t.Errorf("bad region: %q", *ud.Region)

--- a/fastly/logging_digitalocean_test.go
+++ b/fastly/logging_digitalocean_test.go
@@ -164,16 +164,16 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Errorf("bad path: %q", *digitaloceanCreateResp1.Path)
 	}
 	if *digitaloceanCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *digitaloceanCreateResp1.Period)
+		t.Errorf("bad period: %d", *digitaloceanCreateResp1.Period)
 	}
 	if *digitaloceanCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanCreateResp1.GzipLevel)
 	}
 	if *digitaloceanCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *digitaloceanCreateResp1.Format)
 	}
 	if *digitaloceanCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *digitaloceanCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *digitaloceanCreateResp1.FormatVersion)
 	}
 	if *digitaloceanCreateResp1.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", *digitaloceanCreateResp1.TimestampFormat)
@@ -191,13 +191,13 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *digitaloceanCreateResp2.CompressionCodec)
 	}
 	if *digitaloceanCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanCreateResp2.GzipLevel)
 	}
 	if *digitaloceanCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *digitaloceanCreateResp3.CompressionCodec)
 	}
 	if *digitaloceanCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -246,16 +246,16 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Errorf("bad path: %q", *digitaloceanCreateResp1.Path)
 	}
 	if *digitaloceanCreateResp1.Period != *digitaloceanGetResp.Period {
-		t.Errorf("bad period: %q", *digitaloceanCreateResp1.Period)
+		t.Errorf("bad period: %d", *digitaloceanCreateResp1.Period)
 	}
 	if *digitaloceanCreateResp1.GzipLevel != *digitaloceanGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanCreateResp1.GzipLevel)
 	}
 	if *digitaloceanCreateResp1.Format != *digitaloceanGetResp.Format {
 		t.Errorf("bad format: %q", *digitaloceanCreateResp1.Format)
 	}
 	if *digitaloceanCreateResp1.FormatVersion != *digitaloceanGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *digitaloceanCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *digitaloceanCreateResp1.FormatVersion)
 	}
 	if *digitaloceanCreateResp1.TimestampFormat != *digitaloceanGetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *digitaloceanCreateResp1.TimestampFormat)
@@ -333,7 +333,7 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *digitaloceanUpdateResp1.CompressionCodec)
 	}
 	if digitaloceanUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *digitaloceanUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanUpdateResp1.GzipLevel)
 	}
 	if *digitaloceanUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *digitaloceanUpdateResp1.ProcessingRegion)
@@ -342,13 +342,13 @@ func TestClient_DigitalOceans(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *digitaloceanUpdateResp2.CompressionCodec)
 	}
 	if *digitaloceanUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanUpdateResp2.GzipLevel)
 	}
 	if digitaloceanUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *digitaloceanUpdateResp3.CompressionCodec)
 	}
 	if *digitaloceanUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanUpdateResp3.GzipLevel)
 	}
 
 	// Delete
@@ -522,16 +522,16 @@ func TestClient_DigitalOceans_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *digitaloceanCreateResp1.Path)
 	}
 	if *digitaloceanCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *digitaloceanCreateResp1.Period)
+		t.Errorf("bad period: %d", *digitaloceanCreateResp1.Period)
 	}
 	if *digitaloceanCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanCreateResp1.GzipLevel)
 	}
 	if *digitaloceanCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *digitaloceanCreateResp1.Format)
 	}
 	if *digitaloceanCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *digitaloceanCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *digitaloceanCreateResp1.FormatVersion)
 	}
 	if *digitaloceanCreateResp1.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", *digitaloceanCreateResp1.TimestampFormat)
@@ -549,13 +549,13 @@ func TestClient_DigitalOceans_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *digitaloceanCreateResp2.CompressionCodec)
 	}
 	if *digitaloceanCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanCreateResp2.GzipLevel)
 	}
 	if *digitaloceanCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *digitaloceanCreateResp3.CompressionCodec)
 	}
 	if *digitaloceanCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -604,16 +604,16 @@ func TestClient_DigitalOceans_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *digitaloceanCreateResp1.Path)
 	}
 	if *digitaloceanCreateResp1.Period != *digitaloceanGetResp.Period {
-		t.Errorf("bad period: %q", *digitaloceanCreateResp1.Period)
+		t.Errorf("bad period: %d", *digitaloceanCreateResp1.Period)
 	}
 	if *digitaloceanCreateResp1.GzipLevel != *digitaloceanGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *digitaloceanCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanCreateResp1.GzipLevel)
 	}
 	if *digitaloceanCreateResp1.Format != *digitaloceanGetResp.Format {
 		t.Errorf("bad format: %q", *digitaloceanCreateResp1.Format)
 	}
 	if *digitaloceanCreateResp1.FormatVersion != *digitaloceanGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *digitaloceanCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *digitaloceanCreateResp1.FormatVersion)
 	}
 	if *digitaloceanCreateResp1.TimestampFormat != *digitaloceanGetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *digitaloceanCreateResp1.TimestampFormat)
@@ -691,7 +691,7 @@ func TestClient_DigitalOceans_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *digitaloceanUpdateResp1.CompressionCodec)
 	}
 	if digitaloceanUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *digitaloceanUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanUpdateResp1.GzipLevel)
 	}
 	if *digitaloceanUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *digitaloceanUpdateResp1.ProcessingRegion)
@@ -700,13 +700,13 @@ func TestClient_DigitalOceans_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *digitaloceanUpdateResp2.CompressionCodec)
 	}
 	if *digitaloceanUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanUpdateResp2.GzipLevel)
 	}
 	if digitaloceanUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *digitaloceanUpdateResp3.CompressionCodec)
 	}
 	if *digitaloceanUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *digitaloceanUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *digitaloceanUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/logging_elasticsearch_test.go
+++ b/fastly/logging_elasticsearch_test.go
@@ -103,10 +103,10 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad password: %q", *es.Password)
 	}
 	if *es.RequestMaxEntries != 1 {
-		t.Errorf("bad request_max_entries: %q", *es.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *es.RequestMaxEntries)
 	}
 	if *es.RequestMaxBytes != 1000 {
-		t.Errorf("bad request_max_bytes: %q", *es.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *es.RequestMaxBytes)
 	}
 	if *es.Placement != "none" {
 		t.Errorf("bad placement: %q", *es.Placement)
@@ -176,10 +176,10 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad password: %q", *es.Password)
 	}
 	if *es.RequestMaxEntries != *nes.RequestMaxEntries {
-		t.Errorf("bad request_max_entries: %q", *es.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *es.RequestMaxEntries)
 	}
 	if *es.RequestMaxBytes != *nes.RequestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *es.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *es.RequestMaxBytes)
 	}
 	if *es.Placement != *nes.Placement {
 		t.Errorf("bad placement: %q", *es.Placement)
@@ -338,10 +338,10 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad password: %q", *es.Password)
 	}
 	if *es.RequestMaxEntries != 1 {
-		t.Errorf("bad request_max_entries: %q", *es.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *es.RequestMaxEntries)
 	}
 	if *es.RequestMaxBytes != 1000 {
-		t.Errorf("bad request_max_bytes: %q", *es.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *es.RequestMaxBytes)
 	}
 	if *es.Placement != "none" {
 		t.Errorf("bad placement: %q", *es.Placement)
@@ -411,10 +411,10 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad password: %q", *es.Password)
 	}
 	if *es.RequestMaxEntries != *nes.RequestMaxEntries {
-		t.Errorf("bad request_max_entries: %q", *es.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *es.RequestMaxEntries)
 	}
 	if *es.RequestMaxBytes != *nes.RequestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *es.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *es.RequestMaxBytes)
 	}
 	if *es.Placement != *nes.Placement {
 		t.Errorf("bad placement: %q", *es.Placement)

--- a/fastly/logging_ftp_test.go
+++ b/fastly/logging_ftp_test.go
@@ -151,7 +151,7 @@ func TestClient_FTPs(t *testing.T) {
 		t.Errorf("bad address: %q", *ftpCreateResp1.Address)
 	}
 	if *ftpCreateResp1.Port != 1234 {
-		t.Errorf("bad port: %q", *ftpCreateResp1.Port)
+		t.Errorf("bad port: %d", *ftpCreateResp1.Port)
 	}
 	if *ftpCreateResp1.PublicKey != pgpPublicKey() {
 		t.Errorf("bad public_key: %q", *ftpCreateResp1.PublicKey)
@@ -166,16 +166,16 @@ func TestClient_FTPs(t *testing.T) {
 		t.Errorf("bad path: %q", *ftpCreateResp1.Path)
 	}
 	if *ftpCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *ftpCreateResp1.Period)
+		t.Errorf("bad period: %d", *ftpCreateResp1.Period)
 	}
 	if *ftpCreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *ftpCreateResp1.CompressionCodec)
 	}
 	if *ftpCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *ftpCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpCreateResp1.GzipLevel)
 	}
 	if *ftpCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ftpCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *ftpCreateResp1.FormatVersion)
 	}
 	if *ftpCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *ftpCreateResp1.Format)
@@ -193,13 +193,13 @@ func TestClient_FTPs(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *ftpCreateResp2.CompressionCodec)
 	}
 	if *ftpCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *ftpCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpCreateResp2.GzipLevel)
 	}
 	if *ftpCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *ftpCreateResp3.CompressionCodec)
 	}
 	if *ftpCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *ftpCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -236,7 +236,7 @@ func TestClient_FTPs(t *testing.T) {
 		t.Errorf("bad address: %q", *ftpCreateResp1.Address)
 	}
 	if *ftpCreateResp1.Port != *ftpGetResp.Port {
-		t.Errorf("bad port: %q", *ftpCreateResp1.Port)
+		t.Errorf("bad port: %d", *ftpCreateResp1.Port)
 	}
 	if *ftpCreateResp1.PublicKey != *ftpGetResp.PublicKey {
 		t.Errorf("bad public_key: %q", *ftpCreateResp1.PublicKey)
@@ -251,16 +251,16 @@ func TestClient_FTPs(t *testing.T) {
 		t.Errorf("bad path: %q", *ftpCreateResp1.Path)
 	}
 	if *ftpCreateResp1.Period != *ftpGetResp.Period {
-		t.Errorf("bad period: %q", *ftpCreateResp1.Period)
+		t.Errorf("bad period: %d", *ftpCreateResp1.Period)
 	}
 	if *ftpCreateResp1.CompressionCodec != *ftpGetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *ftpCreateResp1.CompressionCodec)
 	}
 	if *ftpCreateResp1.GzipLevel != *ftpGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *ftpCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpCreateResp1.GzipLevel)
 	}
 	if *ftpCreateResp1.FormatVersion != *ftpGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *ftpCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *ftpCreateResp1.FormatVersion)
 	}
 	if *ftpCreateResp1.Format != *ftpGetResp.Format {
 		t.Errorf("bad format: %q", *ftpCreateResp1.Format)
@@ -334,7 +334,7 @@ func TestClient_FTPs(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *ftpUpdateResp1.CompressionCodec)
 	}
 	if ftpUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *ftpUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpUpdateResp1.GzipLevel)
 	}
 	if *ftpUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *ftpUpdateResp1.ProcessingRegion)
@@ -343,13 +343,13 @@ func TestClient_FTPs(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *ftpUpdateResp2.CompressionCodec)
 	}
 	if *ftpUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *ftpUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpUpdateResp2.GzipLevel)
 	}
 	if ftpUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *ftpUpdateResp3.CompressionCodec)
 	}
 	if *ftpUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *ftpUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpUpdateResp3.GzipLevel)
 	}
 
 	// Delete
@@ -510,7 +510,7 @@ func TestClient_FTPs_Compute(t *testing.T) {
 		t.Errorf("bad address: %q", *ftpCreateResp1.Address)
 	}
 	if *ftpCreateResp1.Port != 1234 {
-		t.Errorf("bad port: %q", *ftpCreateResp1.Port)
+		t.Errorf("bad port: %d", *ftpCreateResp1.Port)
 	}
 	if *ftpCreateResp1.PublicKey != pgpPublicKey() {
 		t.Errorf("bad public_key: %q", *ftpCreateResp1.PublicKey)
@@ -525,16 +525,16 @@ func TestClient_FTPs_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *ftpCreateResp1.Path)
 	}
 	if *ftpCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *ftpCreateResp1.Period)
+		t.Errorf("bad period: %d", *ftpCreateResp1.Period)
 	}
 	if *ftpCreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *ftpCreateResp1.CompressionCodec)
 	}
 	if *ftpCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *ftpCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpCreateResp1.GzipLevel)
 	}
 	if *ftpCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ftpCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *ftpCreateResp1.FormatVersion)
 	}
 	if *ftpCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *ftpCreateResp1.Format)
@@ -552,13 +552,13 @@ func TestClient_FTPs_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *ftpCreateResp2.CompressionCodec)
 	}
 	if *ftpCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *ftpCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpCreateResp2.GzipLevel)
 	}
 	if *ftpCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *ftpCreateResp3.CompressionCodec)
 	}
 	if *ftpCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *ftpCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -595,7 +595,7 @@ func TestClient_FTPs_Compute(t *testing.T) {
 		t.Errorf("bad address: %q", *ftpCreateResp1.Address)
 	}
 	if *ftpCreateResp1.Port != *ftpGetResp.Port {
-		t.Errorf("bad port: %q", *ftpCreateResp1.Port)
+		t.Errorf("bad port: %d", *ftpCreateResp1.Port)
 	}
 	if *ftpCreateResp1.PublicKey != *ftpGetResp.PublicKey {
 		t.Errorf("bad public_key: %q", *ftpCreateResp1.PublicKey)
@@ -610,16 +610,16 @@ func TestClient_FTPs_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *ftpCreateResp1.Path)
 	}
 	if *ftpCreateResp1.Period != *ftpGetResp.Period {
-		t.Errorf("bad period: %q", *ftpCreateResp1.Period)
+		t.Errorf("bad period: %d", *ftpCreateResp1.Period)
 	}
 	if *ftpCreateResp1.CompressionCodec != *ftpGetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *ftpCreateResp1.CompressionCodec)
 	}
 	if *ftpCreateResp1.GzipLevel != *ftpGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *ftpCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpCreateResp1.GzipLevel)
 	}
 	if *ftpCreateResp1.FormatVersion != *ftpGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *ftpCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *ftpCreateResp1.FormatVersion)
 	}
 	if *ftpCreateResp1.Format != *ftpGetResp.Format {
 		t.Errorf("bad format: %q", *ftpCreateResp1.Format)
@@ -693,7 +693,7 @@ func TestClient_FTPs_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *ftpUpdateResp1.CompressionCodec)
 	}
 	if ftpUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *ftpUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpUpdateResp1.GzipLevel)
 	}
 	if *ftpUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *ftpUpdateResp1.ProcessingRegion)
@@ -702,13 +702,13 @@ func TestClient_FTPs_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *ftpUpdateResp2.CompressionCodec)
 	}
 	if *ftpUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *ftpUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpUpdateResp2.GzipLevel)
 	}
 	if ftpUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *ftpUpdateResp3.CompressionCodec)
 	}
 	if *ftpUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *ftpUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *ftpUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/logging_gcs_test.go
+++ b/fastly/logging_gcs_test.go
@@ -164,16 +164,16 @@ func TestClient_GCSs(t *testing.T) {
 		t.Errorf("bad path: %q", *gcsCreateResp1.Path)
 	}
 	if *gcsCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *gcsCreateResp1.Period)
+		t.Errorf("bad period: %d", *gcsCreateResp1.Period)
 	}
 	if *gcsCreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
 	if *gcsCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsCreateResp1.GzipLevel)
 	}
 	if *gcsCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *gcsCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *gcsCreateResp1.FormatVersion)
 	}
 	if *gcsCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *gcsCreateResp1.Format)
@@ -191,13 +191,13 @@ func TestClient_GCSs(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
 	if *gcsCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsCreateResp1.GzipLevel)
 	}
 	if *gcsCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
 	if *gcsCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsCreateResp1.GzipLevel)
 	}
 
 	// List
@@ -246,16 +246,16 @@ func TestClient_GCSs(t *testing.T) {
 		t.Errorf("bad path: %q", *gcsCreateResp1.Path)
 	}
 	if *gcsCreateResp1.Period != *gcsGetResp.Period {
-		t.Errorf("bad period: %q", *gcsCreateResp1.Period)
+		t.Errorf("bad period: %d", *gcsCreateResp1.Period)
 	}
 	if *gcsCreateResp1.CompressionCodec != *gcsGetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
 	if *gcsCreateResp1.GzipLevel != *gcsGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsCreateResp1.GzipLevel)
 	}
 	if *gcsCreateResp1.FormatVersion != *gcsGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *gcsCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *gcsCreateResp1.FormatVersion)
 	}
 	if *gcsCreateResp1.Format != *gcsGetResp.Format {
 		t.Errorf("bad format: %q", *gcsCreateResp1.Format)
@@ -333,7 +333,7 @@ func TestClient_GCSs(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *gcsUpdateResp1.CompressionCodec)
 	}
 	if *gcsUpdateResp1.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *gcsUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsUpdateResp1.GzipLevel)
 	}
 	if *gcsUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *gcsUpdateResp1.ProcessingRegion)
@@ -342,13 +342,13 @@ func TestClient_GCSs(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *gcsUpdateResp2.CompressionCodec)
 	}
 	if *gcsUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *gcsUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsUpdateResp2.GzipLevel)
 	}
 	if gcsUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *gcsUpdateResp3.CompressionCodec)
 	}
 	if *gcsUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *gcsUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsUpdateResp3.GzipLevel)
 	}
 
 	// Delete
@@ -522,16 +522,16 @@ func TestClient_GCSs_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *gcsCreateResp1.Path)
 	}
 	if *gcsCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *gcsCreateResp1.Period)
+		t.Errorf("bad period: %d", *gcsCreateResp1.Period)
 	}
 	if *gcsCreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
 	if *gcsCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsCreateResp1.GzipLevel)
 	}
 	if *gcsCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *gcsCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *gcsCreateResp1.FormatVersion)
 	}
 	if *gcsCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *gcsCreateResp1.Format)
@@ -549,13 +549,13 @@ func TestClient_GCSs_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
 	if *gcsCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsCreateResp1.GzipLevel)
 	}
 	if *gcsCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
 	if *gcsCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsCreateResp1.GzipLevel)
 	}
 
 	// List
@@ -604,16 +604,16 @@ func TestClient_GCSs_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *gcsCreateResp1.Path)
 	}
 	if *gcsCreateResp1.Period != *gcsGetResp.Period {
-		t.Errorf("bad period: %q", *gcsCreateResp1.Period)
+		t.Errorf("bad period: %d", *gcsCreateResp1.Period)
 	}
 	if *gcsCreateResp1.CompressionCodec != *gcsGetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *gcsCreateResp1.CompressionCodec)
 	}
 	if *gcsCreateResp1.GzipLevel != *gcsGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *gcsCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsCreateResp1.GzipLevel)
 	}
 	if *gcsCreateResp1.FormatVersion != *gcsGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *gcsCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *gcsCreateResp1.FormatVersion)
 	}
 	if *gcsCreateResp1.Format != *gcsGetResp.Format {
 		t.Errorf("bad format: %q", *gcsCreateResp1.Format)
@@ -691,7 +691,7 @@ func TestClient_GCSs_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *gcsUpdateResp1.CompressionCodec)
 	}
 	if *gcsUpdateResp1.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *gcsUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsUpdateResp1.GzipLevel)
 	}
 	if *gcsUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *gcsUpdateResp1.ProcessingRegion)
@@ -700,13 +700,13 @@ func TestClient_GCSs_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *gcsUpdateResp2.CompressionCodec)
 	}
 	if *gcsUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *gcsUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsUpdateResp2.GzipLevel)
 	}
 	if gcsUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *gcsUpdateResp3.CompressionCodec)
 	}
 	if *gcsUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *gcsUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *gcsUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/logging_grafanacloudlogs_test.go
+++ b/fastly/logging_grafanacloudlogs_test.go
@@ -67,7 +67,7 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 		t.Errorf("bad format: %q", *d.Format)
 	}
 	if *d.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *d.FormatVersion)
+		t.Errorf("bad format_version: %d", *d.FormatVersion)
 	}
 	if *d.Placement != "none" {
 		t.Errorf("bad placement: %q", *d.Placement)
@@ -110,7 +110,7 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 		t.Errorf("bad format: %q", *d.Format)
 	}
 	if *d.FormatVersion != *nd.FormatVersion {
-		t.Errorf("bad format_version: %q", *d.FormatVersion)
+		t.Errorf("bad format_version: %d", *d.FormatVersion)
 	}
 	if *d.Placement != *nd.Placement {
 		t.Errorf("bad placement: %q", *d.Placement)
@@ -142,7 +142,7 @@ func TestClient_GrafanaCloudLogs(t *testing.T) {
 		t.Errorf("bad name: %q", *ud.Name)
 	}
 	if *ud.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ud.FormatVersion)
+		t.Errorf("bad format_version: %d", *ud.FormatVersion)
 	}
 	if *ud.URL != "https://test456.grafana.net" {
 		t.Errorf("bad url: %q", *ud.URL)
@@ -228,7 +228,7 @@ func TestClient_GrafanaCloudLogs_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *d.Format)
 	}
 	if *d.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *d.FormatVersion)
+		t.Errorf("bad format_version: %d", *d.FormatVersion)
 	}
 	if *d.Placement != "none" {
 		t.Errorf("bad placement: %q", *d.Placement)
@@ -271,7 +271,7 @@ func TestClient_GrafanaCloudLogs_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *d.Format)
 	}
 	if *d.FormatVersion != *nd.FormatVersion {
-		t.Errorf("bad format_version: %q", *d.FormatVersion)
+		t.Errorf("bad format_version: %d", *d.FormatVersion)
 	}
 	if *d.Placement != *nd.Placement {
 		t.Errorf("bad placement: %q", *d.Placement)
@@ -303,7 +303,7 @@ func TestClient_GrafanaCloudLogs_Compute(t *testing.T) {
 		t.Errorf("bad name: %q", *ud.Name)
 	}
 	if *ud.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ud.FormatVersion)
+		t.Errorf("bad format_version: %d", *ud.FormatVersion)
 	}
 	if *ud.URL != "https://test456.grafana.net" {
 		t.Errorf("bad url: %q", *ud.URL)

--- a/fastly/logging_heroku_test.go
+++ b/fastly/logging_heroku_test.go
@@ -57,7 +57,7 @@ func TestClient_Herokus(t *testing.T) {
 		t.Errorf("bad format: %q", *h.Format)
 	}
 	if *h.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *h.FormatVersion)
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 	if *h.Placement != "none" {
 		t.Errorf("bad placement: %q", *h.Placement)
@@ -103,7 +103,7 @@ func TestClient_Herokus(t *testing.T) {
 		t.Errorf("bad format: %q", *h.Format)
 	}
 	if *h.FormatVersion != *nh.FormatVersion {
-		t.Errorf("bad format_version: %q", *h.FormatVersion)
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 	if *h.Placement != *nh.Placement {
 		t.Errorf("bad placement: %q", *h.Placement)
@@ -208,7 +208,7 @@ func TestClient_Herokus_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *h.Format)
 	}
 	if *h.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *h.FormatVersion)
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 	if *h.Placement != "none" {
 		t.Errorf("bad placement: %q", *h.Placement)
@@ -254,7 +254,7 @@ func TestClient_Herokus_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *h.Format)
 	}
 	if *h.FormatVersion != *nh.FormatVersion {
-		t.Errorf("bad format_version: %q", *h.FormatVersion)
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 	if *h.Placement != *nh.Placement {
 		t.Errorf("bad placement: %q", *h.Placement)

--- a/fastly/logging_honeycomb_test.go
+++ b/fastly/logging_honeycomb_test.go
@@ -57,7 +57,7 @@ func TestClient_Honeycombs(t *testing.T) {
 		t.Errorf("bad format: %q", *h.Format)
 	}
 	if *h.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *h.FormatVersion)
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 	if *h.Placement != "none" {
 		t.Errorf("bad placement: %q", *h.Placement)
@@ -103,7 +103,7 @@ func TestClient_Honeycombs(t *testing.T) {
 		t.Errorf("bad format: %q", *h.Format)
 	}
 	if *h.FormatVersion != *nh.FormatVersion {
-		t.Errorf("bad format_version: %q", *h.FormatVersion)
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 	if *h.Placement != *nh.Placement {
 		t.Errorf("bad placement: %q", *h.Placement)
@@ -212,7 +212,7 @@ func TestClient_Honeycombs_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *h.Format)
 	}
 	if *h.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *h.FormatVersion)
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 	if *h.Placement != "none" {
 		t.Errorf("bad placement: %q", *h.Placement)
@@ -258,7 +258,7 @@ func TestClient_Honeycombs_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *h.Format)
 	}
 	if *h.FormatVersion != *nh.FormatVersion {
-		t.Errorf("bad format_version: %q", *h.FormatVersion)
+		t.Errorf("bad format_version: %d", *h.FormatVersion)
 	}
 	if *h.Placement != *nh.Placement {
 		t.Errorf("bad placement: %q", *h.Placement)

--- a/fastly/logging_https_test.go
+++ b/fastly/logging_https_test.go
@@ -195,10 +195,10 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad url: %q", *httpsCreateResp1.URL)
 	}
 	if *httpsCreateResp1.RequestMaxEntries != 1 {
-		t.Errorf("bad request_max_entries: %q", *httpsCreateResp1.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *httpsCreateResp1.RequestMaxEntries)
 	}
 	if *httpsCreateResp1.RequestMaxBytes != 1000 {
-		t.Errorf("bad request_max_bytes: %q", *httpsCreateResp1.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *httpsCreateResp1.RequestMaxBytes)
 	}
 	if *httpsCreateResp1.ContentType != JSONMimeType {
 		t.Errorf("bad content_type: %q", *httpsCreateResp1.ContentType)
@@ -216,7 +216,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad json_format: %q", *httpsCreateResp1.JSONFormat)
 	}
 	if *httpsCreateResp1.Period != 5 {
-		t.Errorf("bad period: %q", *httpsCreateResp1.Period)
+		t.Errorf("bad period: %d", *httpsCreateResp1.Period)
 	}
 	if *httpsCreateResp1.Placement != "none" {
 		t.Errorf("bad placement: %q", *httpsCreateResp1.Placement)
@@ -243,13 +243,13 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad compression_codec: %q", *httpsCreateResp2.CompressionCodec)
 	}
 	if *httpsCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *httpsCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *httpsCreateResp2.GzipLevel)
 	}
 	if *httpsCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *httpsCreateResp3.CompressionCodec)
 	}
 	if *httpsCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *httpsCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *httpsCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -289,10 +289,10 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad url: %q", *httpsCreateResp1.URL)
 	}
 	if *httpsCreateResp1.RequestMaxEntries != *nh.RequestMaxEntries {
-		t.Errorf("bad request_max_entries: %q", *httpsCreateResp1.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *httpsCreateResp1.RequestMaxEntries)
 	}
 	if *httpsCreateResp1.RequestMaxBytes != *nh.RequestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *httpsCreateResp1.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *httpsCreateResp1.RequestMaxBytes)
 	}
 	if *httpsCreateResp1.ContentType != *nh.ContentType {
 		t.Errorf("bad content_type: %q", *httpsCreateResp1.ContentType)
@@ -310,7 +310,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad json_format: %q", *httpsCreateResp1.JSONFormat)
 	}
 	if *httpsCreateResp1.Period != *nh.Period {
-		t.Errorf("bad period: %q", *httpsCreateResp1.Period)
+		t.Errorf("bad period: %d", *httpsCreateResp1.Period)
 	}
 	if *httpsCreateResp1.Placement != *nh.Placement {
 		t.Errorf("bad placement: %q", *httpsCreateResp1.Placement)
@@ -385,7 +385,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad placement: %q", *uh2.Placement)
 	}
 	if *uh2.GzipLevel != 3 {
-		t.Errorf("bad gzip_level: %q", *uh2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *uh2.GzipLevel)
 	}
 
 	// Delete
@@ -584,10 +584,10 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad url: %q", *httpsCreateResp1.URL)
 	}
 	if *httpsCreateResp1.RequestMaxEntries != 1 {
-		t.Errorf("bad request_max_entries: %q", *httpsCreateResp1.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *httpsCreateResp1.RequestMaxEntries)
 	}
 	if *httpsCreateResp1.RequestMaxBytes != 1000 {
-		t.Errorf("bad request_max_bytes: %q", *httpsCreateResp1.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *httpsCreateResp1.RequestMaxBytes)
 	}
 	if *httpsCreateResp1.ContentType != JSONMimeType {
 		t.Errorf("bad content_type: %q", *httpsCreateResp1.ContentType)
@@ -629,13 +629,13 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad compression_codec: %q", *httpsCreateResp2.CompressionCodec)
 	}
 	if *httpsCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *httpsCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *httpsCreateResp2.GzipLevel)
 	}
 	if *httpsCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *httpsCreateResp3.CompressionCodec)
 	}
 	if *httpsCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *httpsCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *httpsCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -675,10 +675,10 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad url: %q", *httpsCreateResp1.URL)
 	}
 	if *httpsCreateResp1.RequestMaxEntries != *nh.RequestMaxEntries {
-		t.Errorf("bad request_max_entries: %q", *httpsCreateResp1.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *httpsCreateResp1.RequestMaxEntries)
 	}
 	if *httpsCreateResp1.RequestMaxBytes != *nh.RequestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *httpsCreateResp1.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *httpsCreateResp1.RequestMaxBytes)
 	}
 	if *httpsCreateResp1.ContentType != *nh.ContentType {
 		t.Errorf("bad content_type: %q", *httpsCreateResp1.ContentType)

--- a/fastly/logging_kafka_test.go
+++ b/fastly/logging_kafka_test.go
@@ -91,7 +91,7 @@ func TestClient_Kafkas(t *testing.T) {
 		t.Errorf("bad format: %q", *k.Format)
 	}
 	if *k.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *k.FormatVersion)
+		t.Errorf("bad format_version: %d", *k.FormatVersion)
 	}
 	if *k.Placement != "none" {
 		t.Errorf("bad placement: %q", *k.Placement)
@@ -112,7 +112,7 @@ func TestClient_Kafkas(t *testing.T) {
 		t.Errorf("bad parse_log_keyvals: %t", *k.ParseLogKeyvals)
 	}
 	if *k.RequestMaxBytes != requestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *k.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *k.RequestMaxBytes)
 	}
 	if *k.AuthMethod != "scram-sha-512" {
 		t.Errorf("bad auth_method: %q", *k.AuthMethod)
@@ -173,7 +173,7 @@ func TestClient_Kafkas(t *testing.T) {
 		t.Errorf("bad format: %q", *k.Format)
 	}
 	if *k.FormatVersion != *nk.FormatVersion {
-		t.Errorf("bad format_version: %q", *k.FormatVersion)
+		t.Errorf("bad format_version: %d", *k.FormatVersion)
 	}
 	if *k.Placement != *nk.Placement {
 		t.Errorf("bad placement: %q", *k.Placement)
@@ -194,7 +194,7 @@ func TestClient_Kafkas(t *testing.T) {
 		t.Errorf("bad parse_log_keyvals: %t", *k.ParseLogKeyvals)
 	}
 	if *k.RequestMaxBytes != requestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *k.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *k.RequestMaxBytes)
 	}
 	if *k.AuthMethod != "scram-sha-512" {
 		t.Errorf("bad auth_method: %q", *k.AuthMethod)
@@ -338,7 +338,7 @@ func TestClient_Kafkas_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *k.Format)
 	}
 	if *k.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *k.FormatVersion)
+		t.Errorf("bad format_version: %d", *k.FormatVersion)
 	}
 	if *k.Placement != "none" {
 		t.Errorf("bad placement: %q", *k.Placement)
@@ -359,7 +359,7 @@ func TestClient_Kafkas_Compute(t *testing.T) {
 		t.Errorf("bad parse_log_keyvals: %t", *k.ParseLogKeyvals)
 	}
 	if *k.RequestMaxBytes != requestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *k.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *k.RequestMaxBytes)
 	}
 	if *k.AuthMethod != "scram-sha-512" {
 		t.Errorf("bad auth_method: %q", *k.AuthMethod)
@@ -420,7 +420,7 @@ func TestClient_Kafkas_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *k.Format)
 	}
 	if *k.FormatVersion != *nk.FormatVersion {
-		t.Errorf("bad format_version: %q", *k.FormatVersion)
+		t.Errorf("bad format_version: %d", *k.FormatVersion)
 	}
 	if *k.Placement != *nk.Placement {
 		t.Errorf("bad placement: %q", *k.Placement)
@@ -441,7 +441,7 @@ func TestClient_Kafkas_Compute(t *testing.T) {
 		t.Errorf("bad parse_log_keyvals: %t", *k.ParseLogKeyvals)
 	}
 	if *k.RequestMaxBytes != requestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *k.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *k.RequestMaxBytes)
 	}
 	if *k.AuthMethod != "scram-sha-512" {
 		t.Errorf("bad auth_method: %q", *k.AuthMethod)

--- a/fastly/logging_kinesis_test.go
+++ b/fastly/logging_kinesis_test.go
@@ -137,7 +137,7 @@ func TestClient_Kinesis(t *testing.T) {
 		t.Errorf("bad format: %q", *kinesisCreateResp1.Format)
 	}
 	if *kinesisCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *kinesisCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *kinesisCreateResp1.FormatVersion)
 	}
 	if *kinesisCreateResp1.Placement != "none" {
 		t.Errorf("bad placement: %q", *kinesisCreateResp1.Placement)
@@ -218,7 +218,7 @@ func TestClient_Kinesis(t *testing.T) {
 		t.Errorf("bad format: %q", *kinesisCreateResp1.Format)
 	}
 	if *kinesisCreateResp1.FormatVersion != *kinesisGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *kinesisCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *kinesisCreateResp1.FormatVersion)
 	}
 	if *kinesisCreateResp1.Placement != *kinesisGetResp.Placement {
 		t.Errorf("bad placement: %q", *kinesisCreateResp1.Placement)
@@ -483,7 +483,7 @@ func TestClient_Kinesis_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *kinesisCreateResp1.Format)
 	}
 	if *kinesisCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *kinesisCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *kinesisCreateResp1.FormatVersion)
 	}
 	if *kinesisCreateResp1.Placement != "none" {
 		t.Errorf("bad placement: %q", *kinesisCreateResp1.Placement)
@@ -564,7 +564,7 @@ func TestClient_Kinesis_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *kinesisCreateResp1.Format)
 	}
 	if *kinesisCreateResp1.FormatVersion != *kinesisGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *kinesisCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *kinesisCreateResp1.FormatVersion)
 	}
 	if *kinesisCreateResp1.Placement != *kinesisGetResp.Placement {
 		t.Errorf("bad placement: %q", *kinesisCreateResp1.Placement)

--- a/fastly/logging_logentries_test.go
+++ b/fastly/logging_logentries_test.go
@@ -55,7 +55,7 @@ func TestClient_Logentries(t *testing.T) {
 		t.Errorf("bad name: %q", *le.Name)
 	}
 	if *le.Port != 0 {
-		t.Errorf("bad port: %q", *le.Port)
+		t.Errorf("bad port: %d", *le.Port)
 	}
 	if !*le.UseTLS {
 		t.Errorf("bad use_tls: %t", *le.UseTLS)
@@ -67,7 +67,7 @@ func TestClient_Logentries(t *testing.T) {
 		t.Errorf("bad format: %q", *le.Format)
 	}
 	if *le.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *le.FormatVersion)
+		t.Errorf("bad format_version: %d", *le.FormatVersion)
 	}
 	if *le.Placement != "none" {
 		t.Errorf("bad placement: %q", *le.Placement)
@@ -107,7 +107,7 @@ func TestClient_Logentries(t *testing.T) {
 		t.Errorf("bad name: %q", *le.Name)
 	}
 	if *le.Port != *nle.Port {
-		t.Errorf("bad port: %q", *le.Port)
+		t.Errorf("bad port: %d", *le.Port)
 	}
 	if *le.UseTLS != *nle.UseTLS {
 		t.Errorf("bad use_tls: %t", *le.UseTLS)
@@ -119,7 +119,7 @@ func TestClient_Logentries(t *testing.T) {
 		t.Errorf("bad format: %q", *le.Format)
 	}
 	if *le.FormatVersion != *nle.FormatVersion {
-		t.Errorf("bad format_version: %q", *le.FormatVersion)
+		t.Errorf("bad format_version: %d", *le.FormatVersion)
 	}
 	if *le.Placement != *nle.Placement {
 		t.Errorf("bad placement: %q", *le.Placement)
@@ -150,7 +150,7 @@ func TestClient_Logentries(t *testing.T) {
 		t.Errorf("bad name: %q", *ule.Name)
 	}
 	if *ule.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ule.FormatVersion)
+		t.Errorf("bad format_version: %d", *ule.FormatVersion)
 	}
 	if *ule.Region != "ap" {
 		t.Errorf("bad region: %q", *ule.Region)
@@ -224,7 +224,7 @@ func TestClient_Logentries_Compute(t *testing.T) {
 		t.Errorf("bad name: %q", *le.Name)
 	}
 	if *le.Port != 0 {
-		t.Errorf("bad port: %q", *le.Port)
+		t.Errorf("bad port: %d", *le.Port)
 	}
 	if !*le.UseTLS {
 		t.Errorf("bad use_tls: %t", *le.UseTLS)
@@ -236,7 +236,7 @@ func TestClient_Logentries_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *le.Format)
 	}
 	if *le.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *le.FormatVersion)
+		t.Errorf("bad format_version: %d", *le.FormatVersion)
 	}
 	if *le.Placement != "none" {
 		t.Errorf("bad placement: %q", *le.Placement)
@@ -276,7 +276,7 @@ func TestClient_Logentries_Compute(t *testing.T) {
 		t.Errorf("bad name: %q", *le.Name)
 	}
 	if *le.Port != *nle.Port {
-		t.Errorf("bad port: %q", *le.Port)
+		t.Errorf("bad port: %d", *le.Port)
 	}
 	if *le.UseTLS != *nle.UseTLS {
 		t.Errorf("bad use_tls: %t", *le.UseTLS)
@@ -288,7 +288,7 @@ func TestClient_Logentries_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *le.Format)
 	}
 	if *le.FormatVersion != *nle.FormatVersion {
-		t.Errorf("bad format_version: %q", *le.FormatVersion)
+		t.Errorf("bad format_version: %d", *le.FormatVersion)
 	}
 	if *le.Placement != *nle.Placement {
 		t.Errorf("bad placement: %q", *le.Placement)
@@ -318,7 +318,7 @@ func TestClient_Logentries_Compute(t *testing.T) {
 		t.Errorf("bad name: %q", *ule.Name)
 	}
 	if *ule.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ule.FormatVersion)
+		t.Errorf("bad format_version: %d", *ule.FormatVersion)
 	}
 	if *ule.Region != "ap" {
 		t.Errorf("bad region: %q", *ule.Region)

--- a/fastly/logging_loggly_test.go
+++ b/fastly/logging_loggly_test.go
@@ -58,7 +58,7 @@ func TestClient_Loggly(t *testing.T) {
 		t.Errorf("bad format: %q", *lg.Format)
 	}
 	if *lg.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *lg.FormatVersion)
+		t.Errorf("bad format_version: %d", *lg.FormatVersion)
 	}
 	if *lg.Placement != "none" {
 		t.Errorf("bad placement: %q", *lg.Placement)
@@ -101,7 +101,7 @@ func TestClient_Loggly(t *testing.T) {
 		t.Errorf("bad format: %q", *lg.Format)
 	}
 	if *lg.FormatVersion != *nlg.FormatVersion {
-		t.Errorf("bad format_version: %q", *lg.FormatVersion)
+		t.Errorf("bad format_version: %d", *lg.FormatVersion)
 	}
 	if *lg.Placement != *nlg.Placement {
 		t.Errorf("bad placement: %q", *lg.Placement)
@@ -130,7 +130,7 @@ func TestClient_Loggly(t *testing.T) {
 		t.Errorf("bad name: %q", *ulg.Name)
 	}
 	if *ulg.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ulg.FormatVersion)
+		t.Errorf("bad format_version: %d", *ulg.FormatVersion)
 	}
 	if *ulg.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *ulg.ProcessingRegion)
@@ -201,7 +201,7 @@ func TestClient_Loggly_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *lg.Format)
 	}
 	if *lg.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *lg.FormatVersion)
+		t.Errorf("bad format_version: %d", *lg.FormatVersion)
 	}
 	if *lg.Placement != "none" {
 		t.Errorf("bad placement: %q", *lg.Placement)
@@ -244,7 +244,7 @@ func TestClient_Loggly_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *lg.Format)
 	}
 	if *lg.FormatVersion != *nlg.FormatVersion {
-		t.Errorf("bad format_version: %q", *lg.FormatVersion)
+		t.Errorf("bad format_version: %d", *lg.FormatVersion)
 	}
 	if *lg.Placement != *nlg.Placement {
 		t.Errorf("bad placement: %q", *lg.Placement)
@@ -273,7 +273,7 @@ func TestClient_Loggly_Compute(t *testing.T) {
 		t.Errorf("bad name: %q", *ulg.Name)
 	}
 	if *ulg.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *ulg.FormatVersion)
+		t.Errorf("bad format_version: %d", *ulg.FormatVersion)
 	}
 	if *ulg.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *ulg.ProcessingRegion)

--- a/fastly/logging_logshuttle_test.go
+++ b/fastly/logging_logshuttle_test.go
@@ -57,7 +57,7 @@ func TestClient_Logshuttles(t *testing.T) {
 		t.Errorf("bad format: %q", *l.Format)
 	}
 	if *l.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *l.FormatVersion)
+		t.Errorf("bad format_version: %d", *l.FormatVersion)
 	}
 	if *l.Placement != "none" {
 		t.Errorf("bad placement: %q", *l.Placement)
@@ -103,7 +103,7 @@ func TestClient_Logshuttles(t *testing.T) {
 		t.Errorf("bad format: %q", *l.Format)
 	}
 	if *l.FormatVersion != *nl.FormatVersion {
-		t.Errorf("bad format_version: %q", *l.FormatVersion)
+		t.Errorf("bad format_version: %d", *l.FormatVersion)
 	}
 	if *l.Placement != *nl.Placement {
 		t.Errorf("bad placement: %q", *l.Placement)
@@ -212,7 +212,7 @@ func TestClient_Logshuttles_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *l.Format)
 	}
 	if *l.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *l.FormatVersion)
+		t.Errorf("bad format_version: %d", *l.FormatVersion)
 	}
 	if *l.Placement != "none" {
 		t.Errorf("bad placement: %q", *l.Placement)
@@ -258,7 +258,7 @@ func TestClient_Logshuttles_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *l.Format)
 	}
 	if *l.FormatVersion != *nl.FormatVersion {
-		t.Errorf("bad format_version: %q", *l.FormatVersion)
+		t.Errorf("bad format_version: %d", *l.FormatVersion)
 	}
 	if *l.Placement != *nl.Placement {
 		t.Errorf("bad placement: %q", *l.Placement)

--- a/fastly/logging_newrelic_test.go
+++ b/fastly/logging_newrelic_test.go
@@ -96,7 +96,7 @@ func TestClient_NewRelic(t *testing.T) {
 		t.Errorf("bad format: %q", *newRelicResp1.Format)
 	}
 	if *newRelicResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *newRelicResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicResp1.FormatVersion)
 	}
 	if *newRelicResp1.Placement != "none" {
 		t.Errorf("bad placement: %q", *newRelicResp1.Placement)
@@ -114,7 +114,7 @@ func TestClient_NewRelic(t *testing.T) {
 		t.Errorf("bad format: %q", *newRelicResp2.Format)
 	}
 	if *newRelicResp2.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *newRelicResp2.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicResp2.FormatVersion)
 	}
 	if *newRelicResp2.Placement != "none" {
 		t.Errorf("bad placement: %q", *newRelicResp2.Placement)
@@ -172,7 +172,7 @@ func TestClient_NewRelic(t *testing.T) {
 		t.Errorf("bad format: %q", *newRelicResp1.Format)
 	}
 	if *newRelicResp1.FormatVersion != *newRelicGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *newRelicResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicResp1.FormatVersion)
 	}
 	if *newRelicResp1.Placement != *newRelicGetResp.Placement {
 		t.Errorf("bad placement: %q", *newRelicResp1.Placement)
@@ -190,7 +190,7 @@ func TestClient_NewRelic(t *testing.T) {
 		t.Errorf("bad format: %q", *newRelicResp2.Format)
 	}
 	if *newRelicResp2.FormatVersion != *newRelicGetResp2.FormatVersion {
-		t.Errorf("bad format_version: %q", *newRelicResp2.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicResp2.FormatVersion)
 	}
 	if *newRelicResp2.Placement != *newRelicGetResp2.Placement {
 		t.Errorf("bad placement: %q", *newRelicResp2.Placement)
@@ -238,7 +238,7 @@ func TestClient_NewRelic(t *testing.T) {
 		t.Errorf("bad name: %q", *newRelicUpdateResp1.Name)
 	}
 	if *newRelicUpdateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *newRelicUpdateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicUpdateResp1.FormatVersion)
 	}
 	if *newRelicUpdateResp1.Region != "eu" {
 		t.Errorf("bad region: %q", *newRelicUpdateResp1.Region)
@@ -350,7 +350,7 @@ func TestClient_NewRelic_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *newRelicResp1.Format)
 	}
 	if *newRelicResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *newRelicResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicResp1.FormatVersion)
 	}
 	if *newRelicResp1.Placement != "none" {
 		t.Errorf("bad placement: %q", *newRelicResp1.Placement)
@@ -368,7 +368,7 @@ func TestClient_NewRelic_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *newRelicResp2.Format)
 	}
 	if *newRelicResp2.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *newRelicResp2.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicResp2.FormatVersion)
 	}
 	if *newRelicResp2.Placement != "none" {
 		t.Errorf("bad placement: %q", *newRelicResp2.Placement)
@@ -426,7 +426,7 @@ func TestClient_NewRelic_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *newRelicResp1.Format)
 	}
 	if *newRelicResp1.FormatVersion != *newRelicGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *newRelicResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicResp1.FormatVersion)
 	}
 	if *newRelicResp1.Placement != *newRelicGetResp.Placement {
 		t.Errorf("bad placement: %q", *newRelicResp1.Placement)
@@ -444,7 +444,7 @@ func TestClient_NewRelic_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *newRelicResp2.Format)
 	}
 	if *newRelicResp2.FormatVersion != *newRelicGetResp2.FormatVersion {
-		t.Errorf("bad format_version: %q", *newRelicResp2.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicResp2.FormatVersion)
 	}
 	if *newRelicResp2.Placement != *newRelicGetResp2.Placement {
 		t.Errorf("bad placement: %q", *newRelicResp2.Placement)
@@ -492,7 +492,7 @@ func TestClient_NewRelic_Compute(t *testing.T) {
 		t.Errorf("bad name: %q", *newRelicUpdateResp1.Name)
 	}
 	if *newRelicUpdateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *newRelicUpdateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *newRelicUpdateResp1.FormatVersion)
 	}
 	if *newRelicUpdateResp1.Region != "eu" {
 		t.Errorf("bad region: %q", *newRelicUpdateResp1.Region)

--- a/fastly/logging_newrelicotlp_test.go
+++ b/fastly/logging_newrelicotlp_test.go
@@ -63,7 +63,7 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 		t.Errorf("bad format: %q", *n.Format)
 	}
 	if *n.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *n.FormatVersion)
+		t.Errorf("bad format_version: %d", *n.FormatVersion)
 	}
 	if *n.Placement != "none" {
 		t.Errorf("bad placement: %q", *n.Placement)
@@ -109,7 +109,7 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 		t.Errorf("bad format: %q", *n.Format)
 	}
 	if *n.FormatVersion != *nn.FormatVersion {
-		t.Errorf("bad format_version: %q", *n.FormatVersion)
+		t.Errorf("bad format_version: %d", *n.FormatVersion)
 	}
 	if *n.Placement != *nn.Placement {
 		t.Errorf("bad placement: %q", *n.Placement)
@@ -138,7 +138,7 @@ func TestClient_NewRelicOTLP(t *testing.T) {
 		t.Errorf("bad name: %q", *un.Name)
 	}
 	if *un.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *un.FormatVersion)
+		t.Errorf("bad format_version: %d", *un.FormatVersion)
 	}
 	if *un.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *un.ProcessingRegion)
@@ -213,7 +213,7 @@ func TestClient_NewRelicOTLP_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *n.Format)
 	}
 	if *n.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *n.FormatVersion)
+		t.Errorf("bad format_version: %d", *n.FormatVersion)
 	}
 	if *n.Placement != "none" {
 		t.Errorf("bad placement: %q", *n.Placement)
@@ -259,7 +259,7 @@ func TestClient_NewRelicOTLP_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *n.Format)
 	}
 	if *n.FormatVersion != *nn.FormatVersion {
-		t.Errorf("bad format_version: %q", *n.FormatVersion)
+		t.Errorf("bad format_version: %d", *n.FormatVersion)
 	}
 	if *n.Placement != *nn.Placement {
 		t.Errorf("bad placement: %q", *n.Placement)
@@ -288,7 +288,7 @@ func TestClient_NewRelicOTLP_Compute(t *testing.T) {
 		t.Errorf("bad name: %q", *un.Name)
 	}
 	if *un.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *un.FormatVersion)
+		t.Errorf("bad format_version: %d", *un.FormatVersion)
 	}
 	if *un.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *un.ProcessingRegion)

--- a/fastly/logging_openstack_test.go
+++ b/fastly/logging_openstack_test.go
@@ -164,19 +164,19 @@ func TestClient_Openstack(t *testing.T) {
 		t.Errorf("bad url: %q", *osCreateResp1.URL)
 	}
 	if *osCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *osCreateResp1.Period)
+		t.Errorf("bad period: %d", *osCreateResp1.Period)
 	}
 	if *osCreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad comprssion_codec: %q", *osCreateResp1.CompressionCodec)
 	}
 	if *osCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *osCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osCreateResp1.GzipLevel)
 	}
 	if *osCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *osCreateResp1.Format)
 	}
 	if *osCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *osCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *osCreateResp1.FormatVersion)
 	}
 	if *osCreateResp1.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", *osCreateResp1.TimestampFormat)
@@ -194,13 +194,13 @@ func TestClient_Openstack(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *osCreateResp2.CompressionCodec)
 	}
 	if *osCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *osCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osCreateResp2.GzipLevel)
 	}
 	if *osCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *osCreateResp3.CompressionCodec)
 	}
 	if *osCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *osCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -249,19 +249,19 @@ func TestClient_Openstack(t *testing.T) {
 		t.Errorf("bad url: %q", *osCreateResp1.URL)
 	}
 	if *osCreateResp1.Period != *osGetResp.Period {
-		t.Errorf("bad period: %q", *osCreateResp1.Period)
+		t.Errorf("bad period: %d", *osCreateResp1.Period)
 	}
 	if *osCreateResp1.CompressionCodec != *osGetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *osCreateResp1.CompressionCodec)
 	}
 	if *osCreateResp1.GzipLevel != *osGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *osCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osCreateResp1.GzipLevel)
 	}
 	if *osCreateResp1.Format != *osGetResp.Format {
 		t.Errorf("bad format: %q", *osCreateResp1.Format)
 	}
 	if *osCreateResp1.FormatVersion != *osGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *osCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *osCreateResp1.FormatVersion)
 	}
 	if *osCreateResp1.TimestampFormat != *osGetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *osCreateResp1.TimestampFormat)
@@ -339,7 +339,7 @@ func TestClient_Openstack(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *osUpdateResp1.CompressionCodec)
 	}
 	if osUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *osUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osUpdateResp1.GzipLevel)
 	}
 	if *osUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *osUpdateResp1.ProcessingRegion)
@@ -348,13 +348,13 @@ func TestClient_Openstack(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *osUpdateResp2.CompressionCodec)
 	}
 	if *osUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *osUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osUpdateResp2.GzipLevel)
 	}
 	if osUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *osUpdateResp3.CompressionCodec)
 	}
 	if *osUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *osUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osUpdateResp3.GzipLevel)
 	}
 
 	// Delete
@@ -528,19 +528,19 @@ func TestClient_Openstack_Compute(t *testing.T) {
 		t.Errorf("bad url: %q", *osCreateResp1.URL)
 	}
 	if *osCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *osCreateResp1.Period)
+		t.Errorf("bad period: %d", *osCreateResp1.Period)
 	}
 	if *osCreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad comprssion_codec: %q", *osCreateResp1.CompressionCodec)
 	}
 	if *osCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *osCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osCreateResp1.GzipLevel)
 	}
 	if *osCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *osCreateResp1.Format)
 	}
 	if *osCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *osCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *osCreateResp1.FormatVersion)
 	}
 	if *osCreateResp1.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", *osCreateResp1.TimestampFormat)
@@ -558,13 +558,13 @@ func TestClient_Openstack_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *osCreateResp2.CompressionCodec)
 	}
 	if *osCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *osCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osCreateResp2.GzipLevel)
 	}
 	if *osCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *osCreateResp3.CompressionCodec)
 	}
 	if *osCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *osCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -613,19 +613,19 @@ func TestClient_Openstack_Compute(t *testing.T) {
 		t.Errorf("bad url: %q", *osCreateResp1.URL)
 	}
 	if *osCreateResp1.Period != *osGetResp.Period {
-		t.Errorf("bad period: %q", *osCreateResp1.Period)
+		t.Errorf("bad period: %d", *osCreateResp1.Period)
 	}
 	if *osCreateResp1.CompressionCodec != *osGetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *osCreateResp1.CompressionCodec)
 	}
 	if *osCreateResp1.GzipLevel != *osGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *osCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osCreateResp1.GzipLevel)
 	}
 	if *osCreateResp1.Format != *osGetResp.Format {
 		t.Errorf("bad format: %q", *osCreateResp1.Format)
 	}
 	if *osCreateResp1.FormatVersion != *osGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *osCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *osCreateResp1.FormatVersion)
 	}
 	if *osCreateResp1.TimestampFormat != *osGetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *osCreateResp1.TimestampFormat)
@@ -703,7 +703,7 @@ func TestClient_Openstack_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *osUpdateResp1.CompressionCodec)
 	}
 	if osUpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *osUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osUpdateResp1.GzipLevel)
 	}
 	if *osUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *osUpdateResp1.ProcessingRegion)
@@ -712,13 +712,13 @@ func TestClient_Openstack_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *osUpdateResp2.CompressionCodec)
 	}
 	if *osUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *osUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osUpdateResp2.GzipLevel)
 	}
 	if osUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *osUpdateResp3.CompressionCodec)
 	}
 	if *osUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *osUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *osUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/logging_papertrail_test.go
+++ b/fastly/logging_papertrail_test.go
@@ -57,10 +57,10 @@ func TestClient_Papertrails(t *testing.T) {
 		t.Errorf("bad address: %q", *p.Address)
 	}
 	if *p.Port != 1234 {
-		t.Errorf("bad port: %q", *p.Port)
+		t.Errorf("bad port: %d", *p.Port)
 	}
 	if *p.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *p.FormatVersion)
+		t.Errorf("bad format_version: %d", *p.FormatVersion)
 	}
 	if *p.Format != "format" {
 		t.Errorf("bad format: %q", *p.Format)
@@ -103,10 +103,10 @@ func TestClient_Papertrails(t *testing.T) {
 		t.Errorf("bad address: %q", *p.Address)
 	}
 	if *p.Port != *np.Port {
-		t.Errorf("bad port: %q", *p.Port)
+		t.Errorf("bad port: %d", *p.Port)
 	}
 	if *p.FormatVersion != *np.FormatVersion {
-		t.Errorf("bad format_version: %q", *p.FormatVersion)
+		t.Errorf("bad format_version: %d", *p.FormatVersion)
 	}
 	if *p.Format != *np.Format {
 		t.Errorf("bad format: %q", *p.Format)
@@ -204,10 +204,10 @@ func TestClient_Papertrails_Compute(t *testing.T) {
 		t.Errorf("bad address: %q", *p.Address)
 	}
 	if *p.Port != 1234 {
-		t.Errorf("bad port: %q", *p.Port)
+		t.Errorf("bad port: %d", *p.Port)
 	}
 	if *p.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *p.FormatVersion)
+		t.Errorf("bad format_version: %d", *p.FormatVersion)
 	}
 	if *p.Format != "format" {
 		t.Errorf("bad format: %q", *p.Format)
@@ -250,10 +250,10 @@ func TestClient_Papertrails_Compute(t *testing.T) {
 		t.Errorf("bad address: %q", *p.Address)
 	}
 	if *p.Port != *np.Port {
-		t.Errorf("bad port: %q", *p.Port)
+		t.Errorf("bad port: %d", *p.Port)
 	}
 	if *p.FormatVersion != *np.FormatVersion {
-		t.Errorf("bad format_version: %q", *p.FormatVersion)
+		t.Errorf("bad format_version: %d", *p.FormatVersion)
 	}
 	if *p.Format != *np.Format {
 		t.Errorf("bad format: %q", *p.Format)

--- a/fastly/logging_pubsub_test.go
+++ b/fastly/logging_pubsub_test.go
@@ -100,7 +100,7 @@ bv1KwcKoQbNVXwauH79JKc0=
 		t.Errorf("bad project_id: %q", *pubsub.ProjectID)
 	}
 	if *pubsub.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *pubsub.FormatVersion)
+		t.Errorf("bad format_version: %d", *pubsub.FormatVersion)
 	}
 	if *pubsub.Format != "format" {
 		t.Errorf("bad format: %q", *pubsub.Format)
@@ -152,7 +152,7 @@ bv1KwcKoQbNVXwauH79JKc0=
 		t.Errorf("bad project_id: %q", *pubsub.ProjectID)
 	}
 	if *pubsub.FormatVersion != *npubsub.FormatVersion {
-		t.Errorf("bad format_version: %q", *pubsub.FormatVersion)
+		t.Errorf("bad format_version: %d", *pubsub.FormatVersion)
 	}
 	if *pubsub.Format != *npubsub.Format {
 		t.Errorf("bad format: %q", *pubsub.Format)
@@ -296,7 +296,7 @@ bv1KwcKoQbNVXwauH79JKc0=
 		t.Errorf("bad project_id: %q", *pubsub.ProjectID)
 	}
 	if *pubsub.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *pubsub.FormatVersion)
+		t.Errorf("bad format_version: %d", *pubsub.FormatVersion)
 	}
 	if *pubsub.Format != "format" {
 		t.Errorf("bad format: %q", *pubsub.Format)
@@ -348,7 +348,7 @@ bv1KwcKoQbNVXwauH79JKc0=
 		t.Errorf("bad project_id: %q", *pubsub.ProjectID)
 	}
 	if *pubsub.FormatVersion != *npubsub.FormatVersion {
-		t.Errorf("bad format_version: %q", *pubsub.FormatVersion)
+		t.Errorf("bad format_version: %d", *pubsub.FormatVersion)
 	}
 	if *pubsub.Format != *npubsub.Format {
 		t.Errorf("bad format: %q", *pubsub.Format)

--- a/fastly/logging_s3_test.go
+++ b/fastly/logging_s3_test.go
@@ -268,19 +268,19 @@ func TestClient_S3s(t *testing.T) {
 		t.Errorf("bad path: %q", *s3CreateResp1.Path)
 	}
 	if *s3CreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *s3CreateResp1.Period)
+		t.Errorf("bad period: %d", *s3CreateResp1.Period)
 	}
 	if *s3CreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *s3CreateResp1.CompressionCodec)
 	}
 	if *s3CreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *s3CreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3CreateResp1.GzipLevel)
 	}
 	if *s3CreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *s3CreateResp1.Format)
 	}
 	if *s3CreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *s3CreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *s3CreateResp1.FormatVersion)
 	}
 	if *s3CreateResp1.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", *s3CreateResp1.TimestampFormat)
@@ -310,16 +310,16 @@ func TestClient_S3s(t *testing.T) {
 		t.Errorf("bad acl: %s", *s3CreateResp1.ACL)
 	}
 	if *s3CreateResp1.FileMaxBytes != MiB {
-		t.Errorf("bad file_max_bytes: %q", *s3CreateResp1.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3CreateResp1.FileMaxBytes)
 	}
 	if *s3CreateResp2.FileMaxBytes != 10*MiB {
-		t.Errorf("bad file_max_bytes: %q", *s3CreateResp2.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3CreateResp2.FileMaxBytes)
 	}
 	if *s3CreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *s3CreateResp1.CompressionCodec)
 	}
 	if *s3CreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *s3CreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3CreateResp1.GzipLevel)
 	}
 	if *s3CreateResp3.Redundancy != S3RedundancyStandardIA {
 		t.Errorf("bad acl: %s", *s3CreateResp3.Redundancy)
@@ -328,7 +328,7 @@ func TestClient_S3s(t *testing.T) {
 		t.Errorf("bad acl: %s", *s3CreateResp3.ACL)
 	}
 	if *s3CreateResp3.FileMaxBytes != 0 {
-		t.Errorf("bad file_max_bytes: %q", *s3CreateResp3.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3CreateResp3.FileMaxBytes)
 	}
 	if s3CreateResp4.AccessKey != nil {
 		t.Errorf("bad access_key: %q", *s3CreateResp4.AccessKey)
@@ -346,7 +346,7 @@ func TestClient_S3s(t *testing.T) {
 		t.Errorf("bad acl: %s", *s3CreateResp4.ACL)
 	}
 	if *s3CreateResp4.FileMaxBytes != 10*MiB {
-		t.Errorf("bad file_max_bytes: %q", *s3CreateResp4.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3CreateResp4.FileMaxBytes)
 	}
 
 	// List
@@ -411,19 +411,19 @@ func TestClient_S3s(t *testing.T) {
 		t.Errorf("bad path: %q", *s3CreateResp1.Path)
 	}
 	if *s3CreateResp1.Period != *s3GetResp.Period {
-		t.Errorf("bad period: %q", *s3CreateResp1.Period)
+		t.Errorf("bad period: %d", *s3CreateResp1.Period)
 	}
 	if *s3CreateResp1.CompressionCodec != *s3GetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *s3CreateResp1.CompressionCodec)
 	}
 	if *s3CreateResp1.GzipLevel != *s3GetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *s3CreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3CreateResp1.GzipLevel)
 	}
 	if *s3CreateResp1.Format != *s3GetResp.Format {
 		t.Errorf("bad format: %q", *s3CreateResp1.Format)
 	}
 	if *s3CreateResp1.FormatVersion != *s3GetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *s3CreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *s3CreateResp1.FormatVersion)
 	}
 	if *s3CreateResp1.TimestampFormat != *s3GetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *s3CreateResp1.TimestampFormat)
@@ -588,10 +588,10 @@ func TestClient_S3s(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *s3UpdateResp1.CompressionCodec)
 	}
 	if s3UpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *s3UpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3UpdateResp1.GzipLevel)
 	}
 	if *s3UpdateResp1.FileMaxBytes != 5*MiB {
-		t.Errorf("bad file_max_bytes: %q", *s3UpdateResp1.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3UpdateResp1.FileMaxBytes)
 	}
 	if *s3UpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *s3UpdateResp1.ProcessingRegion)
@@ -600,13 +600,13 @@ func TestClient_S3s(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *s3UpdateResp2.CompressionCodec)
 	}
 	if *s3UpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *s3UpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3UpdateResp2.GzipLevel)
 	}
 	if s3UpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *s3UpdateResp3.CompressionCodec)
 	}
 	if *s3UpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *s3UpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3UpdateResp3.GzipLevel)
 	}
 	if *s3UpdateResp4.AccessKey != "" {
 		t.Errorf("bad access_key: %q", *s3UpdateResp4.AccessKey)
@@ -902,19 +902,19 @@ func TestClient_S3s_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *s3CreateResp1.Path)
 	}
 	if *s3CreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *s3CreateResp1.Period)
+		t.Errorf("bad period: %d", *s3CreateResp1.Period)
 	}
 	if *s3CreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *s3CreateResp1.CompressionCodec)
 	}
 	if *s3CreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *s3CreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3CreateResp1.GzipLevel)
 	}
 	if *s3CreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *s3CreateResp1.Format)
 	}
 	if *s3CreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *s3CreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *s3CreateResp1.FormatVersion)
 	}
 	if *s3CreateResp1.TimestampFormat != "%Y" {
 		t.Errorf("bad timestamp_format: %q", *s3CreateResp1.TimestampFormat)
@@ -944,16 +944,16 @@ func TestClient_S3s_Compute(t *testing.T) {
 		t.Errorf("bad acl: %s", *s3CreateResp1.ACL)
 	}
 	if *s3CreateResp1.FileMaxBytes != MiB {
-		t.Errorf("bad file_max_bytes: %q", *s3CreateResp1.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3CreateResp1.FileMaxBytes)
 	}
 	if *s3CreateResp2.FileMaxBytes != 10*MiB {
-		t.Errorf("bad file_max_bytes: %q", *s3CreateResp2.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3CreateResp2.FileMaxBytes)
 	}
 	if *s3CreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *s3CreateResp1.CompressionCodec)
 	}
 	if *s3CreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *s3CreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3CreateResp1.GzipLevel)
 	}
 	if *s3CreateResp3.Redundancy != S3RedundancyStandardIA {
 		t.Errorf("bad acl: %s", *s3CreateResp3.Redundancy)
@@ -962,7 +962,7 @@ func TestClient_S3s_Compute(t *testing.T) {
 		t.Errorf("bad acl: %s", *s3CreateResp3.ACL)
 	}
 	if *s3CreateResp3.FileMaxBytes != 0 {
-		t.Errorf("bad file_max_bytes: %q", *s3CreateResp3.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3CreateResp3.FileMaxBytes)
 	}
 	if s3CreateResp4.AccessKey != nil {
 		t.Errorf("bad access_key: %q", *s3CreateResp4.AccessKey)
@@ -980,7 +980,7 @@ func TestClient_S3s_Compute(t *testing.T) {
 		t.Errorf("bad acl: %s", *s3CreateResp4.ACL)
 	}
 	if *s3CreateResp4.FileMaxBytes != 10*MiB {
-		t.Errorf("bad file_max_bytes: %q", *s3CreateResp4.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3CreateResp4.FileMaxBytes)
 	}
 
 	// List
@@ -1045,19 +1045,19 @@ func TestClient_S3s_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *s3CreateResp1.Path)
 	}
 	if *s3CreateResp1.Period != *s3GetResp.Period {
-		t.Errorf("bad period: %q", *s3CreateResp1.Period)
+		t.Errorf("bad period: %d", *s3CreateResp1.Period)
 	}
 	if *s3CreateResp1.CompressionCodec != *s3GetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *s3CreateResp1.CompressionCodec)
 	}
 	if *s3CreateResp1.GzipLevel != *s3GetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *s3CreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3CreateResp1.GzipLevel)
 	}
 	if *s3CreateResp1.Format != *s3GetResp.Format {
 		t.Errorf("bad format: %q", *s3CreateResp1.Format)
 	}
 	if *s3CreateResp1.FormatVersion != *s3GetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *s3CreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *s3CreateResp1.FormatVersion)
 	}
 	if *s3CreateResp1.TimestampFormat != *s3GetResp.TimestampFormat {
 		t.Errorf("bad timestamp_format: %q", *s3CreateResp1.TimestampFormat)
@@ -1222,10 +1222,10 @@ func TestClient_S3s_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *s3UpdateResp1.CompressionCodec)
 	}
 	if s3UpdateResp1.GzipLevel != nil {
-		t.Errorf("bad gzip_level: %q", *s3UpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3UpdateResp1.GzipLevel)
 	}
 	if *s3UpdateResp1.FileMaxBytes != 5*MiB {
-		t.Errorf("bad file_max_bytes: %q", *s3UpdateResp1.FileMaxBytes)
+		t.Errorf("bad file_max_bytes: %d", *s3UpdateResp1.FileMaxBytes)
 	}
 	if *s3UpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *s3UpdateResp1.ProcessingRegion)
@@ -1234,13 +1234,13 @@ func TestClient_S3s_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *s3UpdateResp2.CompressionCodec)
 	}
 	if *s3UpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *s3UpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3UpdateResp2.GzipLevel)
 	}
 	if s3UpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *s3UpdateResp3.CompressionCodec)
 	}
 	if *s3UpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *s3UpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *s3UpdateResp3.GzipLevel)
 	}
 	if *s3UpdateResp4.AccessKey != "" {
 		t.Errorf("bad access_key: %q", *s3UpdateResp4.AccessKey)

--- a/fastly/logging_scalyr_test.go
+++ b/fastly/logging_scalyr_test.go
@@ -58,7 +58,7 @@ func TestClient_Scalyrs(t *testing.T) {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.Placement != "none" {
 		t.Errorf("bad placement: %q", *s.Placement)
@@ -107,7 +107,7 @@ func TestClient_Scalyrs(t *testing.T) {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != *ns.FormatVersion {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.Placement != *ns.Placement {
 		t.Errorf("bad placement: %q", *s.Placement)
@@ -224,7 +224,7 @@ func TestClient_Scalyrs_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.Placement != "none" {
 		t.Errorf("bad placement: %q", *s.Placement)
@@ -273,7 +273,7 @@ func TestClient_Scalyrs_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != *ns.FormatVersion {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.Placement != *ns.Placement {
 		t.Errorf("bad placement: %q", *s.Placement)

--- a/fastly/logging_sftp_test.go
+++ b/fastly/logging_sftp_test.go
@@ -162,7 +162,7 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Errorf("bad address: %q", *sftpCreateResp1.Address)
 	}
 	if *sftpCreateResp1.Port != 1234 {
-		t.Errorf("bad port: %q", *sftpCreateResp1.Port)
+		t.Errorf("bad port: %d", *sftpCreateResp1.Port)
 	}
 	if *sftpCreateResp1.PublicKey != pgpPublicKey() {
 		t.Errorf("bad public_key: %q", *sftpCreateResp1.PublicKey)
@@ -183,16 +183,16 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Errorf("bad path: %q", *sftpCreateResp1.Path)
 	}
 	if *sftpCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *sftpCreateResp1.Period)
+		t.Errorf("bad period: %d", *sftpCreateResp1.Period)
 	}
 	if *sftpCreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *sftpCreateResp1.CompressionCodec)
 	}
 	if *sftpCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *sftpCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpCreateResp1.GzipLevel)
 	}
 	if *sftpCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *sftpCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *sftpCreateResp1.FormatVersion)
 	}
 	if *sftpCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *sftpCreateResp1.Format)
@@ -210,13 +210,13 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *sftpCreateResp2.CompressionCodec)
 	}
 	if *sftpCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *sftpCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpCreateResp2.GzipLevel)
 	}
 	if *sftpCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *sftpCreateResp3.CompressionCodec)
 	}
 	if *sftpCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *sftpCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -254,7 +254,7 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Errorf("bad address: %q", *sftpCreateResp1.Address)
 	}
 	if *sftpCreateResp1.Port != *sftpGetResp.Port {
-		t.Errorf("bad port: %q", *sftpCreateResp1.Port)
+		t.Errorf("bad port: %d", *sftpCreateResp1.Port)
 	}
 	if *sftpCreateResp1.PublicKey != *sftpGetResp.PublicKey {
 		t.Errorf("bad public_key: %q", *sftpCreateResp1.PublicKey)
@@ -275,16 +275,16 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Errorf("bad path: %q", *sftpCreateResp1.Path)
 	}
 	if *sftpCreateResp1.Period != *sftpGetResp.Period {
-		t.Errorf("bad period: %q", *sftpCreateResp1.Period)
+		t.Errorf("bad period: %d", *sftpCreateResp1.Period)
 	}
 	if *sftpCreateResp1.CompressionCodec != *sftpGetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *sftpCreateResp1.CompressionCodec)
 	}
 	if *sftpCreateResp1.GzipLevel != *sftpGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *sftpCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpCreateResp1.GzipLevel)
 	}
 	if *sftpCreateResp1.FormatVersion != *sftpGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *sftpCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *sftpCreateResp1.FormatVersion)
 	}
 	if *sftpCreateResp1.Format != *sftpGetResp.Format {
 		t.Errorf("bad format: %q", *sftpCreateResp1.Format)
@@ -362,7 +362,7 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *sftpUpdateResp1.CompressionCodec)
 	}
 	if *sftpUpdateResp1.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *sftpUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpUpdateResp1.GzipLevel)
 	}
 	if *sftpUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *sftpUpdateResp1.ProcessingRegion)
@@ -371,13 +371,13 @@ func TestClient_SFTPs(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *sftpUpdateResp2.CompressionCodec)
 	}
 	if *sftpUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *sftpUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpUpdateResp2.GzipLevel)
 	}
 	if sftpUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *sftpUpdateResp3.CompressionCodec)
 	}
 	if *sftpUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *sftpUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpUpdateResp3.GzipLevel)
 	}
 
 	// Delete
@@ -548,7 +548,7 @@ func TestClient_SFTPs_Compute(t *testing.T) {
 		t.Errorf("bad address: %q", *sftpCreateResp1.Address)
 	}
 	if *sftpCreateResp1.Port != 1234 {
-		t.Errorf("bad port: %q", *sftpCreateResp1.Port)
+		t.Errorf("bad port: %d", *sftpCreateResp1.Port)
 	}
 	if *sftpCreateResp1.PublicKey != pgpPublicKey() {
 		t.Errorf("bad public_key: %q", *sftpCreateResp1.PublicKey)
@@ -569,16 +569,16 @@ func TestClient_SFTPs_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *sftpCreateResp1.Path)
 	}
 	if *sftpCreateResp1.Period != 12 {
-		t.Errorf("bad period: %q", *sftpCreateResp1.Period)
+		t.Errorf("bad period: %d", *sftpCreateResp1.Period)
 	}
 	if *sftpCreateResp1.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *sftpCreateResp1.CompressionCodec)
 	}
 	if *sftpCreateResp1.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *sftpCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpCreateResp1.GzipLevel)
 	}
 	if *sftpCreateResp1.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *sftpCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *sftpCreateResp1.FormatVersion)
 	}
 	if *sftpCreateResp1.Format != "format" {
 		t.Errorf("bad format: %q", *sftpCreateResp1.Format)
@@ -596,13 +596,13 @@ func TestClient_SFTPs_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *sftpCreateResp2.CompressionCodec)
 	}
 	if *sftpCreateResp2.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *sftpCreateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpCreateResp2.GzipLevel)
 	}
 	if *sftpCreateResp3.CompressionCodec != "snappy" {
 		t.Errorf("bad compression_codec: %q", *sftpCreateResp3.CompressionCodec)
 	}
 	if *sftpCreateResp3.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *sftpCreateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpCreateResp3.GzipLevel)
 	}
 
 	// List
@@ -640,7 +640,7 @@ func TestClient_SFTPs_Compute(t *testing.T) {
 		t.Errorf("bad address: %q", *sftpCreateResp1.Address)
 	}
 	if *sftpCreateResp1.Port != *sftpGetResp.Port {
-		t.Errorf("bad port: %q", *sftpCreateResp1.Port)
+		t.Errorf("bad port: %d", *sftpCreateResp1.Port)
 	}
 	if *sftpCreateResp1.PublicKey != *sftpGetResp.PublicKey {
 		t.Errorf("bad public_key: %q", *sftpCreateResp1.PublicKey)
@@ -661,16 +661,16 @@ func TestClient_SFTPs_Compute(t *testing.T) {
 		t.Errorf("bad path: %q", *sftpCreateResp1.Path)
 	}
 	if *sftpCreateResp1.Period != *sftpGetResp.Period {
-		t.Errorf("bad period: %q", *sftpCreateResp1.Period)
+		t.Errorf("bad period: %d", *sftpCreateResp1.Period)
 	}
 	if *sftpCreateResp1.CompressionCodec != *sftpGetResp.CompressionCodec {
 		t.Errorf("bad compression_codec: %q", *sftpCreateResp1.CompressionCodec)
 	}
 	if *sftpCreateResp1.GzipLevel != *sftpGetResp.GzipLevel {
-		t.Errorf("bad gzip_level: %q", *sftpCreateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpCreateResp1.GzipLevel)
 	}
 	if *sftpCreateResp1.FormatVersion != *sftpGetResp.FormatVersion {
-		t.Errorf("bad format_version: %q", *sftpCreateResp1.FormatVersion)
+		t.Errorf("bad format_version: %d", *sftpCreateResp1.FormatVersion)
 	}
 	if *sftpCreateResp1.Format != *sftpGetResp.Format {
 		t.Errorf("bad format: %q", *sftpCreateResp1.Format)
@@ -748,7 +748,7 @@ func TestClient_SFTPs_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *sftpUpdateResp1.CompressionCodec)
 	}
 	if *sftpUpdateResp1.GzipLevel != 8 {
-		t.Errorf("bad gzip_level: %q", *sftpUpdateResp1.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpUpdateResp1.GzipLevel)
 	}
 	if *sftpUpdateResp1.ProcessingRegion != "eu" {
 		t.Errorf("bad log_processing_region: %q", *sftpUpdateResp1.ProcessingRegion)
@@ -757,13 +757,13 @@ func TestClient_SFTPs_Compute(t *testing.T) {
 		t.Errorf("bad compression_codec: %q", *sftpUpdateResp2.CompressionCodec)
 	}
 	if *sftpUpdateResp2.GzipLevel != 0 {
-		t.Errorf("bad gzip_level: %q", *sftpUpdateResp2.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpUpdateResp2.GzipLevel)
 	}
 	if sftpUpdateResp3.CompressionCodec != nil {
 		t.Errorf("bad compression_codec: %q", *sftpUpdateResp3.CompressionCodec)
 	}
 	if *sftpUpdateResp3.GzipLevel != 9 {
-		t.Errorf("bad gzip_level: %q", *sftpUpdateResp3.GzipLevel)
+		t.Errorf("bad gzip_level: %d", *sftpUpdateResp3.GzipLevel)
 	}
 
 	// Delete

--- a/fastly/logging_splunk_test.go
+++ b/fastly/logging_splunk_test.go
@@ -85,16 +85,16 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad url: %q", *s.URL)
 	}
 	if *s.RequestMaxEntries != 1 {
-		t.Errorf("bad request_max_entries: %q", *s.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *s.RequestMaxEntries)
 	}
 	if *s.RequestMaxBytes != 1000 {
-		t.Errorf("bad request_max_bytes: %q", *s.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *s.RequestMaxBytes)
 	}
 	if *s.Format != "%h %l %u %t \"%r\" %>s %b" {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.Placement != "none" {
 		t.Errorf("bad placement: %q", *s.Placement)
@@ -152,16 +152,16 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad url: %q", *s.URL)
 	}
 	if *s.RequestMaxEntries != *ns.RequestMaxEntries {
-		t.Errorf("bad request_max_entries: %q", *s.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *s.RequestMaxEntries)
 	}
 	if *s.RequestMaxBytes != *ns.RequestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *s.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *s.RequestMaxBytes)
 	}
 	if *s.Format != *ns.Format {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != *ns.FormatVersion {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.Placement != *ns.Placement {
 		t.Errorf("bad placement: %q", *s.Placement)
@@ -305,16 +305,16 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad url: %q", *s.URL)
 	}
 	if *s.RequestMaxEntries != 1 {
-		t.Errorf("bad request_max_entries: %q", *s.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *s.RequestMaxEntries)
 	}
 	if *s.RequestMaxBytes != 1000 {
-		t.Errorf("bad request_max_bytes: %q", *s.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *s.RequestMaxBytes)
 	}
 	if *s.Format != "%h %l %u %t \"%r\" %>s %b" {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != 2 {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.Placement != "none" {
 		t.Errorf("bad placement: %q", *s.Placement)
@@ -372,16 +372,16 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad url: %q", *s.URL)
 	}
 	if *s.RequestMaxEntries != *ns.RequestMaxEntries {
-		t.Errorf("bad request_max_entries: %q", *s.RequestMaxEntries)
+		t.Errorf("bad request_max_entries: %d", *s.RequestMaxEntries)
 	}
 	if *s.RequestMaxBytes != *ns.RequestMaxBytes {
-		t.Errorf("bad request_max_bytes: %q", *s.RequestMaxBytes)
+		t.Errorf("bad request_max_bytes: %d", *s.RequestMaxBytes)
 	}
 	if *s.Format != *ns.Format {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != *ns.FormatVersion {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.Placement != *ns.Placement {
 		t.Errorf("bad placement: %q", *s.Placement)

--- a/fastly/logging_sumologic_test.go
+++ b/fastly/logging_sumologic_test.go
@@ -60,7 +60,7 @@ func TestClient_Sumologics(t *testing.T) {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != 1 {
-		t.Errorf("bad format version: %q", *s.FormatVersion)
+		t.Errorf("bad format version: %d", *s.FormatVersion)
 	}
 	if *s.MessageType != "classic" {
 		t.Errorf("bad message type: %q", *s.MessageType)
@@ -106,7 +106,7 @@ func TestClient_Sumologics(t *testing.T) {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != *ns.FormatVersion {
-		t.Errorf("bad format version: %q", *s.FormatVersion)
+		t.Errorf("bad format version: %d", *s.FormatVersion)
 	}
 	if *s.MessageType != *ns.MessageType {
 		t.Errorf("bad message type: %q", *s.MessageType)
@@ -207,7 +207,7 @@ func TestClient_Sumologics_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != 1 {
-		t.Errorf("bad format version: %q", *s.FormatVersion)
+		t.Errorf("bad format version: %d", *s.FormatVersion)
 	}
 	if *s.MessageType != "classic" {
 		t.Errorf("bad message type: %q", *s.MessageType)
@@ -253,7 +253,7 @@ func TestClient_Sumologics_Compute(t *testing.T) {
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != *ns.FormatVersion {
-		t.Errorf("bad format version: %q", *s.FormatVersion)
+		t.Errorf("bad format version: %d", *s.FormatVersion)
 	}
 	if *s.MessageType != *ns.MessageType {
 		t.Errorf("bad message type: %q", *s.MessageType)

--- a/fastly/logging_syslog_test.go
+++ b/fastly/logging_syslog_test.go
@@ -89,7 +89,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad hostname: %q", *s.Hostname)
 	}
 	if *s.Port != 1234 {
-		t.Errorf("bad port: %q", *s.Port)
+		t.Errorf("bad port: %d", *s.Port)
 	}
 	if !*s.UseTLS {
 		t.Errorf("bad use_tls: %t", *s.UseTLS)
@@ -159,7 +159,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad hostname: %q", *s.Hostname)
 	}
 	if *s.Port != *ns.Port {
-		t.Errorf("bad port: %q", *s.Port)
+		t.Errorf("bad port: %d", *s.Port)
 	}
 	if *s.UseTLS != *ns.UseTLS {
 		t.Errorf("bad use_tls: %t", *s.UseTLS)
@@ -183,7 +183,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != *ns.FormatVersion {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.MessageType != *ns.MessageType {
 		t.Errorf("bad message_type: %q", *s.MessageType)
@@ -323,7 +323,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad hostname: %q", *s.Hostname)
 	}
 	if *s.Port != 1234 {
-		t.Errorf("bad port: %q", *s.Port)
+		t.Errorf("bad port: %d", *s.Port)
 	}
 	if !*s.UseTLS {
 		t.Errorf("bad use_tls: %t", *s.UseTLS)
@@ -393,7 +393,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad hostname: %q", *s.Hostname)
 	}
 	if *s.Port != *ns.Port {
-		t.Errorf("bad port: %q", *s.Port)
+		t.Errorf("bad port: %d", *s.Port)
 	}
 	if *s.UseTLS != *ns.UseTLS {
 		t.Errorf("bad use_tls: %t", *s.UseTLS)
@@ -417,7 +417,7 @@ Wm7DCfrPNGVwFWUQOmsPue9rZBgO
 		t.Errorf("bad format: %q", *s.Format)
 	}
 	if *s.FormatVersion != *ns.FormatVersion {
-		t.Errorf("bad format_version: %q", *s.FormatVersion)
+		t.Errorf("bad format_version: %d", *s.FormatVersion)
 	}
 	if *s.MessageType != *ns.MessageType {
 		t.Errorf("bad message_type: %q", *s.MessageType)

--- a/fastly/ngwaf/v1/lists/api_test.go
+++ b/fastly/ngwaf/v1/lists/api_test.go
@@ -54,7 +54,7 @@ func runListsTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 		t.Errorf("unexpected list description: got %q, expected %q", list.Description, listDescription)
 	}
 	if len(list.Entries) != len(listEntries) {
-		t.Errorf("unexpected list entry length: got %q, expected %q", len(list.Entries), len(listEntries))
+		t.Errorf("unexpected list entry length: got %d, expected %d", len(list.Entries), len(listEntries))
 	}
 	if list.Entries[0] != listEntries[0] {
 		t.Errorf("unexpected list entry: got %q, expected %q", list.Entries[0], listEntries[0])
@@ -106,7 +106,7 @@ func runListsTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 		t.Errorf("unexpected list description: got %q, expected %q", getList.Description, listDescription)
 	}
 	if len(getList.Entries) != len(listEntries) {
-		t.Errorf("unexpected list entry length: got %q, expected %q", len(getList.Entries), len(listEntries))
+		t.Errorf("unexpected list entry length: got %d, expected %d", len(getList.Entries), len(listEntries))
 	}
 	if getList.Entries[0] != listEntries[0] {
 		t.Errorf("unexpected list entry: got %q, expected %q", getList.Entries[0], listEntries[0])
@@ -149,7 +149,7 @@ func runListsTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 		t.Errorf("unexpected list description: got %q, expected %q", updateList.Description, updateListDescription)
 	}
 	if len(updateList.Entries) != len(updateListEntries) {
-		t.Errorf("unexpected list entry length: got %q, expected %q", len(updateList.Entries), len(updateListEntries))
+		t.Errorf("unexpected list entry length: got %d, expected %d", len(updateList.Entries), len(updateListEntries))
 	}
 	if updateList.Entries[0] != updateListEntries[0] {
 		t.Errorf("unexpected list entry: got %q, expected %q", updateList.Entries[0], updateListEntries[0])
@@ -182,14 +182,14 @@ func runListsTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 		t.Fatal(err)
 	}
 	if len(lists.Data) != 1 {
-		t.Errorf("unexpected lists length: got %q, expected %q", len(lists.Data), 1)
+		t.Errorf("unexpected lists length: got %d, expected %d", len(lists.Data), 1)
 	}
 	listedList := &lists.Data[0]
 	if listedList.Description != updateListDescription {
 		t.Errorf("unexpected list description: got %q, expected %q", listedList.Description, updateListDescription)
 	}
 	if len(listedList.Entries) != len(updateListEntries) {
-		t.Errorf("unexpected list entry length: got %q, expected %q", len(listedList.Entries), len(updateListEntries))
+		t.Errorf("unexpected list entry length: got %d, expected %d", len(listedList.Entries), len(updateListEntries))
 	}
 	if listedList.Entries[0] != updateListEntries[0] {
 		t.Errorf("unexpected list entry: got %q, expected %q", listedList.Entries[0], updateListEntries[0])

--- a/fastly/ngwaf/v1/signals/api_test.go
+++ b/fastly/ngwaf/v1/signals/api_test.go
@@ -130,7 +130,7 @@ func runSignalsTest(t *testing.T, scopeType scope.Type, appliesToID string) {
 		t.Fatal(err)
 	}
 	if len(listedSignals.Data) != 1 {
-		t.Errorf("unexpected signal list length: got %q, expected %q", len(listedSignals.Data), 1)
+		t.Errorf("unexpected signal list length: got %d, expected %d", len(listedSignals.Data), 1)
 	}
 	if listedSignals.Data[0].Description != updatedSignalDescription {
 		t.Errorf("unexpected signal type: got %q, expected %q", listedSignals.Data[0].Description, updatedSignalDescription)

--- a/fastly/ngwaf/v1/workspaces/redactions/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/redactions/api_test.go
@@ -100,7 +100,7 @@ func TestClient_Redactions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(listedRedactions.Data) != 1 {
-		t.Errorf("unexpected redaction list length: got %q, expected %q", len(listedRedactions.Data), 1)
+		t.Errorf("unexpected redaction list length: got %d, expected %d", len(listedRedactions.Data), 1)
 	}
 	if listedRedactions.Data[0].Type != updatedRedactionType {
 		t.Errorf("unexpected redaction type: got %q, expected %q", listedRedactions.Data[0].Type, updatedRedactionType)

--- a/fastly/ngwaf/v1/workspaces/requests/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/requests/api_test.go
@@ -175,7 +175,7 @@ func TestClient_requests(t *testing.T) {
 		t.Fatal(err)
 	}
 	if request.AgentResponseCode != testRequest.AgentResponseCode {
-		t.Errorf("unexpected request AgentResponseCode: got %q, expected %q", request.AgentResponseCode, testRequest.AgentResponseCode)
+		t.Errorf("unexpected request AgentResponseCode: got %d, expected %d", request.AgentResponseCode, testRequest.AgentResponseCode)
 	}
 	if request.Country != testRequest.Country {
 		t.Errorf("unexpected request Country: got %q, expected %q", request.Country, testRequest.Country)
@@ -200,14 +200,14 @@ func TestClient_requests(t *testing.T) {
 	}
 	assert.ElementsMatch(t, request.RequestHeaders, testRequest.RequestHeaders)
 	if request.ResponseCode != testRequest.ResponseCode {
-		t.Errorf("unexpected request ResponseCode: got %q, expected %q", request.ResponseCode, testRequest.ResponseCode)
+		t.Errorf("unexpected request ResponseCode: got %d, expected %d", request.ResponseCode, testRequest.ResponseCode)
 	}
 	assert.ElementsMatch(t, request.ResponseHeaders, testRequest.ResponseHeaders)
 	if request.ResponseSize != testRequest.ResponseSize {
-		t.Errorf("unexpected request ResponseSize: got %q, expected %q", request.ResponseSize, testRequest.ResponseSize)
+		t.Errorf("unexpected request ResponseSize: got %d, expected %d", request.ResponseSize, testRequest.ResponseSize)
 	}
 	if request.ResponseTime != testRequest.ResponseTime {
-		t.Errorf("unexpected request ResponseTime: got %q, expected %q", request.ResponseTime, testRequest.ResponseTime)
+		t.Errorf("unexpected request ResponseTime: got %d, expected %d", request.ResponseTime, testRequest.ResponseTime)
 	}
 	if request.Scheme != testRequest.Scheme {
 		t.Errorf("unexpected request Scheme: got %q, expected %q", request.Scheme, testRequest.Scheme)
@@ -250,7 +250,7 @@ func TestClient_requests(t *testing.T) {
 		t.Fatal(err)
 	}
 	if request.AgentResponseCode != testRequest.AgentResponseCode {
-		t.Errorf("unexpected request AgentResponseCode: got %q, expected %q", request.AgentResponseCode, testRequest.AgentResponseCode)
+		t.Errorf("unexpected request AgentResponseCode: got %d, expected %d", request.AgentResponseCode, testRequest.AgentResponseCode)
 	}
 	if request.Country != testRequest.Country {
 		t.Errorf("unexpected request Country: got %q, expected %q", request.Country, testRequest.Country)
@@ -275,14 +275,14 @@ func TestClient_requests(t *testing.T) {
 	}
 	assert.ElementsMatch(t, request.RequestHeaders, testRequest.RequestHeaders)
 	if request.ResponseCode != testRequest.ResponseCode {
-		t.Errorf("unexpected request ResponseCode: got %q, expected %q", request.ResponseCode, testRequest.ResponseCode)
+		t.Errorf("unexpected request ResponseCode: got %d, expected %d", request.ResponseCode, testRequest.ResponseCode)
 	}
 	assert.ElementsMatch(t, request.ResponseHeaders, testRequest.ResponseHeaders)
 	if request.ResponseSize != testRequest.ResponseSize {
-		t.Errorf("unexpected request ResponseSize: got %q, expected %q", request.ResponseSize, testRequest.ResponseSize)
+		t.Errorf("unexpected request ResponseSize: got %d, expected %d", request.ResponseSize, testRequest.ResponseSize)
 	}
 	if request.ResponseTime != testRequest.ResponseTime {
-		t.Errorf("unexpected request ResponseTime: got %q, expected %q", request.ResponseTime, testRequest.ResponseTime)
+		t.Errorf("unexpected request ResponseTime: got %d, expected %d", request.ResponseTime, testRequest.ResponseTime)
 	}
 	if request.Scheme != testRequest.Scheme {
 		t.Errorf("unexpected request Scheme: got %q, expected %q", request.Scheme, testRequest.Scheme)

--- a/fastly/ngwaf/v1/workspaces/thresholds/api_test.go
+++ b/fastly/ngwaf/v1/workspaces/thresholds/api_test.go
@@ -41,10 +41,10 @@ func TestClient_Thresholds(t *testing.T) {
 		t.Errorf("unexpected threshold action: got %q, expected %q", threshold.Action, testAction)
 	}
 	if threshold.Interval != testInterval {
-		t.Errorf("unexpected threshold interval: got %q, expected %q", threshold.Interval, testInterval)
+		t.Errorf("unexpected threshold interval: got %d, expected %d", threshold.Interval, testInterval)
 	}
 	if threshold.Limit != testLimit {
-		t.Errorf("unexpected threshold limit: got %q, expected %q", threshold.Limit, testLimit)
+		t.Errorf("unexpected threshold limit: got %d, expected %d", threshold.Limit, testLimit)
 	}
 	if threshold.Name != testName {
 		t.Errorf("unexpected threshold name: got %q, expected %q", threshold.Name, testName)
@@ -56,7 +56,7 @@ func TestClient_Thresholds(t *testing.T) {
 		t.Errorf("unexpected threshold don't notify: got %t, should default to false", threshold.DontNotify)
 	}
 	if threshold.Duration != 0 {
-		t.Errorf("unexpected threshold duration: got %q, should default to 0", threshold.Duration)
+		t.Errorf("unexpected threshold duration: got %d, should default to 0", threshold.Duration)
 	}
 	if threshold.Enabled {
 		t.Errorf("unexpected threshold enabled: got %t, should default to false", threshold.Enabled)
@@ -91,10 +91,10 @@ func TestClient_Thresholds(t *testing.T) {
 		t.Errorf("unexpected threshold action: got %q, expected %q", getTestThreshold.Action, testAction)
 	}
 	if getTestThreshold.Interval != testInterval {
-		t.Errorf("unexpected threshold interval: got %q, expected %q", getTestThreshold.Interval, testInterval)
+		t.Errorf("unexpected threshold interval: got %d, expected %d", getTestThreshold.Interval, testInterval)
 	}
 	if getTestThreshold.Limit != testLimit {
-		t.Errorf("unexpected threshold limit: got %q, expected %q", getTestThreshold.Limit, testLimit)
+		t.Errorf("unexpected threshold limit: got %d, expected %d", getTestThreshold.Limit, testLimit)
 	}
 	if getTestThreshold.Name != testName {
 		t.Errorf("unexpected threshold name: got %q, expected %q", getTestThreshold.Name, testName)
@@ -106,7 +106,7 @@ func TestClient_Thresholds(t *testing.T) {
 		t.Errorf("unexpected threshold don't notify: got %t, should default to false", getTestThreshold.DontNotify)
 	}
 	if getTestThreshold.Duration != 0 {
-		t.Errorf("unexpected threshold duration: got %q, should default to 0", getTestThreshold.Duration)
+		t.Errorf("unexpected threshold duration: got %d, should default to 0", getTestThreshold.Duration)
 	}
 	if getTestThreshold.Enabled {
 		t.Errorf("unexpected threshold enabled: got %t, should default to false", getTestThreshold.Enabled)
@@ -146,10 +146,10 @@ func TestClient_Thresholds(t *testing.T) {
 		t.Errorf("unexpected threshold action: got %q, expected %q", updatedThreshold.Action, updatedtestAction)
 	}
 	if updatedThreshold.Interval != updatedTestInterval {
-		t.Errorf("unexpected threshold interval: got %q, expected %q", updatedThreshold.Interval, updatedTestInterval)
+		t.Errorf("unexpected threshold interval: got %d, expected %d", updatedThreshold.Interval, updatedTestInterval)
 	}
 	if updatedThreshold.Limit != updateTestLimit {
-		t.Errorf("unexpected threshold limit: got %q, expected %q", updatedThreshold.Limit, updateTestLimit)
+		t.Errorf("unexpected threshold limit: got %d, expected %d", updatedThreshold.Limit, updateTestLimit)
 	}
 	if updatedThreshold.Name != updatedTestName {
 		t.Errorf("unexpected threshold name: got %q, expected %q", updatedThreshold.Name, updatedTestName)
@@ -161,7 +161,7 @@ func TestClient_Thresholds(t *testing.T) {
 		t.Errorf("unexpected threshold don't notify: got %t, expected %t", updatedThreshold.DontNotify, updatedTestDontNotify)
 	}
 	if updatedThreshold.Duration != updatedTestDuration {
-		t.Errorf("unexpected threshold duration: got %q, expected %q", updatedThreshold.Duration, updatedTestDuration)
+		t.Errorf("unexpected threshold duration: got %d, expected %d", updatedThreshold.Duration, updatedTestDuration)
 	}
 	if updatedThreshold.Enabled != updatedTestEnabled {
 		t.Errorf("unexpected threshold enabled: got %t, expected %t", updatedThreshold.Enabled, updatedTestEnabled)
@@ -179,7 +179,7 @@ func TestClient_Thresholds(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(listedThresholds.Data) != 1 {
-		t.Errorf("unexpected threshold list length: got %q, expected %q", len(listedThresholds.Data), 1)
+		t.Errorf("unexpected threshold list length: got %d, expected %d", len(listedThresholds.Data), 1)
 	}
 	if listedThresholds.Data[0].ThresholdID != thresholdID {
 		t.Errorf("unexpected threshold id: got %q, expected %q", listedThresholds.Data[0].ThresholdID, thresholdID)

--- a/fastly/objectstorage/accesskeys/api_test.go
+++ b/fastly/objectstorage/accesskeys/api_test.go
@@ -60,7 +60,7 @@ func TestClient_AccessKey(t *testing.T) {
 		t.Errorf("unexpected AccessKey permission: got %q, expected %q", accessKey.Permission, TestAccessKeyPermission)
 	}
 	if len(accessKey.Buckets) != len(TestAccessKeyBuckets) {
-		t.Errorf("unexpected AccessKey buckets length: got %q, expected %q", len(accessKey.Buckets), len(TestAccessKeyBuckets))
+		t.Errorf("unexpected AccessKey buckets length: got %d, expected %d", len(accessKey.Buckets), len(TestAccessKeyBuckets))
 	}
 	if accessKey.Buckets[0] != TestAccessKeyBuckets[0] {
 		t.Errorf("unexpected AccessKey bucket: got %q, expected %q", accessKey.Buckets[0], TestAccessKeyBuckets[0])
@@ -95,7 +95,7 @@ func TestClient_AccessKey(t *testing.T) {
 		t.Errorf("unexpected AccessKey Permissions: got %q, expected %q", ak.Permission, accessKey.Permission)
 	}
 	if len(ak.Buckets) != len(accessKey.Buckets) {
-		t.Errorf("unexpected AccessKey Buckets length: got %q, expected %q", len(ak.Buckets), len(accessKey.Buckets))
+		t.Errorf("unexpected AccessKey Buckets length: got %d, expected %d", len(ak.Buckets), len(accessKey.Buckets))
 	}
 	if ak.Buckets[0] != accessKey.Buckets[0] {
 		t.Errorf("unexpected AccessKey Buckets contents: got %q, expected %q", ak.Buckets[0], accessKey.Buckets[0])

--- a/fastly/resource_test.go
+++ b/fastly/resource_test.go
@@ -305,7 +305,7 @@ func TestResourceJSONRoundtrip(t *testing.T) {
 		t.Errorf("ServiceID: got %q, want %q", got, want)
 	}
 	if got, want := *decoded.ServiceVersion, *r.ServiceVersion; got != want {
-		t.Errorf("ServiceVersion: got %q, want %q", got, want)
+		t.Errorf("ServiceVersion: got %d, want %d", got, want)
 	}
 	if got, want := decoded.CreatedAt, r.CreatedAt; got == nil || !got.Equal(*want) {
 		t.Errorf("CreatedAt: got %s, want %s", got, want)

--- a/fastly/service_version_test.go
+++ b/fastly/service_version_test.go
@@ -26,7 +26,7 @@ func TestClient_Versions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if *v.Number == 0 {
-		t.Errorf("bad number: %q", *v.Number)
+		t.Errorf("bad number: %d", *v.Number)
 	}
 	if *v.Comment != "test comment" {
 		t.Errorf("bad comment: %q", *v.Comment)
@@ -61,7 +61,7 @@ func TestClient_Versions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if *nv.Number == 0 {
-		t.Errorf("bad number: %q", *nv.Number)
+		t.Errorf("bad number: %d", *nv.Number)
 	}
 	if *nv.Comment != *v.Comment {
 		t.Errorf("bad comment: %q", *v.Comment)
@@ -137,7 +137,7 @@ func TestClient_Versions_Compute(t *testing.T) {
 		t.Fatal(err)
 	}
 	if *v.Number == 0 {
-		t.Errorf("bad number: %q", *v.Number)
+		t.Errorf("bad number: %d", *v.Number)
 	}
 	if *v.Comment != "test comment" {
 		t.Errorf("bad comment: %q", *v.Comment)
@@ -172,7 +172,7 @@ func TestClient_Versions_Compute(t *testing.T) {
 		t.Fatal(err)
 	}
 	if *nv.Number == 0 {
-		t.Errorf("bad number: %q", *nv.Number)
+		t.Errorf("bad number: %d", *nv.Number)
 	}
 	if *nv.Comment != *v.Comment {
 		t.Errorf("bad comment: %q", *v.Comment)

--- a/fastly/vcl_rate_limiter_test.go
+++ b/fastly/vcl_rate_limiter_test.go
@@ -58,7 +58,7 @@ func TestClient_ERL(t *testing.T) {
 		t.Errorf("bad name: %q", *e.Name)
 	}
 	if *e.RpsLimit != 20 {
-		t.Errorf("wrong value: %q", *e.RpsLimit)
+		t.Errorf("wrong value: %d", *e.RpsLimit)
 	}
 	if *e.Response.ERLContent != "Too many requests" {
 		t.Errorf("want 'Too many requests', got %q", *e.Response.ERLContent)
@@ -67,7 +67,7 @@ func TestClient_ERL(t *testing.T) {
 		t.Errorf("want 'application/json', got %q", *e.Response.ERLContentType)
 	}
 	if *e.Response.ERLStatus != http.StatusTooManyRequests {
-		t.Errorf("want 429, got %q", *e.Response.ERLStatus)
+		t.Errorf("want 429, got %d", *e.Response.ERLStatus)
 	}
 
 	// List

--- a/fastly/vcl_response_object_test.go
+++ b/fastly/vcl_response_object_test.go
@@ -54,7 +54,7 @@ func TestClient_ResponseObjects(t *testing.T) {
 		t.Errorf("bad name: %q", *ro.Name)
 	}
 	if *ro.Status != http.StatusOK {
-		t.Errorf("bad status: %q", *ro.Status)
+		t.Errorf("bad status: %d", *ro.Status)
 	}
 	if *ro.Response != "Ok" {
 		t.Errorf("bad response: %q", *ro.Response)
@@ -97,7 +97,7 @@ func TestClient_ResponseObjects(t *testing.T) {
 		t.Errorf("bad name: %q", *ro.Name)
 	}
 	if *ro.Status != *nro.Status {
-		t.Errorf("bad status: %q", *ro.Status)
+		t.Errorf("bad status: %d", *ro.Status)
 	}
 	if *ro.Response != *nro.Response {
 		t.Errorf("bad response: %q", *ro.Response)

--- a/fastly/vcl_snippets_test.go
+++ b/fastly/vcl_snippets_test.go
@@ -50,7 +50,7 @@ func TestClient_Snippets(t *testing.T) {
 		t.Errorf("incorrect Priority: want %v, have %q", defaultPriority, *cs.Priority)
 	}
 	if *cs.Dynamic != defaultDynamic {
-		t.Errorf("incorrect Dynamic: want %v, have %q", defaultDynamic, *cs.Dynamic)
+		t.Errorf("incorrect Dynamic: want %v, have %d", defaultDynamic, *cs.Dynamic)
 	}
 	if *cs.Content != vclContent {
 		t.Errorf("incorrect Content: want %v, have %q", vclContent, *cs.Content)
@@ -87,7 +87,7 @@ func TestClient_Snippets(t *testing.T) {
 		t.Errorf("incorrect Priority: want %v, have %q", priority, *cs.Priority)
 	}
 	if *cs.Dynamic != dynamic {
-		t.Errorf("incorrect Dynamic: want %v, have %q", dynamic, *cs.Dynamic)
+		t.Errorf("incorrect Dynamic: want %v, have %d", dynamic, *cs.Dynamic)
 	}
 	if cs.Content != nil {
 		t.Errorf("incorrect Content: want %v, have %q", "", *cs.Content) // dynamic snippets don't return content
@@ -162,7 +162,7 @@ func TestClient_Snippets(t *testing.T) {
 		t.Errorf("incorrect Priority: want %v, have %q", defaultPriority, *vs.Priority)
 	}
 	if *vs.Dynamic != defaultDynamic {
-		t.Errorf("incorrect Dynamic: want %v, have %q", defaultDynamic, *vs.Dynamic)
+		t.Errorf("incorrect Dynamic: want %v, have %d", defaultDynamic, *vs.Dynamic)
 	}
 	if *vs.Content != vclContent {
 		t.Errorf("incorrect Content: want %v, have %q", vclContent, *vs.Content)
@@ -221,7 +221,7 @@ func TestClient_Snippets(t *testing.T) {
 		t.Errorf("incorrect Priority: want %v, have %q", priority, *vs.Priority)
 	}
 	if *vs.Dynamic != defaultDynamic {
-		t.Errorf("incorrect Dynamic: want %v, have %q", defaultDynamic, *vs.Dynamic)
+		t.Errorf("incorrect Dynamic: want %v, have %d", defaultDynamic, *vs.Dynamic)
 	}
 	if *vs.Content != vclContentUpdated {
 		t.Errorf("incorrect Content: want %v, have %q", vclContentUpdated, *vs.Content)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/fastly/go-fastly/v17
 
-go 1.25.0
-
-toolchain go1.25.4
+go 1.26.5
 
 require (
 	github.com/dnaeon/go-vcr v1.2.0


### PR DESCRIPTION
### Change summary

Bump go.mod and CI (setup-go, golangci-lint) from 1.25 to 1.26.5. golangci-lint is pinned to v2.12.2 since the previous v2.10.1 pin predates 1.26 support.

Go 1.26's stricter go vet printf check now flags %q used with int-typed arguments (previously silently accepted), which broke `go test`.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?
