### PR TITLE
[CDTOOL-1698] Add Log Explorer and Insights API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Enhancements:
 
+- feat(observability): add Log Explorer and Insights API support ([#851](https://github.com/fastly/go-fastly/pull/851))
+
 ### Dependencies:
 
 ### Bug fixes:

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -123,6 +123,10 @@ var ErrMissingWorkspaceID = NewFieldError("WorkspaceID")
 // requires a "ListID" key, but one was not set.
 var ErrMissingListID = NewFieldError("ListID")
 
+// ErrMissingEnd is an error that is returned when an input struct
+// requires an "End" key, but one was not set.
+var ErrMissingEnd = NewFieldError("End")
+
 // ErrMissingEntries is an error that is returned when an input struct
 // requires a "Entries" key, but one was not set.
 var ErrMissingEntries = NewFieldError("Entries")
@@ -402,6 +406,10 @@ var ErrMissingUsername = NewFieldError("Username")
 // ErrMissingValue is an error that is returned when an input struct
 // requires a "Value" key, but one was not set.
 var ErrMissingValue = NewFieldError("Value")
+
+// ErrMissingVisualization is an error that is returned when an input struct
+// requires a "Visualization" key, but one was not set.
+var ErrMissingVisualization = NewFieldError("Visualization")
 
 // ErrMissingWAFActiveRule is an error that is returned when an input struct
 // requires a "Rules" key, but there needs to be at least one WAFActiveRule entry.

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -67,6 +67,10 @@ const alertTypeDoesNotMatch string = "alert type does not match"
 // but the alert is not of the correct type.
 var ErrInvalidType = NewFieldError("Type").Message(alertTypeDoesNotMatch)
 
+// ErrDuplicateLogExplorerFilter is an error that is returned when Log Explorer
+// filters contain the same field/operator combination with conflicting values.
+var ErrDuplicateLogExplorerFilter = NewFieldError("Filters").Message("duplicate field/operator combination with conflicting values")
+
 // ErrMaxExceededItems is an error that is returned when an input struct
 // specifies an "Items" key value exceeding the maximum allowed.
 var ErrMaxExceededItems = NewFieldError("Items").Message(batchModifyMaxExceeded)

--- a/fastly/errors.go
+++ b/fastly/errors.go
@@ -179,6 +179,10 @@ var ErrMissingRequestID = NewFieldError("RequestID")
 // requires a "Field" key, but one was not set.
 var ErrMissingField = NewFieldError("Field")
 
+// ErrMissingOperator is an error that is returned when an input struct
+// requires an "Operator" key, but one was not set.
+var ErrMissingOperator = NewFieldError("Operator")
+
 // ErrMissingContent is an error that is returned when an input struct
 // requires a "Content" key, but one was not set.
 var ErrMissingContent = NewFieldError("Content")

--- a/fastly/fixtures/observability_log_explorer/get.yaml
+++ b/fastly/fixtures/observability_log_explorer/get.yaml
@@ -1,0 +1,49 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/17.2.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/observability/log-explorer?end=2026-08-13T15%3A00%3A00Z&filter%5Bresponse_time%5D%5Bgte%5D=0&limit=5&service_id=kKJb5bOFI47uHeBVluGfX1&start=2026-08-12T15%3A00%3A00Z
+    method: GET
+  response:
+    body: '{"data":null,"meta":{"filters":{"start":"2026-08-12T15:00:00Z","end":"2026-08-13T15:00:00Z","limit":5,"service_id":"kKJb5bOFI47uHeBVluGfX1","field_filters":[{"field":"response_time","operator":"gte","value":0}]}}}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "213"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 13 Aug 2026 16:26:26 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "1539"
+      X-Served-By:
+      - cache-chi-kigq8000110-CHI, cache-lga21980-LGA
+      X-Timer:
+      - S1786638384.464923,VS0,VE1568
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/fixtures/observability_log_insights/get.yaml
+++ b/fastly/fixtures/observability_log_insights/get.yaml
@@ -1,0 +1,49 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/17.2.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/observability/log-insights?end=2026-08-13T15%3A00%3A00Z&limit=10&service_id=kKJb5bOFI47uHeBVluGfX1&start=2026-08-12T15%3A00%3A00Z&visualization=top-url-by-requests
+    method: GET
+  response:
+    body: '{"data":[],"meta":{"filters":{"domain_exact_match":true,"end":"2026-08-13T15:00:00Z","limit":10,"service_id":"kKJb5bOFI47uHeBVluGfX1","start":"2026-08-12T15:00:00Z"}}}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "167"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 13 Aug 2026 16:26:26 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "1669"
+      X-Served-By:
+      - cache-chi-kigq8000140-CHI, cache-lga21980-LGA
+      X-Timer:
+      - S1786638384.465022,VS0,VE1709
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/observability_log_explorer.go
+++ b/fastly/observability_log_explorer.go
@@ -163,6 +163,9 @@ func (c *Client) GetLogRecords(ctx context.Context, i *GetLogRecordsInput) (*Log
 
 	for _, filter := range i.Filters {
 		key := fmt.Sprintf("filter[%s][%s]", filter.Field, filter.Operator)
+		if value, ok := requestOptions.Params[key]; ok && value != filter.Value {
+			return nil, ErrDuplicateLogExplorerFilter
+		}
 		requestOptions.Params[key] = filter.Value
 	}
 	if i.Limit != nil {

--- a/fastly/observability_log_explorer.go
+++ b/fastly/observability_log_explorer.go
@@ -1,0 +1,214 @@
+package fastly
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// LogExplorerFilterField represents a field that can be filtered by the Log Explorer API.
+type LogExplorerFilterField string
+
+const (
+	// LogExplorerFilterFieldDomain filters by request domain.
+	LogExplorerFilterFieldDomain LogExplorerFilterField = "domain"
+	// LogExplorerFilterFieldRequestPath filters by request path.
+	LogExplorerFilterFieldRequestPath LogExplorerFilterField = "request_path"
+	// LogExplorerFilterFieldFastlyPOP filters by Fastly POP.
+	LogExplorerFilterFieldFastlyPOP LogExplorerFilterField = "fastly_pop"
+	// LogExplorerFilterFieldResponseTime filters by response time.
+	LogExplorerFilterFieldResponseTime LogExplorerFilterField = "response_time"
+	// LogExplorerFilterFieldResponseStatus filters by HTTP response status.
+	LogExplorerFilterFieldResponseStatus LogExplorerFilterField = "response_status"
+	// LogExplorerFilterFieldFastlyIsShield filters by whether the request was handled by a shield POP.
+	LogExplorerFilterFieldFastlyIsShield LogExplorerFilterField = "fastly_is_shield"
+	// LogExplorerFilterFieldFastlyIsEdge filters by whether the request was handled by an edge POP.
+	LogExplorerFilterFieldFastlyIsEdge LogExplorerFilterField = "fastly_is_edge"
+	// LogExplorerFilterFieldClientOSName filters by client operating system name.
+	LogExplorerFilterFieldClientOSName LogExplorerFilterField = "client_os_name"
+	// LogExplorerFilterFieldClientDeviceType filters by client device type.
+	LogExplorerFilterFieldClientDeviceType LogExplorerFilterField = "client_device_type"
+	// LogExplorerFilterFieldClientBrowserName filters by client browser name.
+	LogExplorerFilterFieldClientBrowserName LogExplorerFilterField = "client_browser_name"
+	// LogExplorerFilterFieldFastlyIsCacheHit filters by whether the request was fulfilled from cache.
+	LogExplorerFilterFieldFastlyIsCacheHit LogExplorerFilterField = "fastly_is_cache_hit"
+)
+
+// LogExplorerFilterFields is a list of supported Log Explorer filter fields.
+var LogExplorerFilterFields = []LogExplorerFilterField{
+	LogExplorerFilterFieldDomain,
+	LogExplorerFilterFieldRequestPath,
+	LogExplorerFilterFieldFastlyPOP,
+	LogExplorerFilterFieldResponseTime,
+	LogExplorerFilterFieldResponseStatus,
+	LogExplorerFilterFieldFastlyIsShield,
+	LogExplorerFilterFieldFastlyIsEdge,
+	LogExplorerFilterFieldClientOSName,
+	LogExplorerFilterFieldClientDeviceType,
+	LogExplorerFilterFieldClientBrowserName,
+	LogExplorerFilterFieldFastlyIsCacheHit,
+}
+
+// LogExplorerFilterOperator represents a comparison operator supported by the Log Explorer API.
+type LogExplorerFilterOperator string
+
+const (
+	// LogExplorerFilterOperatorEq performs an equality comparison.
+	LogExplorerFilterOperatorEq LogExplorerFilterOperator = "eq"
+	// LogExplorerFilterOperatorEndsWith performs a string suffix comparison.
+	LogExplorerFilterOperatorEndsWith LogExplorerFilterOperator = "ends-with"
+	// LogExplorerFilterOperatorIn matches values in a list.
+	LogExplorerFilterOperatorIn LogExplorerFilterOperator = "in"
+	// LogExplorerFilterOperatorNotIn excludes values in a list.
+	LogExplorerFilterOperatorNotIn LogExplorerFilterOperator = "not_in"
+	// LogExplorerFilterOperatorGT performs a greater-than comparison.
+	LogExplorerFilterOperatorGT LogExplorerFilterOperator = "gt"
+	// LogExplorerFilterOperatorGTE performs a greater-than-or-equal comparison.
+	LogExplorerFilterOperatorGTE LogExplorerFilterOperator = "gte"
+	// LogExplorerFilterOperatorLT performs a less-than comparison.
+	LogExplorerFilterOperatorLT LogExplorerFilterOperator = "lt"
+	// LogExplorerFilterOperatorLTE performs a less-than-or-equal comparison.
+	LogExplorerFilterOperatorLTE LogExplorerFilterOperator = "lte"
+)
+
+// LogExplorerFilterOperators is a list of supported Log Explorer filter operators.
+var LogExplorerFilterOperators = []LogExplorerFilterOperator{
+	LogExplorerFilterOperatorEq,
+	LogExplorerFilterOperatorEndsWith,
+	LogExplorerFilterOperatorIn,
+	LogExplorerFilterOperatorNotIn,
+	LogExplorerFilterOperatorGT,
+	LogExplorerFilterOperatorGTE,
+	LogExplorerFilterOperatorLT,
+	LogExplorerFilterOperatorLTE,
+}
+
+// LogExplorerFilter represents a filter supplied to the Log Explorer API.
+type LogExplorerFilter struct {
+	// Field is the log field to which the filter is applied.
+	Field LogExplorerFilterField
+	// Operator is the comparison operator used for the filter.
+	Operator LogExplorerFilterOperator
+	// Value is the value to compare against.
+	Value string
+}
+
+// LogRecord represents a sampled request log returned by the Log Explorer API.
+type LogRecord struct {
+	ClientASNumber        *uint64  `json:"client_as_number"`
+	ClientBrowserName     *string  `json:"client_browser_name"`
+	ClientBrowserVersion  *string  `json:"client_browser_version"`
+	ClientCountryCode     *string  `json:"client_country_code"`
+	ClientDeviceType      *string  `json:"client_device_type"`
+	ClientOSName          *string  `json:"client_os_name"`
+	ClientOSVersion       *string  `json:"client_os_version"`
+	ClientRegion          *string  `json:"client_region"`
+	CustomerID            *string  `json:"customer_id"`
+	FastlyPOP             *string  `json:"fastly_pop"`
+	IsCacheHit            *bool    `json:"is_cache_hit"`
+	IsEdge                *bool    `json:"is_edge"`
+	IsShield              *bool    `json:"is_shield"`
+	OriginHost            *string  `json:"origin_host"`
+	RequestHost           *string  `json:"request_host"`
+	RequestMethod         *string  `json:"request_method"`
+	RequestPath           *string  `json:"request_path"`
+	RequestProtocol       *string  `json:"request_protocol"`
+	ResponseBytesBody     *uint64  `json:"response_bytes_body"`
+	ResponseBytesHeader   *uint64  `json:"response_bytes_header"`
+	ResponseContentLength *uint64  `json:"response_content_length"`
+	ResponseContentType   *string  `json:"response_content_type"`
+	ResponseReason        *string  `json:"response_reason"`
+	ResponseState         *string  `json:"response_state"`
+	ResponseStatus        *int     `json:"response_status"`
+	ResponseTime          *float64 `json:"response_time"`
+	ResponseXCache        *string  `json:"response_x_cache"`
+	ServiceID             *string  `json:"service_id"`
+	Timestamp             *string  `json:"timestamp"`
+}
+
+// LogExplorerAppliedFilter represents a filter echoed by the Log Explorer API.
+type LogExplorerAppliedFilter struct {
+	Field    *LogExplorerFilterField    `json:"field"`
+	Operator *LogExplorerFilterOperator `json:"operator"`
+	Value    any                        `json:"value"`
+}
+
+// LogExplorerFilters represents the filters echoed in a Log Explorer response.
+type LogExplorerFilters struct {
+	End          *string                     `json:"end"`
+	FieldFilters []*LogExplorerAppliedFilter `json:"field_filters"`
+	Limit        *int                        `json:"limit"`
+	ServiceID    *string                     `json:"service_id"`
+	Start        *string                     `json:"start"`
+}
+
+// LogExplorerMeta represents metadata returned by the Log Explorer API.
+type LogExplorerMeta struct {
+	Filters    *LogExplorerFilters `json:"filters"`
+	NextCursor *string             `json:"next_cursor"`
+}
+
+// LogRecordsResponse represents the response from the Log Explorer API.
+type LogRecordsResponse struct {
+	Data []*LogRecord     `json:"data"`
+	Meta *LogExplorerMeta `json:"meta"`
+}
+
+// GetLogRecordsInput is used as input to the GetLogRecords function.
+type GetLogRecordsInput struct {
+	// End specifies the exclusive end time in RFC3339 format (required).
+	End string
+	// Filters limits returned records to logs matching all supplied filters.
+	Filters []LogExplorerFilter
+	// Limit is the maximum number of rows to return. The API defaults to 10 and limits the value to 100.
+	Limit *int
+	// NextCursor is the cursor returned by a previous request for the next page.
+	NextCursor *string
+	// ServiceID is the ID of the service for which log records should be returned (required).
+	ServiceID string
+	// Start specifies the inclusive start time in RFC3339 format (required).
+	Start string
+}
+
+// GetLogRecords retrieves sampled log records from the Log Explorer API.
+func (c *Client) GetLogRecords(ctx context.Context, i *GetLogRecordsInput) (*LogRecordsResponse, error) {
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+	if i.Start == "" {
+		return nil, ErrMissingStart
+	}
+	if i.End == "" {
+		return nil, ErrMissingEnd
+	}
+
+	requestOptions := CreateRequestOptions()
+	requestOptions.Params["service_id"] = i.ServiceID
+	requestOptions.Params["start"] = i.Start
+	requestOptions.Params["end"] = i.End
+
+	for _, filter := range i.Filters {
+		key := fmt.Sprintf("filter[%s][%s]", filter.Field, filter.Operator)
+		requestOptions.Params[key] = filter.Value
+	}
+	if i.Limit != nil {
+		requestOptions.Params["limit"] = strconv.Itoa(*i.Limit)
+	}
+	if i.NextCursor != nil {
+		requestOptions.Params["next_cursor"] = *i.NextCursor
+	}
+
+	resp, err := c.Get(ctx, ToSafeURL("observability", "log-explorer"), requestOptions)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result *LogRecordsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/fastly/observability_log_explorer.go
+++ b/fastly/observability_log_explorer.go
@@ -162,6 +162,13 @@ func (c *Client) GetLogRecords(ctx context.Context, i *GetLogRecordsInput) (*Log
 	requestOptions.Params["end"] = i.End
 
 	for _, filter := range i.Filters {
+		if filter.Field == "" {
+			return nil, ErrMissingField
+		}
+		if filter.Operator == "" {
+			return nil, ErrMissingOperator
+		}
+
 		key := fmt.Sprintf("filter[%s][%s]", filter.Field, filter.Operator)
 		if value, ok := requestOptions.Params[key]; ok && value != filter.Value {
 			return nil, ErrDuplicateLogExplorerFilter

--- a/fastly/observability_log_explorer.go
+++ b/fastly/observability_log_explorer.go
@@ -35,21 +35,6 @@ const (
 	LogExplorerFilterFieldFastlyIsCacheHit LogExplorerFilterField = "fastly_is_cache_hit"
 )
 
-// LogExplorerFilterFields is a list of supported Log Explorer filter fields.
-var LogExplorerFilterFields = []LogExplorerFilterField{
-	LogExplorerFilterFieldDomain,
-	LogExplorerFilterFieldRequestPath,
-	LogExplorerFilterFieldFastlyPOP,
-	LogExplorerFilterFieldResponseTime,
-	LogExplorerFilterFieldResponseStatus,
-	LogExplorerFilterFieldFastlyIsShield,
-	LogExplorerFilterFieldFastlyIsEdge,
-	LogExplorerFilterFieldClientOSName,
-	LogExplorerFilterFieldClientDeviceType,
-	LogExplorerFilterFieldClientBrowserName,
-	LogExplorerFilterFieldFastlyIsCacheHit,
-}
-
 // LogExplorerFilterOperator represents a comparison operator supported by the Log Explorer API.
 type LogExplorerFilterOperator string
 
@@ -71,18 +56,6 @@ const (
 	// LogExplorerFilterOperatorLTE performs a less-than-or-equal comparison.
 	LogExplorerFilterOperatorLTE LogExplorerFilterOperator = "lte"
 )
-
-// LogExplorerFilterOperators is a list of supported Log Explorer filter operators.
-var LogExplorerFilterOperators = []LogExplorerFilterOperator{
-	LogExplorerFilterOperatorEq,
-	LogExplorerFilterOperatorEndsWith,
-	LogExplorerFilterOperatorIn,
-	LogExplorerFilterOperatorNotIn,
-	LogExplorerFilterOperatorGT,
-	LogExplorerFilterOperatorGTE,
-	LogExplorerFilterOperatorLT,
-	LogExplorerFilterOperatorLTE,
-}
 
 // LogExplorerFilter represents a filter supplied to the Log Explorer API.
 type LogExplorerFilter struct {

--- a/fastly/observability_log_explorer_test.go
+++ b/fastly/observability_log_explorer_test.go
@@ -1,0 +1,108 @@
+package fastly
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_GetLogRecords_validation(t *testing.T) {
+	assert := assert.New(t)
+
+	_, err := TestClient.GetLogRecords(context.TODO(), &GetLogRecordsInput{
+		Start: "2026-08-12T15:00:00Z",
+		End:   "2026-08-13T15:00:00Z",
+	})
+	assert.ErrorIs(err, ErrMissingServiceID)
+
+	_, err = TestClient.GetLogRecords(context.TODO(), &GetLogRecordsInput{
+		ServiceID: TestDeliveryServiceID,
+		End:       "2026-08-13T15:00:00Z",
+	})
+	assert.ErrorIs(err, ErrMissingStart)
+
+	_, err = TestClient.GetLogRecords(context.TODO(), &GetLogRecordsInput{
+		ServiceID: TestDeliveryServiceID,
+		Start:     "2026-08-12T15:00:00Z",
+	})
+	assert.ErrorIs(err, ErrMissingEnd)
+}
+
+func TestClient_GetLogRecords(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	t.Parallel()
+
+	// NOTE: Update these to a recent time range when regenerating the test
+	// fixture, otherwise the data may be outside Log Explorer retention.
+	const (
+		start = "2026-08-12T15:00:00Z"
+		end   = "2026-08-13T15:00:00Z"
+	)
+	const limit = 5
+
+	var (
+		result *LogRecordsResponse
+		err    error
+	)
+	Record(t, "observability_log_explorer/get", func(c *Client) {
+		result, err = c.GetLogRecords(context.TODO(), &GetLogRecordsInput{
+			ServiceID: TestDeliveryServiceID,
+			Start:     start,
+			End:       end,
+			Limit:     ToPointer(limit),
+			Filters: []LogExplorerFilter{
+				{
+					Field:    LogExplorerFilterFieldResponseTime,
+					Operator: LogExplorerFilterOperatorGTE,
+					Value:    "0",
+				},
+			},
+		})
+	})
+	require.NoError(err)
+	require.NotNil(result)
+	require.NotNil(result.Meta)
+	require.NotNil(result.Meta.Filters)
+
+	filters := result.Meta.Filters
+	require.NotNil(filters.ServiceID)
+	require.NotNil(filters.Start)
+	require.NotNil(filters.End)
+	require.NotNil(filters.Limit)
+
+	assert.Equal(TestDeliveryServiceID, *filters.ServiceID)
+	assert.Equal(limit, *filters.Limit)
+	assertRFC3339TimeEqual(t, start, *filters.Start)
+	assertRFC3339TimeEqual(t, end, *filters.End)
+
+	require.Len(filters.FieldFilters, 1)
+	require.NotNil(filters.FieldFilters[0])
+	require.NotNil(filters.FieldFilters[0].Field)
+	require.NotNil(filters.FieldFilters[0].Operator)
+	assert.Equal(LogExplorerFilterFieldResponseTime, *filters.FieldFilters[0].Field)
+	assert.Equal(LogExplorerFilterOperatorGTE, *filters.FieldFilters[0].Operator)
+	assert.Equal(float64(0), filters.FieldFilters[0].Value)
+
+	assert.Nil(result.Meta.NextCursor)
+	assert.Nil(result.Data)
+}
+
+func assertRFC3339TimeEqual(t *testing.T, want, got string) {
+	t.Helper()
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	wantTime, err := time.Parse(time.RFC3339Nano, want)
+	require.NoError(err)
+
+	gotTime, err := time.Parse(time.RFC3339Nano, got)
+	require.NoError(err)
+
+	assert.True(gotTime.Equal(wantTime), "got time %q, want %q", got, want)
+}

--- a/fastly/observability_log_explorer_test.go
+++ b/fastly/observability_log_explorer_test.go
@@ -36,6 +36,32 @@ func TestClient_GetLogRecords_validation(t *testing.T) {
 		End:       "2026-08-13T15:00:00Z",
 		Filters: []LogExplorerFilter{
 			{
+				Operator: LogExplorerFilterOperatorGTE,
+				Value:    "0",
+			},
+		},
+	})
+	assert.ErrorIs(err, ErrMissingField)
+
+	_, err = TestClient.GetLogRecords(context.TODO(), &GetLogRecordsInput{
+		ServiceID: TestDeliveryServiceID,
+		Start:     "2026-08-12T15:00:00Z",
+		End:       "2026-08-13T15:00:00Z",
+		Filters: []LogExplorerFilter{
+			{
+				Field: LogExplorerFilterFieldResponseTime,
+				Value: "0",
+			},
+		},
+	})
+	assert.ErrorIs(err, ErrMissingOperator)
+
+	_, err = TestClient.GetLogRecords(context.TODO(), &GetLogRecordsInput{
+		ServiceID: TestDeliveryServiceID,
+		Start:     "2026-08-12T15:00:00Z",
+		End:       "2026-08-13T15:00:00Z",
+		Filters: []LogExplorerFilter{
+			{
 				Field:    LogExplorerFilterFieldResponseTime,
 				Operator: LogExplorerFilterOperatorGTE,
 				Value:    "0",

--- a/fastly/observability_log_explorer_test.go
+++ b/fastly/observability_log_explorer_test.go
@@ -29,6 +29,25 @@ func TestClient_GetLogRecords_validation(t *testing.T) {
 		Start:     "2026-08-12T15:00:00Z",
 	})
 	assert.ErrorIs(err, ErrMissingEnd)
+
+	_, err = TestClient.GetLogRecords(context.TODO(), &GetLogRecordsInput{
+		ServiceID: TestDeliveryServiceID,
+		Start:     "2026-08-12T15:00:00Z",
+		End:       "2026-08-13T15:00:00Z",
+		Filters: []LogExplorerFilter{
+			{
+				Field:    LogExplorerFilterFieldResponseTime,
+				Operator: LogExplorerFilterOperatorGTE,
+				Value:    "0",
+			},
+			{
+				Field:    LogExplorerFilterFieldResponseTime,
+				Operator: LogExplorerFilterOperatorGTE,
+				Value:    "1",
+			},
+		},
+	})
+	assert.ErrorIs(err, ErrDuplicateLogExplorerFilter)
 }
 
 func TestClient_GetLogRecords(t *testing.T) {

--- a/fastly/observability_log_insights.go
+++ b/fastly/observability_log_insights.go
@@ -43,25 +43,6 @@ const (
 	LogInsightsVisualizationTop503Responses LogInsightsVisualization = "top-503-responses"
 )
 
-// LogInsightsVisualizations is a list of supported Log Insights visualizations.
-var LogInsightsVisualizations = []LogInsightsVisualization{
-	LogInsightsVisualizationTopURLByBandwidth,
-	LogInsightsVisualizationBottomURLByCacheHitRatio,
-	LogInsightsVisualizationTopURLByCacheHitRatio,
-	LogInsightsVisualizationCountryStatistics,
-	LogInsightsVisualizationTopURLByDurationSum,
-	LogInsightsVisualizationTop4XXURLs,
-	LogInsightsVisualizationTop5XXURLs,
-	LogInsightsVisualizationTopURLByMisses,
-	LogInsightsVisualizationTopURLByRequests,
-	LogInsightsVisualizationTopBrowserByRequests,
-	LogInsightsVisualizationTopContentTypeByRequests,
-	LogInsightsVisualizationTopDeviceByRequests,
-	LogInsightsVisualizationTopOSByRequests,
-	LogInsightsVisualizationResponseStatusCodes,
-	LogInsightsVisualizationTop503Responses,
-}
-
 // LogInsightsDimensions represents the dimensions returned by the Log Insights API.
 type LogInsightsDimensions struct {
 	Browser        *string `json:"browser"`

--- a/fastly/observability_log_insights.go
+++ b/fastly/observability_log_insights.go
@@ -1,0 +1,192 @@
+package fastly
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// LogInsightsVisualization represents a visualization supported by the Log Insights API.
+type LogInsightsVisualization string
+
+const (
+	// LogInsightsVisualizationTopURLByBandwidth returns URLs using the most bandwidth.
+	LogInsightsVisualizationTopURLByBandwidth LogInsightsVisualization = "top-url-by-bandwidth"
+	// LogInsightsVisualizationBottomURLByCacheHitRatio returns URLs with the lowest cache hit ratio.
+	LogInsightsVisualizationBottomURLByCacheHitRatio LogInsightsVisualization = "bottom-url-by-cache-hit-ratio"
+	// LogInsightsVisualizationTopURLByCacheHitRatio returns URLs with the highest cache hit ratio.
+	LogInsightsVisualizationTopURLByCacheHitRatio LogInsightsVisualization = "top-url-by-cache-hit-ratio"
+	// LogInsightsVisualizationCountryStatistics returns country statistics.
+	LogInsightsVisualizationCountryStatistics LogInsightsVisualization = "country-statistics"
+	// LogInsightsVisualizationTopURLByDurationSum returns URLs with the highest cumulative response duration.
+	LogInsightsVisualizationTopURLByDurationSum LogInsightsVisualization = "top-url-by-duration-sum"
+	// LogInsightsVisualizationTop4XXURLs returns URLs with the most 4xx responses.
+	LogInsightsVisualizationTop4XXURLs LogInsightsVisualization = "top-4xx-urls"
+	// LogInsightsVisualizationTop5XXURLs returns URLs with the most 5xx responses.
+	LogInsightsVisualizationTop5XXURLs LogInsightsVisualization = "top-5xx-urls"
+	// LogInsightsVisualizationTopURLByMisses returns URLs with the most cache misses.
+	LogInsightsVisualizationTopURLByMisses LogInsightsVisualization = "top-url-by-misses"
+	// LogInsightsVisualizationTopURLByRequests returns URLs with the most requests.
+	LogInsightsVisualizationTopURLByRequests LogInsightsVisualization = "top-url-by-requests"
+	// LogInsightsVisualizationTopBrowserByRequests returns browsers generating the most requests.
+	LogInsightsVisualizationTopBrowserByRequests LogInsightsVisualization = "top-browser-by-requests"
+	// LogInsightsVisualizationTopContentTypeByRequests returns content types with the most requests.
+	LogInsightsVisualizationTopContentTypeByRequests LogInsightsVisualization = "top-content-type-by-requests"
+	// LogInsightsVisualizationTopDeviceByRequests returns device types generating the most requests.
+	LogInsightsVisualizationTopDeviceByRequests LogInsightsVisualization = "top-device-by-requests"
+	// LogInsightsVisualizationTopOSByRequests returns operating systems generating the most requests.
+	LogInsightsVisualizationTopOSByRequests LogInsightsVisualization = "top-os-by-requests"
+	// LogInsightsVisualizationResponseStatusCodes returns response status code statistics.
+	LogInsightsVisualizationResponseStatusCodes LogInsightsVisualization = "response-status-codes"
+	// LogInsightsVisualizationTop503Responses returns the most common 503 responses.
+	LogInsightsVisualizationTop503Responses LogInsightsVisualization = "top-503-responses"
+)
+
+// LogInsightsVisualizations is a list of supported Log Insights visualizations.
+var LogInsightsVisualizations = []LogInsightsVisualization{
+	LogInsightsVisualizationTopURLByBandwidth,
+	LogInsightsVisualizationBottomURLByCacheHitRatio,
+	LogInsightsVisualizationTopURLByCacheHitRatio,
+	LogInsightsVisualizationCountryStatistics,
+	LogInsightsVisualizationTopURLByDurationSum,
+	LogInsightsVisualizationTop4XXURLs,
+	LogInsightsVisualizationTop5XXURLs,
+	LogInsightsVisualizationTopURLByMisses,
+	LogInsightsVisualizationTopURLByRequests,
+	LogInsightsVisualizationTopBrowserByRequests,
+	LogInsightsVisualizationTopContentTypeByRequests,
+	LogInsightsVisualizationTopDeviceByRequests,
+	LogInsightsVisualizationTopOSByRequests,
+	LogInsightsVisualizationResponseStatusCodes,
+	LogInsightsVisualizationTop503Responses,
+}
+
+// LogInsightsDimensions represents the dimensions returned by the Log Insights API.
+type LogInsightsDimensions struct {
+	Browser        *string `json:"browser"`
+	BrowserVersion *string `json:"browser_version"`
+	ContentType    *string `json:"content_type"`
+	Country        *string `json:"country"`
+	Device         *string `json:"device"`
+	OS             *string `json:"os"`
+	Region         *string `json:"region"`
+	Response       *string `json:"response"`
+	StatusCode     *string `json:"status-code"`
+	URL            *string `json:"url"`
+}
+
+// LogInsightsValue represents the metrics returned for a Log Insights dimension.
+type LogInsightsValue struct {
+	AverageBandwidthBytes  *float64 `json:"average_bandwidth_bytes"`
+	AverageResponseTime    *float64 `json:"average_response_time"`
+	BandwidthPercentage    *float64 `json:"bandwidth_percentage"`
+	CacheHitRatio          *float64 `json:"cache_hit_ratio"`
+	CountryCHR             *float64 `json:"country_chr"`
+	CountryErrorRate       *float64 `json:"country_error_rate"`
+	CountryRequestRate     *float64 `json:"country_request_rate"`
+	MissRate               *float64 `json:"miss_rate"`
+	P95ResponseTime        *float64 `json:"p95_response_time"`
+	Rate                   *float64 `json:"rate"`
+	Rate503PerURL          *float64 `json:"503_rate_per_url"`
+	RatePerStatus          *float64 `json:"rate_per_status"`
+	RatePerURL             *float64 `json:"rate_per_url"`
+	RegionCHR              *float64 `json:"region_chr"`
+	RegionErrorRate        *float64 `json:"region_error_rate"`
+	RequestPercentage      *float64 `json:"request_percentage"`
+	ResponseTimePercentage *float64 `json:"response_time_percentage"`
+}
+
+// LogInsightsData represents a dimension and its associated values.
+type LogInsightsData struct {
+	Dimensions *LogInsightsDimensions `json:"dimensions"`
+	Values     []*LogInsightsValue    `json:"values"`
+}
+
+// LogInsightsFilters represents the filters echoed in a Log Insights response.
+type LogInsightsFilters struct {
+	DomainExactMatch *bool   `json:"domain_exact_match"`
+	End              *string `json:"end"`
+	Limit            *int    `json:"limit"`
+	ServiceID        *string `json:"service_id"`
+	Start            *string `json:"start"`
+}
+
+// LogInsightsMeta represents metadata returned by the Log Insights API.
+type LogInsightsMeta struct {
+	Filters *LogInsightsFilters `json:"filters"`
+}
+
+// LogInsightsResponse represents the response from the Log Insights API.
+type LogInsightsResponse struct {
+	Data []*LogInsightsData `json:"data"`
+	Meta *LogInsightsMeta   `json:"meta"`
+}
+
+// GetLogInsightsInput is used as input to the GetLogInsights function.
+type GetLogInsightsInput struct {
+	// Domain limits data to the specified request domain.
+	Domain *string
+	// DomainExactMatch determines whether Domain is treated as an exact match. The API defaults to true.
+	DomainExactMatch *bool
+	// End specifies the exclusive end time in RFC3339 format (required).
+	End string
+	// Limit is the maximum number of rows to return. The API defaults to 10 and limits the value to 100.
+	Limit *int
+	// POPs limits data to the supplied Fastly POP codes.
+	POPs []string
+	// ServiceID is the ID of the service for which insights should be returned (required).
+	ServiceID string
+	// Start specifies the inclusive start time in RFC3339 format (required).
+	Start string
+	// Visualization specifies the Log Insights visualization to return (required).
+	Visualization LogInsightsVisualization
+}
+
+// GetLogInsights retrieves statistics from sampled log records.
+func (c *Client) GetLogInsights(ctx context.Context, i *GetLogInsightsInput) (*LogInsightsResponse, error) {
+	if i.ServiceID == "" {
+		return nil, ErrMissingServiceID
+	}
+	if i.Start == "" {
+		return nil, ErrMissingStart
+	}
+	if i.End == "" {
+		return nil, ErrMissingEnd
+	}
+	if i.Visualization == "" {
+		return nil, ErrMissingVisualization
+	}
+
+	requestOptions := CreateRequestOptions()
+	requestOptions.Params["service_id"] = i.ServiceID
+	requestOptions.Params["start"] = i.Start
+	requestOptions.Params["end"] = i.End
+	requestOptions.Params["visualization"] = string(i.Visualization)
+
+	if i.Domain != nil {
+		requestOptions.Params["domain"] = *i.Domain
+	}
+	if i.DomainExactMatch != nil {
+		requestOptions.Params["domain_exact_match"] = strconv.FormatBool(*i.DomainExactMatch)
+	}
+	if i.Limit != nil {
+		requestOptions.Params["limit"] = strconv.Itoa(*i.Limit)
+	}
+	if len(i.POPs) > 0 {
+		requestOptions.Params["pops"] = strings.Join(i.POPs, ",")
+	}
+
+	resp, err := c.Get(ctx, ToSafeURL("observability", "log-insights"), requestOptions)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result *LogInsightsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/fastly/observability_log_insights_test.go
+++ b/fastly/observability_log_insights_test.go
@@ -1,0 +1,104 @@
+package fastly
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_GetLogInsights_validation(t *testing.T) {
+	assert := assert.New(t)
+
+	_, err := TestClient.GetLogInsights(context.TODO(), &GetLogInsightsInput{
+		Start:         "2026-08-12T15:00:00Z",
+		End:           "2026-08-13T15:00:00Z",
+		Visualization: LogInsightsVisualizationTopURLByRequests,
+	})
+	assert.ErrorIs(err, ErrMissingServiceID)
+
+	_, err = TestClient.GetLogInsights(context.TODO(), &GetLogInsightsInput{
+		ServiceID:     TestDeliveryServiceID,
+		End:           "2026-08-13T15:00:00Z",
+		Visualization: LogInsightsVisualizationTopURLByRequests,
+	})
+	assert.ErrorIs(err, ErrMissingStart)
+
+	_, err = TestClient.GetLogInsights(context.TODO(), &GetLogInsightsInput{
+		ServiceID:     TestDeliveryServiceID,
+		Start:         "2026-08-12T15:00:00Z",
+		Visualization: LogInsightsVisualizationTopURLByRequests,
+	})
+	assert.ErrorIs(err, ErrMissingEnd)
+
+	_, err = TestClient.GetLogInsights(context.TODO(), &GetLogInsightsInput{
+		ServiceID: TestDeliveryServiceID,
+		Start:     "2026-08-12T15:00:00Z",
+		End:       "2026-08-13T15:00:00Z",
+	})
+	assert.ErrorIs(err, ErrMissingVisualization)
+}
+
+func TestClient_GetLogInsights(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	t.Parallel()
+
+	// NOTE: Update these to a recent time range when regenerating the test
+	// fixture, otherwise the data may be outside Log Insights retention.
+	const (
+		start = "2026-08-12T15:00:00Z"
+		end   = "2026-08-13T15:00:00Z"
+	)
+	const limit = 10
+
+	var (
+		result *LogInsightsResponse
+		err    error
+	)
+	Record(t, "observability_log_insights/get", func(c *Client) {
+		result, err = c.GetLogInsights(context.TODO(), &GetLogInsightsInput{
+			ServiceID:     TestDeliveryServiceID,
+			Start:         start,
+			End:           end,
+			Limit:         ToPointer(limit),
+			Visualization: LogInsightsVisualizationTopURLByRequests,
+		})
+	})
+	require.NoError(err)
+	require.NotNil(result)
+	require.NotNil(result.Meta)
+	require.NotNil(result.Meta.Filters)
+	require.NotNil(result.Meta.Filters.ServiceID)
+	require.NotNil(result.Meta.Filters.Start)
+	require.NotNil(result.Meta.Filters.End)
+	require.NotNil(result.Meta.Filters.DomainExactMatch)
+	require.NotNil(result.Meta.Filters.Limit)
+
+	assert.Equal(TestDeliveryServiceID, *result.Meta.Filters.ServiceID)
+	assert.Equal(limit, *result.Meta.Filters.Limit)
+	assert.True(*result.Meta.Filters.DomainExactMatch)
+	assertRFC3339TimeEqual(t, start, *result.Meta.Filters.Start)
+	assertRFC3339TimeEqual(t, end, *result.Meta.Filters.End)
+
+	require.NotNil(result.Data)
+	assert.LessOrEqual(len(result.Data), limit)
+
+	for _, data := range result.Data {
+		require.NotNil(data)
+		require.NotNil(data.Dimensions)
+		require.NotNil(data.Dimensions.URL)
+		assert.NotEmpty(*data.Dimensions.URL)
+
+		require.NotNil(data.Values)
+		require.NotEmpty(data.Values)
+		for _, value := range data.Values {
+			require.NotNil(value)
+			require.NotNil(value.RequestPercentage)
+			assert.GreaterOrEqual(*value.RequestPercentage, float64(0))
+			assert.LessOrEqual(*value.RequestPercentage, float64(1))
+		}
+	}
+}

--- a/fastly/observability_log_insights_test.go
+++ b/fastly/observability_log_insights_test.go
@@ -84,21 +84,5 @@ func TestClient_GetLogInsights(t *testing.T) {
 	assertRFC3339TimeEqual(t, end, *result.Meta.Filters.End)
 
 	require.NotNil(result.Data)
-	assert.LessOrEqual(len(result.Data), limit)
-
-	for _, data := range result.Data {
-		require.NotNil(data)
-		require.NotNil(data.Dimensions)
-		require.NotNil(data.Dimensions.URL)
-		assert.NotEmpty(*data.Dimensions.URL)
-
-		require.NotNil(data.Values)
-		require.NotEmpty(data.Values)
-		for _, value := range data.Values {
-			require.NotNil(value)
-			require.NotNil(value.RequestPercentage)
-			assert.GreaterOrEqual(*value.RequestPercentage, float64(0))
-			assert.LessOrEqual(*value.RequestPercentage, float64(1))
-		}
-	}
+	assert.Empty(result.Data)
 }


### PR DESCRIPTION
### Change summary

Adds go-fastly client and VCR test support for the Log Explorer and Log Insights read-only endpoints.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?
