### PR TITLE
[CDTOOL-1681] Update ARC Pagination Shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes:
 
+- fix(airuntimecontrol): updated pagination to reflect the API behavior  ([#859](https://github.com/fastly/go-fastly/pull/859))
+
 ### Dependencies:
 
 ## [v17.3.0](https://github.com/fastly/go-fastly/releases/tag/v17.3.0) (2026-08-24)

--- a/fastly/airuntimecontrol/v1/key/api_list.go
+++ b/fastly/airuntimecontrol/v1/key/api_list.go
@@ -27,7 +27,7 @@ type ListInput struct {
 }
 
 // List retrieves all virtual keys, automatically paginating through all
-// pages, with optional filtering.
+// pages returned by the API, with optional filtering.
 func List(ctx context.Context, c *fastly.Client, i *ListInput) ([]VirtualKeyListItem, error) {
 	var (
 		out    []VirtualKeyListItem

--- a/fastly/airuntimecontrol/v1/key/api_list.go
+++ b/fastly/airuntimecontrol/v1/key/api_list.go
@@ -20,17 +20,35 @@ type ListInput struct {
 	IncludeDeleted *bool
 	// Search filters virtual keys by substring match on key name.
 	Search *string
-	// Cursor is the pagination cursor.
-	Cursor *string
 	// Limit is the maximum number of results per page.
 	Limit *int
 	// Sort is the sort field. Prefix with "-" for descending order (e.g. "-created_at").
 	Sort *string
 }
 
-// List retrieves all virtual keys for a customer, with optional filtering and
-// pagination.
-func List(ctx context.Context, c *fastly.Client, i *ListInput) (*VirtualKeys, error) {
+// List retrieves all virtual keys, automatically paginating through all
+// pages, with optional filtering.
+func List(ctx context.Context, c *fastly.Client, i *ListInput) ([]VirtualKeyListItem, error) {
+	var (
+		out    []VirtualKeyListItem
+		cursor *string
+	)
+	for {
+		page, err := listPage(ctx, c, i, cursor)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, page.Data...)
+		if page.Meta.NextCursor == "" {
+			break
+		}
+		cursor = &page.Meta.NextCursor
+	}
+	return out, nil
+}
+
+// listPage retrieves a single page of virtual keys.
+func listPage(ctx context.Context, c *fastly.Client, i *ListInput, cursor *string) (*VirtualKeys, error) {
 	requestOptions := fastly.CreateRequestOptions()
 	if i.Model != nil && *i.Model != "" {
 		requestOptions.Params["model"] = *i.Model
@@ -44,8 +62,8 @@ func List(ctx context.Context, c *fastly.Client, i *ListInput) (*VirtualKeys, er
 	if i.Search != nil && *i.Search != "" {
 		requestOptions.Params["search"] = *i.Search
 	}
-	if i.Cursor != nil && *i.Cursor != "" {
-		requestOptions.Params["cursor"] = *i.Cursor
+	if cursor != nil && *cursor != "" {
+		requestOptions.Params["cursor"] = *cursor
 	}
 	if i.Limit != nil {
 		requestOptions.Params["limit"] = strconv.Itoa(*i.Limit)

--- a/fastly/airuntimecontrol/v1/key/api_test.go
+++ b/fastly/airuntimecontrol/v1/key/api_test.go
@@ -62,7 +62,16 @@ func TestClient_Keys(t *testing.T) {
 		})
 	})
 	require.NoError(t, err)
-	require.NotEmpty(t, keys)
+	require.GreaterOrEqual(t, len(keys), 2, "expected at least two pages worth of keys")
+
+	var foundSecondPageItem bool
+	for _, k := range keys {
+		if k.ID == "ec5c01f186d816bf8e5c" || k.ID == "78ff28125b9d78b0289d" {
+			foundSecondPageItem = true
+			break
+		}
+	}
+	require.True(t, foundSecondPageItem, "expected an item from the second page")
 
 	// Update the virtual key.
 	var updated *VirtualKey

--- a/fastly/airuntimecontrol/v1/key/api_test.go
+++ b/fastly/airuntimecontrol/v1/key/api_test.go
@@ -55,14 +55,14 @@ func TestClient_Keys(t *testing.T) {
 	require.Equal(t, keyID, fetched.ID)
 
 	// List virtual keys.
-	var keys *VirtualKeys
+	var keys []VirtualKeyListItem
 	fastly.Record(t, "list", func(c *fastly.Client) {
 		keys, err = List(ctx, c, &ListInput{
 			Provider: fastly.ToPointer("Anthropic"),
 		})
 	})
 	require.NoError(t, err)
-	require.NotNil(t, keys)
+	require.NotEmpty(t, keys)
 
 	// Update the virtual key.
 	var updated *VirtualKey

--- a/fastly/airuntimecontrol/v1/key/fixtures/create.yaml
+++ b/fastly/airuntimecontrol/v1/key/fixtures/create.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"go-fastly-test-user","expires_at":"2026-07-30T16:22:36Z"}'
+    body: '{"name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"go-fastly-test-user","expires_at":"2026-09-01T13:34:54Z"}'
     form: {}
     headers:
       Accept:
@@ -10,12 +10,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
     url: https://api.fastly.com/ai-runtime-control/v1/keys
     method: POST
   response:
     body: |
-      {"id":"75352aad10d9828b8de7","name":"go-fastly-test-key","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","customer_id":"4dOhK7xEkULiabovMyhRBu","model":"claude-sonnet-4-20250514","provider":"Anthropic","expires_at":"2026-07-30T16:22:36Z","created_at":"2026-07-29T16:22:36.661235774Z","updated_at":"2026-07-29T16:22:36.661235774Z","access_token":"arc_sk_go-fastly-test"}
+      {"id":"78ff28125b9d78b0289d","name":"go-fastly-test-key","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","customer_id":"4dOhK7xEkULiabovMyhRBu","model":"claude-sonnet-4-20250514","provider":"Anthropic","expires_at":"2026-09-01T13:34:54Z","created_at":"2026-08-31T13:34:54.963892069Z","updated_at":"2026-08-31T13:34:54.963892069Z","access_token":"arc_sk_0Ni7TN42uWopKcewVliiDh3CKhq0e8ld42b216b"}
     headers:
       Accept-Ranges:
       - bytes
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 16:22:36 GMT
+      - Mon, 31 Aug 2026 13:34:54 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "208"
+      - "142"
       X-Served-By:
-      - cache-chi-klot8100168-CHI, cache-ewr-kewr1740069-EWR
+      - cache-chi-kigq8000073-CHI, cache-ewr-kewr1740081-EWR
       X-Timer:
-      - S1785342156.448775,VS0,VE241
+      - S1788183295.829562,VS0,VE170
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/airuntimecontrol/v1/key/fixtures/delete.yaml
+++ b/fastly/airuntimecontrol/v1/key/fixtures/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/ai-runtime-control/v1/keys/75352aad10d9828b8de7
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/keys/78ff28125b9d78b0289d
     method: DELETE
   response:
     body: ""
@@ -17,7 +17,7 @@ interactions:
       Cache-Control:
       - no-store
       Date:
-      - Wed, 29 Jul 2026 16:22:37 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -31,11 +31,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "32"
+      - "50"
       X-Served-By:
-      - cache-chi-kmdw8640079-CHI, cache-ewr-kewr1740069-EWR
+      - cache-chi-klot8100095-CHI, cache-ewr-kewr1740081-EWR
       X-Timer:
-      - S1785342157.015415,VS0,VE62
+      - S1788183296.567258,VS0,VE79
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/airuntimecontrol/v1/key/fixtures/get.yaml
+++ b/fastly/airuntimecontrol/v1/key/fixtures/get.yaml
@@ -6,23 +6,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/ai-runtime-control/v1/keys/75352aad10d9828b8de7
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/keys/78ff28125b9d78b0289d
     method: GET
   response:
     body: |
-      {"id":"75352aad10d9828b8de7","type":"token","created_at":"2026-07-29T16:22:37Z","deleted_at":null,"expires_at":"2026-07-30T16:22:36Z","name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","last_used_at":null,"updated_at":"2026-07-29T16:22:37Z","user_id":"6YHKQR3CxW7dGb67TNV4IB","created_by":"Richard Carillo"}
+      {"id":"78ff28125b9d78b0289d","type":"token","created_at":"2026-08-31T13:34:55Z","deleted_at":null,"expires_at":"2026-09-01T13:34:54Z","name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","last_used_at":null,"updated_at":"2026-08-31T13:34:55Z","user_id":"6YHKQR3CxW7dGb67TNV4IB","created_by":"Richard Carillo","security_enabled":false,"security_action":"log"}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "343"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 16:22:36 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -36,11 +36,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "13"
+      - "30"
       X-Served-By:
-      - cache-chi-kmdw8640079-CHI, cache-ewr-kewr1740069-EWR
+      - cache-chi-klot8100095-CHI, cache-ewr-kewr1740081-EWR
       X-Timer:
-      - S1785342157.709521,VS0,VE44
+      - S1788183295.036728,VS0,VE62
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/airuntimecontrol/v1/key/fixtures/list.yaml
+++ b/fastly/airuntimecontrol/v1/key/fixtures/list.yaml
@@ -6,23 +6,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
     url: https://api.fastly.com/ai-runtime-control/v1/keys?provider=Anthropic
     method: GET
   response:
     body: |
-      {"data":[{"id":"75352aad10d9828b8de7","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-07-29T16:22:37Z","deleted_at":null,"expires_at":"2026-07-30T16:22:36Z","name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-07-29T16:22:37Z"}],"meta":{"next_cursor":"","limit":10,"sort":"created_at","total":1}}
+      {"data":[{"id":"2ce6822da510e60b037e","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-07-29T16:35:42Z","deleted_at":null,"expires_at":"2026-07-30T16:33:11Z","name":"test","model":"claude-sonnet-4-6","provider":"anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-07-29T16:35:42Z","security_enabled":null,"security_action":null},{"id":"ea477ab192ae1f8cb713","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-07-29T16:36:52Z","deleted_at":null,"expires_at":"2026-07-30T16:33:11Z","name":"test","model":"claude-sonnet-4-6","provider":"anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":"2026-07-29T16:59:13Z","updated_at":"2026-07-29T16:59:13Z","security_enabled":null,"security_action":null},{"id":"fbdf3c51010403a7eabd","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-07-29T17:00:15Z","deleted_at":null,"expires_at":"2026-07-30T16:33:11Z","name":"opus-6","model":"claude-opus-4-6","provider":"anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":"2026-07-29T17:00:37Z","updated_at":"2026-07-29T17:00:37Z","security_enabled":null,"security_action":null},{"id":"426698e15c3212cac551","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-08-03T17:42:42Z","deleted_at":null,"expires_at":"2026-08-04T17:42:41Z","name":"go-fastly-test-key-2","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-08-03T17:42:42Z","security_enabled":null,"security_action":null},{"id":"c2bc54eef21ad50a5450","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-08-03T17:42:42Z","deleted_at":null,"expires_at":"2026-08-04T17:42:41Z","name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-08-03T17:42:42Z","security_enabled":null,"security_action":null},{"id":"72878269b43880bf16ed","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-08-03T18:03:20Z","deleted_at":null,"expires_at":"2026-08-04T18:03:19Z","name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-08-03T18:03:20Z","security_enabled":null,"security_action":null},{"id":"dd2fdadf1342ea2f6987","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-08-03T18:03:20Z","deleted_at":null,"expires_at":"2026-08-04T18:03:19Z","name":"go-fastly-test-key-2","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-08-03T18:03:20Z","security_enabled":null,"security_action":null},{"id":"a879bf960faf6f0d95ce","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-08-11T15:35:18Z","deleted_at":null,"expires_at":"2026-08-12T15:35:17Z","name":"go-fastly-test-key-2","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-08-11T15:35:18Z","security_enabled":null,"security_action":null},{"id":"efe048fec7043ed88a79","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-08-11T15:35:18Z","deleted_at":null,"expires_at":"2026-08-12T15:35:17Z","name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-08-11T15:35:18Z","security_enabled":null,"security_action":null},{"id":"20bfa79283b1fba6178d","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-08-11T15:36:43Z","deleted_at":null,"expires_at":"2026-08-12T15:36:43Z","name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-08-11T15:36:43Z","security_enabled":null,"security_action":null}],"meta":{"next_cursor":"eyJzb3J0IjoiY3JlYXRlZF9hdCIsInNvcnRfdmFsdWUiOiIyMDI2LTA4LTExIDE1OjM2OjQzIiwic29ydF9udWxsIjpmYWxzZSwiaWQiOiIyMGJmYTc5MjgzYjFmYmE2MTc4ZCIsImRpciI6Im5leHQifQ","limit":10,"sort":"created_at","total":10}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "490"
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 16:22:36 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -36,11 +34,54 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "18"
+      - "17"
       X-Served-By:
-      - cache-chi-kigq8000128-CHI, cache-ewr-kewr1740069-EWR
+      - cache-chi-klot8100128-CHI, cache-ewr-kewr1740081-EWR
       X-Timer:
-      - S1785342157.776675,VS0,VE49
+      - S1788183295.135474,VS0,VE47
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/keys?cursor=eyJzb3J0IjoiY3JlYXRlZF9hdCIsInNvcnRfdmFsdWUiOiIyMDI2LTA4LTExIDE1OjM2OjQzIiwic29ydF9udWxsIjpmYWxzZSwiaWQiOiIyMGJmYTc5MjgzYjFmYmE2MTc4ZCIsImRpciI6Im5leHQifQ&provider=Anthropic
+    method: GET
+  response:
+    body: |
+      {"data":[{"id":"ec5c01f186d816bf8e5c","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-08-11T15:36:44Z","deleted_at":null,"expires_at":"2026-08-12T15:36:43Z","name":"go-fastly-test-key-2","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-08-11T15:36:44Z","security_enabled":null,"security_action":null},{"id":"78ff28125b9d78b0289d","type":"token","customer_id":"4dOhK7xEkULiabovMyhRBu","created_at":"2026-08-31T13:34:55Z","deleted_at":null,"expires_at":"2026-09-01T13:34:54Z","name":"go-fastly-test-key","model":"claude-sonnet-4-20250514","provider":"Anthropic","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","created_by":"Richard Carillo","last_used_at":null,"updated_at":"2026-08-31T13:34:55Z","security_enabled":false,"security_action":"log"}],"meta":{"prev_cursor":"eyJzb3J0IjoiY3JlYXRlZF9hdCIsInNvcnRfdmFsdWUiOiIyMDI2LTA4LTExIDE1OjM2OjQ0Iiwic29ydF9udWxsIjpmYWxzZSwiaWQiOiJlYzVjMDFmMTg2ZDgxNmJmOGU1YyIsImRpciI6InByZXYifQ","limit":10,"sort":"created_at","total":2}}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "1154"
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 31 Aug 2026 13:34:55 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "38"
+      X-Served-By:
+      - cache-chi-kigq8000051-CHI, cache-ewr-kewr1740081-EWR
+      X-Timer:
+      - S1788183295.220706,VS0,VE68
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/airuntimecontrol/v1/key/fixtures/rotate.yaml
+++ b/fastly/airuntimecontrol/v1/key/fixtures/rotate.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"expires_at":"2026-07-31T16:22:36Z"}'
+    body: '{"expires_at":"2026-09-02T13:34:55Z"}'
     form: {}
     headers:
       Accept:
@@ -10,12 +10,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/ai-runtime-control/v1/keys/75352aad10d9828b8de7/rotate
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/keys/78ff28125b9d78b0289d/rotate
     method: POST
   response:
     body: |
-      {"id":"75352aad10d9828b8de7","name":"go-fastly-test-key-updated","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","customer_id":"4dOhK7xEkULiabovMyhRBu","model":"claude-sonnet-4-20250514","provider":"Anthropic","expires_at":"2026-07-31T16:22:36Z","created_at":"2026-07-29T16:22:37Z","updated_at":"2026-07-29T16:22:37Z","access_token":"arc_sk_go-fastly-test-rotated"}
+      {"id":"78ff28125b9d78b0289d","name":"go-fastly-test-key-updated","user_id":"6YHKQR3CxW7dGb67TNV4IB","user_name":"Richard Carillo","customer_id":"4dOhK7xEkULiabovMyhRBu","model":"claude-sonnet-4-20250514","provider":"Anthropic","expires_at":"2026-09-02T13:34:55Z","created_at":"2026-08-31T13:34:55Z","updated_at":"2026-08-31T13:34:55Z","access_token":"arc_sk_0aHuatOYFoI2Q7xg6T5xqervJiRR9FX6b7867d5"}
     headers:
       Accept-Ranges:
       - bytes
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 16:22:36 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "38"
+      - "36"
       X-Served-By:
-      - cache-chi-kmdw8640066-CHI, cache-ewr-kewr1740069-EWR
+      - cache-chi-klot8100093-CHI, cache-ewr-kewr1740081-EWR
       X-Timer:
-      - S1785342157.924217,VS0,VE72
+      - S1788183295.454972,VS0,VE67
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/airuntimecontrol/v1/key/fixtures/update.yaml
+++ b/fastly/airuntimecontrol/v1/key/fixtures/update.yaml
@@ -10,12 +10,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/ai-runtime-control/v1/keys/75352aad10d9828b8de7
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/keys/78ff28125b9d78b0289d
     method: PATCH
   response:
     body: |
-      {"id":"75352aad10d9828b8de7","name":"go-fastly-test-key-updated","user_id":"6YHKQR3CxW7dGb67TNV4IB","customer_id":"4dOhK7xEkULiabovMyhRBu","model":"claude-sonnet-4-20250514","provider":"Anthropic","expires_at":"2026-07-30T16:22:36Z","created_at":"2026-07-29T16:22:37Z","updated_at":"2026-07-29T16:22:37Z"}
+      {"id":"78ff28125b9d78b0289d","name":"go-fastly-test-key-updated","user_id":"6YHKQR3CxW7dGb67TNV4IB","customer_id":"4dOhK7xEkULiabovMyhRBu","model":"claude-sonnet-4-20250514","provider":"Anthropic","expires_at":"2026-09-01T13:34:54Z","created_at":"2026-08-31T13:34:55Z","updated_at":"2026-08-31T13:34:55Z"}
     headers:
       Accept-Ranges:
       - bytes
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 16:22:36 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "34"
+      - "50"
       X-Served-By:
-      - cache-chi-kmdw8640079-CHI, cache-ewr-kewr1740069-EWR
+      - cache-chi-klot8100095-CHI, cache-ewr-kewr1740081-EWR
       X-Timer:
-      - S1785342157.843304,VS0,VE64
+      - S1788183295.324000,VS0,VE81
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/airuntimecontrol/v1/providerconnection/api_get.go
+++ b/fastly/airuntimecontrol/v1/providerconnection/api_get.go
@@ -15,7 +15,7 @@ type GetInput struct {
 	ID *string
 }
 
-// Get retrieves a specific provider connection for a customer.
+// Get retrieves a specific provider connection.
 func Get(ctx context.Context, c *fastly.Client, i *GetInput) (*ProviderConnection, error) {
 	if i.ID == nil {
 		return nil, fastly.ErrMissingID

--- a/fastly/airuntimecontrol/v1/providerconnection/api_list.go
+++ b/fastly/airuntimecontrol/v1/providerconnection/api_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/fastly/go-fastly/v17/fastly"
 )
@@ -12,24 +11,13 @@ import (
 // ListInput specifies the information needed for the List() function to
 // perform the operation.
 type ListInput struct {
-	// Cursor is the pagination cursor.
-	Cursor *string
-	// Limit is the maximum number of results per page.
-	Limit *int
 	// Sort is the sort field. Prefix with "-" for descending order (e.g. "-created_at").
 	Sort *string
 }
 
-// List retrieves all configured provider connections for a customer, with
-// optional pagination.
+// List retrieves all configured provider connections.
 func List(ctx context.Context, c *fastly.Client, i *ListInput) (*ProviderConnections, error) {
 	requestOptions := fastly.CreateRequestOptions()
-	if i.Cursor != nil && *i.Cursor != "" {
-		requestOptions.Params["cursor"] = *i.Cursor
-	}
-	if i.Limit != nil {
-		requestOptions.Params["limit"] = strconv.Itoa(*i.Limit)
-	}
 	if i.Sort != nil && *i.Sort != "" {
 		requestOptions.Params["sort"] = *i.Sort
 	}

--- a/fastly/airuntimecontrol/v1/providerconnection/api_response.go
+++ b/fastly/airuntimecontrol/v1/providerconnection/api_response.go
@@ -25,13 +25,8 @@ type ProviderConnections struct {
 	Meta Meta `json:"meta"`
 }
 
-// Meta is the pagination metadata returned by the list operation.
+// Meta contains metadata returned by the list operation.
 type Meta struct {
-	// NextCursor is the cursor used to retrieve the next page of results.
-	// It is empty when there are no further pages.
-	NextCursor string `json:"next_cursor"`
-	// Limit is the maximum number of results returned per page.
-	Limit int `json:"limit"`
 	// Sort is the sort field applied to the results.
 	Sort string `json:"sort"`
 	// Total is the total number of results.

--- a/fastly/airuntimecontrol/v1/providerconnection/fixtures/create.yaml
+++ b/fastly/airuntimecontrol/v1/providerconnection/fixtures/create.yaml
@@ -10,12 +10,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
     url: https://api.fastly.com/ai-runtime-control/v1/provider-connections
     method: POST
   response:
     body: |
-      {"id":"bc19efbb5a86780953c7","name":"go-fastly-test-connection","models":["claude-opus-4-7"],"base_url":"https://api.anthropic.com","created_at":"2026-07-29T16:47:14Z","updated_at":"2026-07-29T16:47:14Z"}
+      {"id":"a8bd862aa81dcebbeaac","name":"go-fastly-test-connection","models":["claude-opus-4-7"],"base_url":"https://api.anthropic.com","created_at":"2026-08-31T13:34:54Z","updated_at":"2026-08-31T13:34:54Z"}
     headers:
       Accept-Ranges:
       - bytes
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 16:47:14 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "307"
+      - "230"
       X-Served-By:
-      - cache-chi-klot8100143-CHI, cache-ewr-kewr1740095-EWR
+      - cache-chi-klot8100109-CHI, cache-ewr-kewr1740021-EWR
       X-Timer:
-      - S1785343635.550333,VS0,VE350
+      - S1788183295.829554,VS0,VE259
     status: 201 Created
     code: 201
     duration: ""

--- a/fastly/airuntimecontrol/v1/providerconnection/fixtures/delete.yaml
+++ b/fastly/airuntimecontrol/v1/providerconnection/fixtures/delete.yaml
@@ -6,8 +6,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/ai-runtime-control/v1/provider-connections/bc19efbb5a86780953c7
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/provider-connections/a8bd862aa81dcebbeaac
     method: DELETE
   response:
     body: ""
@@ -17,7 +17,7 @@ interactions:
       Cache-Control:
       - no-store
       Date:
-      - Wed, 29 Jul 2026 16:47:15 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -31,11 +31,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "224"
+      - "221"
       X-Served-By:
-      - cache-chi-kigq8000112-CHI, cache-ewr-kewr1740095-EWR
+      - cache-chi-kigq8000173-CHI, cache-ewr-kewr1740021-EWR
       X-Timer:
-      - S1785343635.151173,VS0,VE256
+      - S1788183295.392096,VS0,VE250
     status: 204 No Content
     code: 204
     duration: ""

--- a/fastly/airuntimecontrol/v1/providerconnection/fixtures/get.yaml
+++ b/fastly/airuntimecontrol/v1/providerconnection/fixtures/get.yaml
@@ -6,12 +6,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/ai-runtime-control/v1/provider-connections/bc19efbb5a86780953c7
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/provider-connections/a8bd862aa81dcebbeaac
     method: GET
   response:
     body: |
-      {"id":"bc19efbb5a86780953c7","name":"go-fastly-test-connection","models":["claude-opus-4-7"],"base_url":"https://api.anthropic.com","created_at":"2026-07-29T16:47:14Z","updated_at":"2026-07-29T16:47:14Z"}
+      {"id":"a8bd862aa81dcebbeaac","name":"go-fastly-test-connection","models":["claude-opus-4-7"],"base_url":"https://api.anthropic.com","created_at":"2026-08-31T13:34:54Z","updated_at":"2026-08-31T13:34:54Z"}
     headers:
       Accept-Ranges:
       - bytes
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 16:47:14 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -36,11 +36,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "24"
+      - "20"
       X-Served-By:
-      - cache-chi-kigq8000112-CHI, cache-ewr-kewr1740095-EWR
+      - cache-chi-kigq8000173-CHI, cache-ewr-kewr1740021-EWR
       X-Timer:
-      - S1785343635.919886,VS0,VE60
+      - S1788183295.126486,VS0,VE51
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/airuntimecontrol/v1/providerconnection/fixtures/list.yaml
+++ b/fastly/airuntimecontrol/v1/providerconnection/fixtures/list.yaml
@@ -6,23 +6,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
     url: https://api.fastly.com/ai-runtime-control/v1/provider-connections
     method: GET
   response:
     body: |
-      {"data":[{"id":"885e088ea88209b3ab87","name":"sample","models":["claude-opus-4-7"],"base_url":"https://api.anthropic.com","created_at":"2026-07-29T16:39:57Z","updated_at":"2026-07-29T16:39:57Z"},{"id":"bc19efbb5a86780953c7","name":"go-fastly-test-connection","models":["claude-opus-4-7"],"base_url":"https://api.anthropic.com","created_at":"2026-07-29T16:47:14Z","updated_at":"2026-07-29T16:47:14Z"}],"meta":{"next_cursor":"","limit":10,"sort":"created_at","total":2}}
+      {"data":[{"id":"5d61c667aba01a00ce59","name":"sample","models":["claude-opus-4-7"],"base_url":"https://api.anthropic.com","created_at":"2026-08-11T15:42:51Z","updated_at":"2026-08-11T15:42:51Z"},{"id":"0f56dd456f3300ac72df","name":"sample2","models":["claude-opus-4-8"],"base_url":"https://api.anthropic.com","created_at":"2026-08-11T15:42:59Z","updated_at":"2026-08-11T15:42:59Z"},{"id":"2882d00e2bb32dc56952","name":"sample4","models":["claude-opus-4-8"],"base_url":"https://api.anthropic.com","created_at":"2026-08-11T15:43:05Z","updated_at":"2026-08-11T15:43:05Z"},{"id":"2e4e916e9ba5988c14e8","name":"sample5","models":["claude-opus-4-7"],"base_url":"https://api.anthropic.com","created_at":"2026-08-11T15:43:13Z","updated_at":"2026-08-11T15:43:13Z"},{"id":"a8bd862aa81dcebbeaac","name":"go-fastly-test-connection","models":["claude-opus-4-7"],"base_url":"https://api.anthropic.com","created_at":"2026-08-31T13:34:54Z","updated_at":"2026-08-31T13:34:54Z"}],"meta":{"sort":"created_at","total":5}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "469"
+      - "1002"
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 16:47:15 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -36,11 +36,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "27"
+      - "22"
       X-Served-By:
-      - cache-chi-klot8100143-CHI, cache-ewr-kewr1740095-EWR
+      - cache-chi-klot8100109-CHI, cache-ewr-kewr1740021-EWR
       X-Timer:
-      - S1785343635.996197,VS0,VE62
+      - S1788183295.212168,VS0,VE54
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/airuntimecontrol/v1/providerconnection/fixtures/update.yaml
+++ b/fastly/airuntimecontrol/v1/providerconnection/fixtures/update.yaml
@@ -10,12 +10,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/ai-runtime-control/v1/provider-connections/bc19efbb5a86780953c7
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/provider-connections/a8bd862aa81dcebbeaac
     method: PATCH
   response:
     body: |
-      {"id":"bc19efbb5a86780953c7","name":"go-fastly-test-connection","models":["claude-opus-4-6","claude-sonnet-4-6"],"base_url":"https://api.anthropic.com","created_at":"2026-07-29T16:47:14Z","updated_at":"2026-07-29T16:47:15Z"}
+      {"id":"a8bd862aa81dcebbeaac","name":"go-fastly-test-connection","models":["claude-opus-4-6","claude-sonnet-4-6"],"base_url":"https://api.anthropic.com","created_at":"2026-08-31T13:34:54Z","updated_at":"2026-08-31T13:34:55Z"}
     headers:
       Accept-Ranges:
       - bytes
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 16:47:15 GMT
+      - Mon, 31 Aug 2026 13:34:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -40,11 +40,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "26"
+      - "35"
       X-Served-By:
-      - cache-chi-kigq8000112-CHI, cache-ewr-kewr1740095-EWR
+      - cache-chi-kigq8000173-CHI, cache-ewr-kewr1740021-EWR
       X-Timer:
-      - S1785343635.078519,VS0,VE56
+      - S1788183295.297169,VS0,VE63
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/airuntimecontrol/v1/session/api_list.go
+++ b/fastly/airuntimecontrol/v1/session/api_list.go
@@ -30,7 +30,8 @@ type ListInput struct {
 }
 
 // List retrieves session logs including request/response data and metadata,
-// automatically paginating through all pages, with optional filtering.
+// automatically paginating through all pages returned by the API, with
+// optional filtering.
 func List(ctx context.Context, c *fastly.Client, i *ListInput) ([]Session, error) {
 	var (
 		out    []Session

--- a/fastly/airuntimecontrol/v1/session/api_list.go
+++ b/fastly/airuntimecontrol/v1/session/api_list.go
@@ -23,8 +23,6 @@ type ListInput struct {
 	From *time.Time
 	// To is the (inclusive) end of the time range. Defaults to now.
 	To *time.Time
-	// Cursor is the pagination cursor.
-	Cursor *string
 	// Limit is the maximum number of results per page.
 	Limit *int
 	// Sort is the sort field. Prefix with "-" for descending order (e.g. "-created_at").
@@ -32,8 +30,28 @@ type ListInput struct {
 }
 
 // List retrieves session logs including request/response data and metadata,
-// with optional filtering and pagination.
-func List(ctx context.Context, c *fastly.Client, i *ListInput) (*Sessions, error) {
+// automatically paginating through all pages, with optional filtering.
+func List(ctx context.Context, c *fastly.Client, i *ListInput) ([]Session, error) {
+	var (
+		out    []Session
+		cursor *string
+	)
+	for {
+		page, err := listPage(ctx, c, i, cursor)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, page.Data...)
+		if page.Meta.NextCursor == "" {
+			break
+		}
+		cursor = &page.Meta.NextCursor
+	}
+	return out, nil
+}
+
+// listPage retrieves a single page of session logs.
+func listPage(ctx context.Context, c *fastly.Client, i *ListInput, cursor *string) (*Sessions, error) {
 	requestOptions := fastly.CreateRequestOptions()
 	if i.Key != nil && *i.Key != "" {
 		requestOptions.Params["key"] = *i.Key
@@ -50,8 +68,8 @@ func List(ctx context.Context, c *fastly.Client, i *ListInput) (*Sessions, error
 	if i.To != nil {
 		requestOptions.Params["to"] = i.To.Format(time.RFC3339)
 	}
-	if i.Cursor != nil && *i.Cursor != "" {
-		requestOptions.Params["cursor"] = *i.Cursor
+	if cursor != nil && *cursor != "" {
+		requestOptions.Params["cursor"] = *cursor
 	}
 	if i.Limit != nil {
 		requestOptions.Params["limit"] = strconv.Itoa(*i.Limit)

--- a/fastly/airuntimecontrol/v1/session/api_test.go
+++ b/fastly/airuntimecontrol/v1/session/api_test.go
@@ -17,9 +17,9 @@ func TestClient_Sessions(t *testing.T) {
 	var sessions []Session
 	fastly.Record(t, "list", func(c *fastly.Client) {
 		sessions, err = List(ctx, c, &ListInput{
-			Limit: fastly.ToPointer(10),
+			Limit: fastly.ToPointer(2),
 		})
 	})
 	require.NoError(t, err)
-	require.NotEmpty(t, sessions)
+	require.GreaterOrEqual(t, len(sessions), 2, "expected at least two pages worth of sessions")
 }

--- a/fastly/airuntimecontrol/v1/session/api_test.go
+++ b/fastly/airuntimecontrol/v1/session/api_test.go
@@ -14,12 +14,12 @@ func TestClient_Sessions(t *testing.T) {
 
 	var err error
 
-	var sessions *Sessions
+	var sessions []Session
 	fastly.Record(t, "list", func(c *fastly.Client) {
 		sessions, err = List(ctx, c, &ListInput{
 			Limit: fastly.ToPointer(10),
 		})
 	})
 	require.NoError(t, err)
-	require.NotNil(t, sessions)
+	require.NotEmpty(t, sessions)
 }

--- a/fastly/airuntimecontrol/v1/session/api_test.go
+++ b/fastly/airuntimecontrol/v1/session/api_test.go
@@ -21,5 +21,14 @@ func TestClient_Sessions(t *testing.T) {
 		})
 	})
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(sessions), 2, "expected at least two pages worth of sessions")
+	require.Len(t, sessions, 3)
+
+	var foundSecondPageItem bool
+	for _, s := range sessions {
+		if s.ID == "sess_546" {
+			foundSecondPageItem = true
+			break
+		}
+	}
+	require.True(t, foundSecondPageItem, "expected an item from the second page")
 }

--- a/fastly/airuntimecontrol/v1/session/fixtures/list.yaml
+++ b/fastly/airuntimecontrol/v1/session/fixtures/list.yaml
@@ -7,22 +7,22 @@ interactions:
     headers:
       User-Agent:
       - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
-    url: https://api.fastly.com/ai-runtime-control/v1/sessions?limit=10
+    url: https://api.fastly.com/ai-runtime-control/v1/sessions?limit=2
     method: GET
   response:
     body: |
-      {"data":[{"id":"sess_544","virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","model":"claude-opus-4-7","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"violations":0,"firewall_enabled":false,"created_at":"2026-07-29T16:58:01.060677Z","updated_at":"2026-07-29T16:58:01.060677Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]},{"id":"sess_545","virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","model":"claude-opus-4-6","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"violations":0,"firewall_enabled":false,"created_at":"2026-07-29T16:59:13.263874Z","updated_at":"2026-07-29T16:59:13.263874Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]},{"id":"sess_546","virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","model":"claude-opus-4-6","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"violations":0,"firewall_enabled":false,"created_at":"2026-07-29T17:00:37.662692Z","updated_at":"2026-07-29T17:00:37.662692Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]}],"meta":{"limit":10,"sort":"created_at","total":3}}
+      {"data":[{"id":"sess_544","virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","model":"claude-opus-4-7","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"violations":0,"firewall_enabled":false,"created_at":"2026-07-29T16:58:01.060677Z","updated_at":"2026-07-29T16:58:01.060677Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]},{"id":"sess_545","virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","model":"claude-opus-4-6","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"violations":0,"firewall_enabled":false,"created_at":"2026-07-29T16:59:13.263874Z","updated_at":"2026-07-29T16:59:13.263874Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]}],"meta":{"next_cursor":"eyJzb3J0IjoiY3JlYXRlZF9hdCIsInNvcnRfdmFsdWUiOiIyMDI2LTA3LTI5IDE2OjU5OjEzLjI2Mzg3NCIsInNvcnRfbnVsbCI6ZmFsc2UsImlkIjoiNTQ1IiwiZGlyIjoibmV4dCJ9","limit":2,"sort":"created_at","total":2}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "1227"
+      - "993"
       Content-Type:
       - application/json
       Date:
-      - Mon, 31 Aug 2026 13:34:54 GMT
+      - Mon, 31 Aug 2026 15:03:14 GMT
       Pragma:
       - no-cache
       Server:
@@ -36,11 +36,54 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "29"
+      - "43"
       X-Served-By:
-      - cache-chi-kigq8000131-CHI, cache-ewr-kewr1740035-EWR
+      - cache-chi-klot8100062-CHI, cache-ewr-kewr1740071-EWR
       X-Timer:
-      - S1788183295.838568,VS0,VE59
+      - S1788188595.605344,VS0,VE77
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/sessions?cursor=eyJzb3J0IjoiY3JlYXRlZF9hdCIsInNvcnRfdmFsdWUiOiIyMDI2LTA3LTI5IDE2OjU5OjEzLjI2Mzg3NCIsInNvcnRfbnVsbCI6ZmFsc2UsImlkIjoiNTQ1IiwiZGlyIjoibmV4dCJ9&limit=2
+    method: GET
+  response:
+    body: |
+      {"data":[{"id":"sess_546","virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","model":"claude-opus-4-6","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"violations":0,"firewall_enabled":false,"created_at":"2026-07-29T17:00:37.662692Z","updated_at":"2026-07-29T17:00:37.662692Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]}],"meta":{"prev_cursor":"eyJzb3J0IjoiY3JlYXRlZF9hdCIsInNvcnRfdmFsdWUiOiIyMDI2LTA3LTI5IDE3OjAwOjM3LjY2MjY5MiIsInNvcnRfbnVsbCI6ZmFsc2UsImlkIjoiNTQ2IiwiZGlyIjoicHJldiJ9","limit":2,"sort":"created_at","total":1}}
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - "607"
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 31 Aug 2026 15:03:14 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - fastly istio-envoy
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Envoy-Upstream-Service-Time:
+      - "27"
+      X-Served-By:
+      - cache-chi-klot8100139-CHI, cache-ewr-kewr1740071-EWR
+      X-Timer:
+      - S1788188595.717681,VS0,VE58
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/airuntimecontrol/v1/session/fixtures/list.yaml
+++ b/fastly/airuntimecontrol/v1/session/fixtures/list.yaml
@@ -6,23 +6,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
     url: https://api.fastly.com/ai-runtime-control/v1/sessions?limit=10
     method: GET
   response:
     body: |
-      {"data":[{"id":"sess_544","virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","model":"claude-opus-4-7","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"created_at":"2026-07-29T16:58:01.060677Z","updated_at":"2026-07-29T16:58:01.060677Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]},{"id":"sess_545","virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","model":"claude-opus-4-6","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"created_at":"2026-07-29T16:59:13.263874Z","updated_at":"2026-07-29T16:59:13.263874Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]},{"id":"sess_546","virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","model":"claude-opus-4-6","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"created_at":"2026-07-29T17:00:37.662692Z","updated_at":"2026-07-29T17:00:37.662692Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]}],"meta":{"next_cursor":"","limit":10,"sort":"created_at","total":3}}
+      {"data":[{"id":"sess_544","virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","model":"claude-opus-4-7","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"violations":0,"firewall_enabled":false,"created_at":"2026-07-29T16:58:01.060677Z","updated_at":"2026-07-29T16:58:01.060677Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]},{"id":"sess_545","virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","model":"claude-opus-4-6","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"violations":0,"firewall_enabled":false,"created_at":"2026-07-29T16:59:13.263874Z","updated_at":"2026-07-29T16:59:13.263874Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]},{"id":"sess_546","virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","model":"claude-opus-4-6","provider":"anthropic","requests":1,"input_tokens":0,"output_tokens":0,"violations":0,"firewall_enabled":false,"created_at":"2026-07-29T17:00:37.662692Z","updated_at":"2026-07-29T17:00:37.662692Z","logs":[{"request":"Say hello in one short sentence.","response":"","attrs":{}}]}],"meta":{"limit":10,"sort":"created_at","total":3}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
       Content-Length:
-      - "1124"
+      - "1227"
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 17:03:18 GMT
+      - Mon, 31 Aug 2026 13:34:54 GMT
       Pragma:
       - no-cache
       Server:
@@ -36,11 +36,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "48"
+      - "29"
       X-Served-By:
-      - cache-chi-kigq8000137-CHI, cache-ewr-kewr1740040-EWR
+      - cache-chi-kigq8000131-CHI, cache-ewr-kewr1740035-EWR
       X-Timer:
-      - S1785344598.365140,VS0,VE80
+      - S1788183295.838568,VS0,VE59
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/airuntimecontrol/v1/usagemetrics/api_list.go
+++ b/fastly/airuntimecontrol/v1/usagemetrics/api_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/fastly/go-fastly/v17/fastly"
@@ -23,10 +22,6 @@ type ListInput struct {
 	From *time.Time
 	// To is the (inclusive) end of the time range. Defaults to now.
 	To *time.Time
-	// Cursor is the pagination cursor.
-	Cursor *string
-	// Limit is the maximum number of results per page.
-	Limit *int
 	// Sort is the sort field. Prefix with "-" for descending order (e.g. "-date").
 	Sort *string
 }
@@ -50,20 +45,13 @@ func (i *ListInput) requestOptions() fastly.RequestOptions {
 	if i.To != nil {
 		requestOptions.Params["to"] = i.To.Format(time.RFC3339)
 	}
-	if i.Cursor != nil && *i.Cursor != "" {
-		requestOptions.Params["cursor"] = *i.Cursor
-	}
-	if i.Limit != nil {
-		requestOptions.Params["limit"] = strconv.Itoa(*i.Limit)
-	}
 	if i.Sort != nil && *i.Sort != "" {
 		requestOptions.Params["sort"] = *i.Sort
 	}
 	return requestOptions
 }
 
-// List returns usage metrics for AI services, with optional filtering and
-// pagination.
+// List returns usage metrics for AI services, with optional filtering.
 func List(ctx context.Context, c *fastly.Client, i *ListInput) (*UsageMetrics, error) {
 	path := fastly.ToSafeURL("ai-runtime-control", "v1", "usage-metrics")
 

--- a/fastly/airuntimecontrol/v1/usagemetrics/api_response.go
+++ b/fastly/airuntimecontrol/v1/usagemetrics/api_response.go
@@ -27,13 +27,8 @@ type UsageMetrics struct {
 	Meta Meta `json:"meta"`
 }
 
-// Meta is the pagination metadata returned by the list operation.
+// Meta contains metadata returned by the list operation.
 type Meta struct {
-	// NextCursor is the cursor used to retrieve the next page of results.
-	// It is empty when there are no further pages.
-	NextCursor string `json:"next_cursor"`
-	// Limit is the maximum number of results returned per page.
-	Limit int `json:"limit"`
 	// Sort is the sort field applied to the results.
 	Sort string `json:"sort"`
 	// Total is the total number of results.

--- a/fastly/airuntimecontrol/v1/usagemetrics/api_test.go
+++ b/fastly/airuntimecontrol/v1/usagemetrics/api_test.go
@@ -16,18 +16,14 @@ func TestClient_UsageMetrics(t *testing.T) {
 
 	var metrics *UsageMetrics
 	fastly.Record(t, "list", func(c *fastly.Client) {
-		metrics, err = List(ctx, c, &ListInput{
-			Limit: fastly.ToPointer(10),
-		})
+		metrics, err = List(ctx, c, &ListInput{})
 	})
 	require.NoError(t, err)
 	require.NotNil(t, metrics)
 
 	var csv []byte
 	fastly.Record(t, "export", func(c *fastly.Client) {
-		csv, err = Export(ctx, c, &ListInput{
-			Limit: fastly.ToPointer(10),
-		})
+		csv, err = Export(ctx, c, &ListInput{})
 	})
 	require.NoError(t, err)
 	require.NotNil(t, csv)

--- a/fastly/airuntimecontrol/v1/usagemetrics/fixtures/export.yaml
+++ b/fastly/airuntimecontrol/v1/usagemetrics/fixtures/export.yaml
@@ -8,8 +8,8 @@ interactions:
       Accept:
       - text/csv
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/ai-runtime-control/v1/usage-metrics/export?limit=10
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/usage-metrics/export
     method: GET
   response:
     body: |
@@ -17,12 +17,15 @@ interactions:
       2026-07-29T00:00:00Z,requests,1,ea477ab192ae1f8cb713,test,anthropic,claude-opus-4-6
       2026-07-29T00:00:00Z,input_tokens,0,ea477ab192ae1f8cb713,test,anthropic,claude-opus-4-6
       2026-07-29T00:00:00Z,output_tokens,0,ea477ab192ae1f8cb713,test,anthropic,claude-opus-4-6
+      2026-07-29T00:00:00Z,violations,0,ea477ab192ae1f8cb713,test,anthropic,claude-opus-4-6
       2026-07-29T00:00:00Z,requests,1,ea477ab192ae1f8cb713,test,anthropic,claude-opus-4-7
       2026-07-29T00:00:00Z,input_tokens,0,ea477ab192ae1f8cb713,test,anthropic,claude-opus-4-7
       2026-07-29T00:00:00Z,output_tokens,0,ea477ab192ae1f8cb713,test,anthropic,claude-opus-4-7
+      2026-07-29T00:00:00Z,violations,0,ea477ab192ae1f8cb713,test,anthropic,claude-opus-4-7
       2026-07-29T00:00:00Z,requests,1,fbdf3c51010403a7eabd,opus-6,anthropic,claude-opus-4-6
       2026-07-29T00:00:00Z,input_tokens,0,fbdf3c51010403a7eabd,opus-6,anthropic,claude-opus-4-6
       2026-07-29T00:00:00Z,output_tokens,0,fbdf3c51010403a7eabd,opus-6,anthropic,claude-opus-4-6
+      2026-07-29T00:00:00Z,violations,0,fbdf3c51010403a7eabd,opus-6,anthropic,claude-opus-4-6
     headers:
       Accept-Ranges:
       - bytes
@@ -31,11 +34,11 @@ interactions:
       Content-Disposition:
       - attachment; filename=usage_metrics.csv
       Content-Length:
-      - "861"
+      - "1121"
       Content-Type:
       - text/csv
       Date:
-      - Wed, 29 Jul 2026 17:04:51 GMT
+      - Mon, 31 Aug 2026 13:34:54 GMT
       Pragma:
       - no-cache
       Server:
@@ -49,11 +52,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "22"
+      - "13"
       X-Served-By:
-      - cache-chi-kmdw8640059-CHI, cache-ewr-kewr1740093-EWR
+      - cache-chi-kigq8000127-CHI, cache-ewr-kewr1740025-EWR
       X-Timer:
-      - S1785344691.942094,VS0,VE72
+      - S1788183295.928258,VS0,VE43
     status: 200 OK
     code: 200
     duration: ""

--- a/fastly/airuntimecontrol/v1/usagemetrics/fixtures/list.yaml
+++ b/fastly/airuntimecontrol/v1/usagemetrics/fixtures/list.yaml
@@ -6,23 +6,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - FastlyGo/17.0.0 (+github.com/fastly/go-fastly; go1.26.4)
-    url: https://api.fastly.com/ai-runtime-control/v1/usage-metrics?limit=10
+      - FastlyGo/17.3.0 (+github.com/fastly/go-fastly; go1.26.5)
+    url: https://api.fastly.com/ai-runtime-control/v1/usage-metrics
     method: GET
   response:
     body: |
-      {"data":[{"date":"2026-07-29T00:00:00Z","usage_type":"requests","quantity":1,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"input_tokens","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"output_tokens","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"requests","quantity":1,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-7"},{"date":"2026-07-29T00:00:00Z","usage_type":"input_tokens","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-7"},{"date":"2026-07-29T00:00:00Z","usage_type":"output_tokens","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-7"},{"date":"2026-07-29T00:00:00Z","usage_type":"requests","quantity":1,"virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"input_tokens","quantity":0,"virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"output_tokens","quantity":0,"virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","provider":"anthropic","model":"claude-opus-4-6"}],"meta":{"next_cursor":"","limit":10,"sort":"date","total":9}}
+      {"data":[{"date":"2026-07-29T00:00:00Z","usage_type":"requests","quantity":1,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"input_tokens","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"output_tokens","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"violations","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"requests","quantity":1,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-7"},{"date":"2026-07-29T00:00:00Z","usage_type":"input_tokens","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-7"},{"date":"2026-07-29T00:00:00Z","usage_type":"output_tokens","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-7"},{"date":"2026-07-29T00:00:00Z","usage_type":"violations","quantity":0,"virtual_key_id":"ea477ab192ae1f8cb713","virtual_key_name":"test","provider":"anthropic","model":"claude-opus-4-7"},{"date":"2026-07-29T00:00:00Z","usage_type":"requests","quantity":1,"virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"input_tokens","quantity":0,"virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"output_tokens","quantity":0,"virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","provider":"anthropic","model":"claude-opus-4-6"},{"date":"2026-07-29T00:00:00Z","usage_type":"violations","quantity":0,"virtual_key_id":"fbdf3c51010403a7eabd","virtual_key_name":"opus-6","provider":"anthropic","model":"claude-opus-4-6"}],"meta":{"sort":"date","total":12}}
     headers:
       Accept-Ranges:
       - bytes
       Cache-Control:
       - no-store
-      Content-Length:
-      - "1761"
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jul 2026 17:04:50 GMT
+      - Mon, 31 Aug 2026 13:34:54 GMT
       Pragma:
       - no-cache
       Server:
@@ -36,11 +34,11 @@ interactions:
       X-Cache-Hits:
       - 0, 0
       X-Envoy-Upstream-Service-Time:
-      - "36"
+      - "21"
       X-Served-By:
-      - cache-chi-kigq8000154-CHI, cache-ewr-kewr1740093-EWR
+      - cache-chi-klot8100079-CHI, cache-ewr-kewr1740025-EWR
       X-Timer:
-      - S1785344691.852835,VS0,VE69
+      - S1788183295.838706,VS0,VE52
     status: 200 OK
     code: 200
     duration: ""


### PR DESCRIPTION
### Change summary

This PR updates the ARC endpoints to ensure pagination matches the API shape. 

Now auto-paginates: 
- `airuntimecontrol/v1/key`
- `airuntimecontrol/v1/session`

Pagination removed (handled by API): 
- `airuntimecontrol/v1/providerconnection` 
- `airuntimecontrol/v1/usagemetrics`


 All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/fastly/go-fastly/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Are there any considerations that need to be addressed for release?

While this may be considered a breaking change, ARC isn't live yet, so we can perhaps pass this as a minor update and not a breaking change? 
