### PR TITLE
[CDTOOL-1699] Improve Log Explorer and Insights consumer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements:
 
 - feat(observability): add Log Explorer and Insights API support ([#851](https://github.com/fastly/go-fastly/pull/851))
+- feat(observability): expose supported values and complete Insights response filters ([#853](https://github.com/fastly/go-fastly/pull/853))
 
 ### Dependencies:
 

--- a/fastly/fixtures/observability_log_insights/get.yaml
+++ b/fastly/fixtures/observability_log_insights/get.yaml
@@ -7,21 +7,21 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.2.0 (+github.com/fastly/go-fastly; go1.26.5)
-    url: https://api.fastly.com/observability/log-insights?end=2026-08-13T15%3A00%3A00Z&limit=10&service_id=kKJb5bOFI47uHeBVluGfX1&start=2026-08-12T15%3A00%3A00Z&visualization=top-url-by-requests
+    url: https://api.fastly.com/observability/log-insights?domain=example.com&domain_exact_match=true&end=2026-08-13T15%3A00%3A00Z&limit=10&pops=IAD%2CDFW&service_id=kKJb5bOFI47uHeBVluGfX1&start=2026-08-12T15%3A00%3A00Z&visualization=top-url-by-requests
     method: GET
   response:
-    body: '{"data":[],"meta":{"filters":{"domain_exact_match":true,"end":"2026-08-13T15:00:00Z","limit":10,"service_id":"kKJb5bOFI47uHeBVluGfX1","start":"2026-08-12T15:00:00Z"}}}'
+    body: '{"data":[],"meta":{"filters":{"domain":"example.com","domain_exact_match":true,"end":"2026-08-13T15:00:00Z","limit":10,"pops":["DFW","IAD"],"service_id":"kKJb5bOFI47uHeBVluGfX1","start":"2026-08-12T15:00:00Z"}}}'
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "167"
+      - "211"
       Content-Type:
       - application/json
       Date:
-      - Thu, 13 Aug 2026 16:26:26 GMT
+      - Mon, 17 Aug 2026 17:38:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -39,11 +39,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "1669"
+      - "2967"
       X-Served-By:
-      - cache-chi-kigq8000140-CHI, cache-lga21980-LGA
+      - cache-chi-klot8100090-CHI, cache-lga21963-LGA
       X-Timer:
-      - S1786638384.465022,VS0,VE1709
+      - S1786988317.979756,VS0,VE2998
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/observability_log_explorer.go
+++ b/fastly/observability_log_explorer.go
@@ -35,6 +35,21 @@ const (
 	LogExplorerFilterFieldFastlyIsCacheHit LogExplorerFilterField = "fastly_is_cache_hit"
 )
 
+// LogExplorerFilterFields is a list of supported Log Explorer filter fields.
+var LogExplorerFilterFields = []LogExplorerFilterField{
+	LogExplorerFilterFieldDomain,
+	LogExplorerFilterFieldRequestPath,
+	LogExplorerFilterFieldFastlyPOP,
+	LogExplorerFilterFieldResponseTime,
+	LogExplorerFilterFieldResponseStatus,
+	LogExplorerFilterFieldFastlyIsShield,
+	LogExplorerFilterFieldFastlyIsEdge,
+	LogExplorerFilterFieldClientOSName,
+	LogExplorerFilterFieldClientDeviceType,
+	LogExplorerFilterFieldClientBrowserName,
+	LogExplorerFilterFieldFastlyIsCacheHit,
+}
+
 // LogExplorerFilterOperator represents a comparison operator supported by the Log Explorer API.
 type LogExplorerFilterOperator string
 
@@ -56,6 +71,18 @@ const (
 	// LogExplorerFilterOperatorLTE performs a less-than-or-equal comparison.
 	LogExplorerFilterOperatorLTE LogExplorerFilterOperator = "lte"
 )
+
+// LogExplorerFilterOperators is a list of supported Log Explorer filter operators.
+var LogExplorerFilterOperators = []LogExplorerFilterOperator{
+	LogExplorerFilterOperatorEq,
+	LogExplorerFilterOperatorEndsWith,
+	LogExplorerFilterOperatorIn,
+	LogExplorerFilterOperatorNotIn,
+	LogExplorerFilterOperatorGT,
+	LogExplorerFilterOperatorGTE,
+	LogExplorerFilterOperatorLT,
+	LogExplorerFilterOperatorLTE,
+}
 
 // LogExplorerFilter represents a filter supplied to the Log Explorer API.
 type LogExplorerFilter struct {

--- a/fastly/observability_log_insights.go
+++ b/fastly/observability_log_insights.go
@@ -43,6 +43,25 @@ const (
 	LogInsightsVisualizationTop503Responses LogInsightsVisualization = "top-503-responses"
 )
 
+// LogInsightsVisualizations is a list of supported Log Insights visualizations.
+var LogInsightsVisualizations = []LogInsightsVisualization{
+	LogInsightsVisualizationTopURLByBandwidth,
+	LogInsightsVisualizationBottomURLByCacheHitRatio,
+	LogInsightsVisualizationTopURLByCacheHitRatio,
+	LogInsightsVisualizationCountryStatistics,
+	LogInsightsVisualizationTopURLByDurationSum,
+	LogInsightsVisualizationTop4XXURLs,
+	LogInsightsVisualizationTop5XXURLs,
+	LogInsightsVisualizationTopURLByMisses,
+	LogInsightsVisualizationTopURLByRequests,
+	LogInsightsVisualizationTopBrowserByRequests,
+	LogInsightsVisualizationTopContentTypeByRequests,
+	LogInsightsVisualizationTopDeviceByRequests,
+	LogInsightsVisualizationTopOSByRequests,
+	LogInsightsVisualizationResponseStatusCodes,
+	LogInsightsVisualizationTop503Responses,
+}
+
 // LogInsightsDimensions represents the dimensions returned by the Log Insights API.
 type LogInsightsDimensions struct {
 	Browser        *string `json:"browser"`
@@ -86,11 +105,13 @@ type LogInsightsData struct {
 
 // LogInsightsFilters represents the filters echoed in a Log Insights response.
 type LogInsightsFilters struct {
-	DomainExactMatch *bool   `json:"domain_exact_match"`
-	End              *string `json:"end"`
-	Limit            *int    `json:"limit"`
-	ServiceID        *string `json:"service_id"`
-	Start            *string `json:"start"`
+	Domain           *string  `json:"domain"`
+	DomainExactMatch *bool    `json:"domain_exact_match"`
+	End              *string  `json:"end"`
+	Limit            *int     `json:"limit"`
+	POPs             []string `json:"pops"`
+	ServiceID        *string  `json:"service_id"`
+	Start            *string  `json:"start"`
 }
 
 // LogInsightsMeta represents metadata returned by the Log Insights API.

--- a/fastly/observability_log_insights_test.go
+++ b/fastly/observability_log_insights_test.go
@@ -49,8 +49,9 @@ func TestClient_GetLogInsights(t *testing.T) {
 	// NOTE: Update these to a recent time range when regenerating the test
 	// fixture, otherwise the data may be outside Log Insights retention.
 	const (
-		start = "2026-08-12T15:00:00Z"
-		end   = "2026-08-13T15:00:00Z"
+		start  = "2026-08-12T15:00:00Z"
+		end    = "2026-08-13T15:00:00Z"
+		domain = "example.com"
 	)
 	const limit = 10
 
@@ -60,28 +61,35 @@ func TestClient_GetLogInsights(t *testing.T) {
 	)
 	Record(t, "observability_log_insights/get", func(c *Client) {
 		result, err = c.GetLogInsights(context.TODO(), &GetLogInsightsInput{
-			ServiceID:     TestDeliveryServiceID,
-			Start:         start,
-			End:           end,
-			Limit:         ToPointer(limit),
-			Visualization: LogInsightsVisualizationTopURLByRequests,
+			ServiceID:        TestDeliveryServiceID,
+			Start:            start,
+			End:              end,
+			Domain:           ToPointer(domain),
+			DomainExactMatch: ToPointer(true),
+			Limit:            ToPointer(limit),
+			POPs:             []string{"IAD", "DFW"},
+			Visualization:    LogInsightsVisualizationTopURLByRequests,
 		})
 	})
 	require.NoError(err)
 	require.NotNil(result)
 	require.NotNil(result.Meta)
 	require.NotNil(result.Meta.Filters)
-	require.NotNil(result.Meta.Filters.ServiceID)
-	require.NotNil(result.Meta.Filters.Start)
-	require.NotNil(result.Meta.Filters.End)
-	require.NotNil(result.Meta.Filters.DomainExactMatch)
-	require.NotNil(result.Meta.Filters.Limit)
+	filters := result.Meta.Filters
+	require.NotNil(filters.Domain)
+	require.NotNil(filters.DomainExactMatch)
+	require.NotNil(filters.End)
+	require.NotNil(filters.Limit)
+	require.NotNil(filters.ServiceID)
+	require.NotNil(filters.Start)
 
-	assert.Equal(TestDeliveryServiceID, *result.Meta.Filters.ServiceID)
-	assert.Equal(limit, *result.Meta.Filters.Limit)
-	assert.True(*result.Meta.Filters.DomainExactMatch)
-	assertRFC3339TimeEqual(t, start, *result.Meta.Filters.Start)
-	assertRFC3339TimeEqual(t, end, *result.Meta.Filters.End)
+	assert.Equal(domain, *filters.Domain)
+	assert.True(*filters.DomainExactMatch)
+	assertRFC3339TimeEqual(t, end, *filters.End)
+	assert.Equal(limit, *filters.Limit)
+	assert.ElementsMatch([]string{"IAD", "DFW"}, filters.POPs)
+	assert.Equal(TestDeliveryServiceID, *filters.ServiceID)
+	assertRFC3339TimeEqual(t, start, *filters.Start)
 
 	require.NotNil(result.Data)
 	assert.Empty(result.Data)


### PR DESCRIPTION
### Change summary

Follow-up to #851.

A live Log Insights request using `domain` and `pops` confirmed that both values are echoed in `meta.filters`, but the current `LogInsightsFilters` response model does not expose them. This change adds those response fields so consumers can access the complete metadata returned by the API.

It also exports the supported Log Explorer filter fields/operators and Log Insights visualizations. This allows consumers such as the CLI to build validated flag choices and a better CLI experience without duplicating the supported API values locally.

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?

### User Impact

N/A