### PR TITLE
[CDTOOL-1722] Add support for `signal_payload` typed client identifiers for Rate Limit Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - feat(observability): add Log Explorer and Insights API support ([#851](https://github.com/fastly/go-fastly/pull/851))
 - feat(observability): expose supported values and complete Insights response filters ([#853](https://github.com/fastly/go-fastly/pull/853))
+- feat(ngwaf/rules): add support for the `signal_payload` type of `client_identifier` in NGWAF Rate Limit rules ([#854](https://github.com/fastly/go-fastly/pull/854))
 
 ### Dependencies:
 

--- a/fastly/ngwaf/v1/rules/api_create.go
+++ b/fastly/ngwaf/v1/rules/api_create.go
@@ -157,6 +157,8 @@ type CreateClientIdentifier struct {
 	Name *string `json:"name,omitempty"`
 	// Type is the type of the client identifier
 	Type *string `json:"type"`
+	// Signal is the signal associated with the client identifier.
+	Signal string `json:"signal,omitempty"`
 }
 
 // Private structs to ensure correct condition types.

--- a/fastly/ngwaf/v1/rules/api_marshal_test.go
+++ b/fastly/ngwaf/v1/rules/api_marshal_test.go
@@ -89,3 +89,78 @@ func TestConditionItem_Marshal_DoesNotEmitFieldsWrapper(t *testing.T) {
 	assert.Equal("equals", m["operator"])
 	assert.Equal("1.2.3.4", m["value"])
 }
+
+func TestCreateClientIdentifier_Marshal_SignalPayload(t *testing.T) {
+	assert := require.New(t)
+
+	typ := "signal_payload"
+	ci := &CreateClientIdentifier{
+		Type:   &typ,
+		Signal: "site.test",
+	}
+
+	b, err := json.Marshal(ci)
+	assert.NoError(err)
+
+	var m map[string]any
+	assert.NoError(json.Unmarshal(b, &m))
+
+	assert.Equal("signal_payload", m["type"])
+	assert.Equal("site.test", m["signal"])
+	_, hasKey := m["key"]
+	_, hasName := m["name"]
+	assert.False(hasKey, "signal_payload identifier must not emit key")
+	assert.False(hasName, "signal_payload identifier must not emit name")
+}
+
+func TestCreateClientIdentifier_Marshal_OmitsSignalForOtherTypes(t *testing.T) {
+	assert := require.New(t)
+
+	typ := "ip"
+	ci := &CreateClientIdentifier{Type: &typ}
+
+	b, err := json.Marshal(ci)
+	assert.NoError(err)
+
+	var m map[string]any
+	assert.NoError(json.Unmarshal(b, &m))
+
+	_, hasSignal := m["signal"]
+	assert.False(hasSignal, "ip identifier must not emit an empty signal field")
+}
+
+func TestUpdateClientIdentifier_Marshal_SignalPayload(t *testing.T) {
+	assert := require.New(t)
+
+	typ := "signal_payload"
+	ci := &UpdateClientIdentifier{
+		Type:   &typ,
+		Signal: "site.test",
+	}
+
+	b, err := json.Marshal(ci)
+	assert.NoError(err)
+
+	var m map[string]any
+	assert.NoError(json.Unmarshal(b, &m))
+
+	assert.Equal("signal_payload", m["type"])
+	assert.Equal("site.test", m["signal"])
+}
+
+func TestUpdateClientIdentifier_Marshal_OmitsSignalForOtherTypes(t *testing.T) {
+	assert := require.New(t)
+
+	typ := "request_header"
+	name := "X-Test"
+	ci := &UpdateClientIdentifier{Type: &typ, Name: &name}
+
+	b, err := json.Marshal(ci)
+	assert.NoError(err)
+
+	var m map[string]any
+	assert.NoError(json.Unmarshal(b, &m))
+
+	_, hasSignal := m["signal"]
+	assert.False(hasSignal, "request_header identifier must not emit an empty signal field")
+}

--- a/fastly/ngwaf/v1/rules/api_response.go
+++ b/fastly/ngwaf/v1/rules/api_response.go
@@ -144,6 +144,8 @@ type ClientIdentifier struct {
 	Name string `json:"name"`
 	// Type is the type of identifier.
 	Type string `json:"type"`
+	// Signal is the signal associated with the client identifier.
+	Signal string `json:"signal"`
 }
 
 // Rule represents the complete configuration of a WAF rule.

--- a/fastly/ngwaf/v1/rules/api_test.go
+++ b/fastly/ngwaf/v1/rules/api_test.go
@@ -1431,6 +1431,188 @@ func runRateLimitRuleTest(t *testing.T, scopeType scope.Type, appliesToID string
 	assert.Contains(updatedMultivalConditions[0].Conditions, ConditionMul{Type: conditionType, Field: updatedField10, Operator: updatedOperator10, Value: updatedValue10})
 }
 
+func TestClient_Rate_Limit_Rule_SignalPayloadClientIdentifier_WorkspaceScope(t *testing.T) {
+	runRateLimitSignalPayloadClientIdentifierTest(t, scope.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
+}
+
+// runRateLimitSignalPayloadClientIdentifierTest exercises the "signal_payload"
+// rate-limit client identifier variant end-to-end (Create, Get, Update), to
+// guard against the SDK silently dropping the identifier's `signal` field.
+func runRateLimitSignalPayloadClientIdentifierTest(t *testing.T, scopeType scope.Type, appliesToID string) {
+	assert := require.New(t)
+
+	var err error
+
+	ruleType := "rate_limit"
+	description := "rate_limit_signal_payload_client_identifier_test"
+	groupOperator := "all"
+	enabled := true
+
+	actionType := "block_signal"
+
+	field1 := "ip"
+	operator1 := "equals"
+	value1 := "127.0.0.1"
+
+	testSignalName := "Rate limit signal payload identifier test " + string(scopeType)
+	testDescription := "This is a description"
+
+	// Create the signal referenced by both the rate limit and the
+	// signal_payload client identifier.
+	var signal *signals.Signal
+	fastly.Record(t, fmt.Sprintf("%s_rate_limit_signal_client_identifier_create_signal", scopeType), func(c *fastly.Client) {
+		signal, err = signals.Create(context.TODO(), c, &signals.CreateInput{
+			Description: fastly.ToPointer(testDescription),
+			Name:        fastly.ToPointer(testSignalName),
+			Scope: &scope.Scope{
+				Type:      scopeType,
+				AppliesTo: []string{appliesToID},
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	threshold := 1
+	interval := 60
+	duration := 300
+	clientIdentifierType := "signal_payload"
+
+	// Create a rate-limit rule whose client identifier is a signal_payload.
+	var rule *Rule
+	fastly.Record(t, fmt.Sprintf("%s_rate_limit_signal_client_identifier_create_rule", scopeType), func(c *fastly.Client) {
+		rule, err = Create(context.TODO(), c, &CreateInput{
+			Scope: &scope.Scope{
+				Type:      scopeType,
+				AppliesTo: []string{appliesToID},
+			},
+			Type:          &ruleType,
+			Description:   &description,
+			GroupOperator: &groupOperator,
+			Enabled:       &enabled,
+			RateLimit: &CreateRateLimit{
+				Signal:    &signal.ReferenceID,
+				Threshold: &threshold,
+				Interval:  &interval,
+				Duration:  &duration,
+				ClientIdentifiers: []*CreateClientIdentifier{
+					{
+						Type:   &clientIdentifierType,
+						Signal: signal.ReferenceID,
+					},
+				},
+			},
+			Actions: []*CreateAction{
+				{
+					Type:   &actionType,
+					Signal: &signal.ReferenceID,
+				},
+			},
+			Conditions: []*CreateCondition{
+				{
+					Field:    &field1,
+					Operator: &operator1,
+					Value:    &value1,
+				},
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure we delete the test rule and signal at the end.
+	defer func() {
+		fastly.Record(t, fmt.Sprintf("%s_rate_limit_signal_client_identifier_delete_rule", scopeType), func(c *fastly.Client) {
+			err = Delete(context.TODO(), c, &DeleteInput{
+				RuleID: fastly.ToPointer(rule.RuleID),
+				Scope: &scope.Scope{
+					Type:      scopeType,
+					AppliesTo: []string{appliesToID},
+				},
+			})
+		})
+		if err != nil {
+			t.Errorf("error during rule cleanup: %v", err)
+		}
+		fastly.Record(t, fmt.Sprintf("%s_rate_limit_signal_client_identifier_delete_signal", scopeType), func(c *fastly.Client) {
+			err = signals.Delete(context.TODO(), c, &signals.DeleteInput{
+				Scope: &scope.Scope{
+					Type:      scopeType,
+					AppliesTo: []string{appliesToID},
+				},
+				SignalID: fastly.ToPointer(signal.SignalID),
+			})
+		})
+		if err != nil {
+			t.Errorf("error during signal cleanup: %v", err)
+		}
+	}()
+
+	assert.Len(rule.RateLimit.ClientIdentifiers, 1)
+	assert.Equal(clientIdentifierType, rule.RateLimit.ClientIdentifiers[0].Type)
+	assert.Equal(signal.ReferenceID, rule.RateLimit.ClientIdentifiers[0].Signal)
+	assert.Empty(rule.RateLimit.ClientIdentifiers[0].Key)
+	assert.Empty(rule.RateLimit.ClientIdentifiers[0].Name)
+
+	// Get the rule and confirm the signal_payload identifier round-trips.
+	var fetched *Rule
+	fastly.Record(t, fmt.Sprintf("%s_rate_limit_signal_client_identifier_get_rule", scopeType), func(c *fastly.Client) {
+		fetched, err = Get(context.TODO(), c, &GetInput{
+			RuleID: fastly.ToPointer(rule.RuleID),
+			Scope: &scope.Scope{
+				Type:      scopeType,
+				AppliesTo: []string{appliesToID},
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(fetched.RateLimit.ClientIdentifiers, 1)
+	assert.Equal(clientIdentifierType, fetched.RateLimit.ClientIdentifiers[0].Type)
+	assert.Equal(signal.ReferenceID, fetched.RateLimit.ClientIdentifiers[0].Signal)
+
+	// Update the rule, keeping the signal_payload identifier, and confirm it
+	// still round-trips through Update().
+	updatedThreshold := 2
+	updatedInterval := 600
+	updatedDuration := 600
+
+	var updatedRule *Rule
+	fastly.Record(t, fmt.Sprintf("%s_rate_limit_signal_client_identifier_update_rule", scopeType), func(c *fastly.Client) {
+		updatedRule, err = Update(context.TODO(), c, &UpdateInput{
+			Scope: &scope.Scope{
+				Type:      scopeType,
+				AppliesTo: []string{appliesToID},
+			},
+			RuleID: fastly.ToPointer(rule.RuleID),
+			RateLimit: &UpdateRateLimit{
+				Signal:    &signal.ReferenceID,
+				Threshold: &updatedThreshold,
+				Interval:  &updatedInterval,
+				Duration:  &updatedDuration,
+				ClientIdentifiers: []*UpdateClientIdentifier{
+					{
+						Type:   &clientIdentifierType,
+						Signal: signal.ReferenceID,
+					},
+				},
+			},
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(updatedThreshold, updatedRule.RateLimit.Threshold)
+	assert.Len(updatedRule.RateLimit.ClientIdentifiers, 1)
+	assert.Equal(clientIdentifierType, updatedRule.RateLimit.ClientIdentifiers[0].Type)
+	assert.Equal(signal.ReferenceID, updatedRule.RateLimit.ClientIdentifiers[0].Signal)
+}
+
 func TestClient_Deception_Rule_WorkspaceScope(t *testing.T) {
 	runDeceptionRuleTest(t, scope.ScopeTypeWorkspace, fastly.TestNGWAFWorkspaceID)
 }

--- a/fastly/ngwaf/v1/rules/api_update.go
+++ b/fastly/ngwaf/v1/rules/api_update.go
@@ -159,6 +159,8 @@ type UpdateClientIdentifier struct {
 	Name *string `json:"name,omitempty"`
 	// Type is the type of the client identifier
 	Type *string `json:"type"`
+	// Signal is the signal associated with the client identifier.
+	Signal string `json:"signal,omitempty"`
 }
 
 // Private structs to ensure correct condition types.

--- a/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_create_rule.yaml
+++ b/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_create_rule.yaml
@@ -1,0 +1,52 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"actions":[{"signal":"site.rate-limit-signal-payload-identifier-test-workspace","type":"block_signal"}],"conditions":[{"type":"single","field":"ip","operator":"equals","value":"127.0.0.1"}],"description":"rate_limit_signal_payload_client_identifier_test","enabled":true,"group_operator":"all","rate_limit":{"client_identifiers":[{"type":"signal_payload","signal":"site.rate-limit-signal-payload-identifier-test-workspace"}],"duration":300,"interval":60,"signal":"site.rate-limit-signal-payload-identifier-test-workspace","threshold":1},"scope":{"type":"workspace","applies_to":["Am2qjXkgamuYp3u54rQkLD"]},"type":"rate_limit"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/17.2.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ngwaf/v1/workspaces/Am2qjXkgamuYp3u54rQkLD/rules
+    method: POST
+  response:
+    body: |
+      {"id":"6a8721b5e286caf0a279a4b4","type":"rate_limit","scope":{"type":"workspace","applies_to":["Am2qjXkgamuYp3u54rQkLD"]},"enabled":true,"description":"rate_limit_signal_payload_client_identifier_test","group_operator":"all","conditions":[{"type":"single","field":"ip","operator":"equals","value":"127.0.0.1"}],"actions":[{"type":"block_signal","signal":"site.rate-limit-signal-payload-identifier-test-workspace"}],"rate_limit":{"signal":"site.rate-limit-signal-payload-identifier-test-workspace","threshold":1,"interval":60,"duration":300,"client_identifiers":[{"type":"signal_payload","signal":"site.rate-limit-signal-payload-identifier-test-workspace"}]},"created_at":"2026-08-20T15:48:05Z","created_by":"rcarillo+devex@fastly.com","updated_at":"2026-08-20T15:48:05Z","customer_id":"4dOhK7xEkULiabovMyhRBu"}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "811"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 Aug 2026 15:48:05 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "609"
+      X-Served-By:
+      - cache-chi-klot8100132-CHI, cache-ewr-kewr1740077-EWR
+      X-Timer:
+      - S1787240885.636888,VS0,VE639
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_create_signal.yaml
+++ b/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_create_signal.yaml
@@ -1,0 +1,53 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"description":"This is a description","name":"Rate limit signal payload
+      identifier test workspace"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/17.2.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ngwaf/v1/workspaces/Am2qjXkgamuYp3u54rQkLD/signals
+    method: POST
+  response:
+    body: |
+      {"id":"KxdApFNOJuvA2rxXv0jQHc","reference_id":"site.rate-limit-signal-payload-identifier-test-workspace","name":"Rate limit signal payload identifier test workspace","description":"This is a description","created_at":"2026-08-20T15:48:04Z","created_by":"rcarillo+devex@fastly.com","updated_at":"2026-08-20T15:48:04Z","scope":{"type":"workspace","applies_to":["Am2qjXkgamuYp3u54rQkLD"]},"customer_id":"4dOhK7xEkULiabovMyhRBu"}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "426"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 Aug 2026 15:48:04 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "3300"
+      X-Served-By:
+      - cache-chi-kigq8000166-CHI, cache-ewr-kewr1740077-EWR
+      X-Timer:
+      - S1787240881.264677,VS0,VE3340
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_delete_rule.yaml
+++ b/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_delete_rule.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/17.2.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ngwaf/v1/workspaces/Am2qjXkgamuYp3u54rQkLD/rules/6a8721b5e286caf0a279a4b4
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 Aug 2026 15:48:07 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "565"
+      X-Served-By:
+      - cache-chi-kigq8000169-CHI, cache-ewr-kewr1740077-EWR
+      X-Timer:
+      - S1787240887.522330,VS0,VE597
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_delete_signal.yaml
+++ b/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_delete_signal.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/17.2.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ngwaf/v1/workspaces/Am2qjXkgamuYp3u54rQkLD/signals/KxdApFNOJuvA2rxXv0jQHc
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 Aug 2026 15:48:07 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "803"
+      X-Served-By:
+      - cache-chi-klot8100128-CHI, cache-ewr-kewr1740077-EWR
+      X-Timer:
+      - S1787240887.136819,VS0,VE835
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_get_rule.yaml
+++ b/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_get_rule.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/17.2.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ngwaf/v1/workspaces/Am2qjXkgamuYp3u54rQkLD/rules/6a8721b5e286caf0a279a4b4
+    method: GET
+  response:
+    body: |
+      {"id":"6a8721b5e286caf0a279a4b4","type":"rate_limit","scope":{"type":"workspace","applies_to":["Am2qjXkgamuYp3u54rQkLD"]},"enabled":true,"description":"rate_limit_signal_payload_client_identifier_test","group_operator":"all","conditions":[{"type":"single","field":"ip","operator":"equals","value":"127.0.0.1"}],"actions":[{"type":"block_signal","signal":"site.rate-limit-signal-payload-identifier-test-workspace"}],"rate_limit":{"signal":"site.rate-limit-signal-payload-identifier-test-workspace","threshold":1,"interval":60,"duration":300,"client_identifiers":[{"type":"signal_payload","signal":"site.rate-limit-signal-payload-identifier-test-workspace"}]},"created_at":"2026-08-20T15:48:05Z","created_by":"rcarillo+devex@fastly.com","updated_at":"2026-08-20T15:48:05Z","customer_id":"4dOhK7xEkULiabovMyhRBu"}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "811"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 Aug 2026 15:48:05 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "386"
+      X-Served-By:
+      - cache-chi-kigq8000169-CHI, cache-ewr-kewr1740077-EWR
+      X-Timer:
+      - S1787240885.301046,VS0,VE417
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_update_rule.yaml
+++ b/fastly/ngwaf/v1/rules/fixtures/workspace_rate_limit_signal_client_identifier_update_rule.yaml
@@ -1,0 +1,52 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"rate_limit":{"client_identifiers":[{"type":"signal_payload","signal":"site.rate-limit-signal-payload-identifier-test-workspace"}],"duration":600,"interval":600,"signal":"site.rate-limit-signal-payload-identifier-test-workspace","threshold":2},"scope":{"type":"workspace","applies_to":["Am2qjXkgamuYp3u54rQkLD"]}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - FastlyGo/17.2.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ngwaf/v1/workspaces/Am2qjXkgamuYp3u54rQkLD/rules/6a8721b5e286caf0a279a4b4
+    method: PATCH
+  response:
+    body: |
+      {"id":"6a8721b5e286caf0a279a4b4","type":"rate_limit","scope":{"type":"workspace","applies_to":["Am2qjXkgamuYp3u54rQkLD"]},"enabled":true,"description":"rate_limit_signal_payload_client_identifier_test","group_operator":"all","conditions":[{"type":"single","field":"ip","operator":"equals","value":"127.0.0.1"}],"actions":[{"type":"block_signal","signal":"site.rate-limit-signal-payload-identifier-test-workspace"}],"rate_limit":{"signal":"site.rate-limit-signal-payload-identifier-test-workspace","threshold":2,"interval":600,"duration":600,"client_identifiers":[{"type":"signal_payload","signal":"site.rate-limit-signal-payload-identifier-test-workspace"}]},"created_at":"2026-08-20T15:48:05Z","created_by":"rcarillo+devex@fastly.com","updated_at":"2026-08-20T15:48:05Z","customer_id":"4dOhK7xEkULiabovMyhRBu"}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "812"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 Aug 2026 15:48:06 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "736"
+      X-Served-By:
+      - cache-chi-kigq8000169-CHI, cache-ewr-kewr1740077-EWR
+      X-Timer:
+      - S1787240886.732932,VS0,VE766
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
### Change summary

This PR adds support for the 'Signal Payload' type Client Identifier for a Rate Limit workspace rules.  

 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### User Impact

Users can now use the "Signal payload" option from the Client identifier field. 
